### PR TITLE
feat: full maintenance workflow UI with CRUD modals

### DIFF
--- a/frontend/src/components/equipment/CreateWorkOrderModal.tsx
+++ b/frontend/src/components/equipment/CreateWorkOrderModal.tsx
@@ -1,0 +1,379 @@
+import { useState } from 'react';
+import { X, AlertTriangle } from 'lucide-react';
+import type { MaintenanceWorkOrder, WorkOrderCategory } from '@/lib/types';
+import { WorkOrderPriority, WorkOrderCategory as WOCat } from '@/lib/types';
+import { createWorkOrder } from '@/api/maintenance';
+
+interface CreateWorkOrderModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreate: (wo: MaintenanceWorkOrder) => void;
+  defaultEquipmentId?: string;
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 10px',
+  backgroundColor: 'var(--color-bg)',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius)',
+  color: 'var(--color-text)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 12,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10,
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: '1.5px',
+  color: 'var(--color-text-muted)',
+  marginBottom: 4,
+  display: 'block',
+};
+
+const selectStyle: React.CSSProperties = {
+  ...inputStyle,
+  appearance: 'none' as const,
+  backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%236b7280' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E")`,
+  backgroundRepeat: 'no-repeat',
+  backgroundPosition: 'right 8px center',
+  paddingRight: 28,
+};
+
+function generateWONumber(): string {
+  const yr = new Date().getFullYear();
+  const seq = Math.floor(1000 + Math.random() * 9000);
+  return `WO-${yr}-${seq}`;
+}
+
+export default function CreateWorkOrderModal({
+  isOpen,
+  onClose,
+  onCreate,
+  defaultEquipmentId,
+}: CreateWorkOrderModalProps) {
+  const [woNumber, setWoNumber] = useState(generateWONumber());
+  const [description, setDescription] = useState('');
+  const [priority, setPriority] = useState<number>(WorkOrderPriority.ROUTINE);
+  const [category, setCategory] = useState<WorkOrderCategory>(WOCat.CORRECTIVE);
+  const [equipmentId, setEquipmentId] = useState(defaultEquipmentId || '');
+  const [unitId, setUnitId] = useState('');
+  const [assignedTo, setAssignedTo] = useState('');
+  const [location, setLocation] = useState('');
+  const [estimatedCompletion, setEstimatedCompletion] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!description.trim()) {
+      setError('Description is required.');
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const result = await createWorkOrder({
+        workOrderNumber: woNumber,
+        description: description.trim(),
+        priority,
+        category,
+        individualEquipmentId: equipmentId || undefined,
+        unitId: unitId || undefined,
+        assignedTo: assignedTo || undefined,
+        location: location || undefined,
+        estimatedCompletion: estimatedCompletion || undefined,
+      });
+      onCreate(result);
+      // Reset form
+      setWoNumber(generateWONumber());
+      setDescription('');
+      setPriority(WorkOrderPriority.ROUTINE);
+      setCategory(WOCat.CORRECTIVE);
+      setEquipmentId(defaultEquipmentId || '');
+      setUnitId('');
+      setAssignedTo('');
+      setLocation('');
+      setEstimatedCompletion('');
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create work order.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 3000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0, 0, 0, 0.85)',
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        style={{
+          width: '90%',
+          maxWidth: 600,
+          maxHeight: '90vh',
+          backgroundColor: 'var(--color-bg-card)',
+          border: '1px solid var(--color-border-strong)',
+          borderRadius: 'var(--radius)',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '14px 16px',
+            borderBottom: '1px solid var(--color-border)',
+          }}
+        >
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 12,
+              fontWeight: 700,
+              letterSpacing: '1.5px',
+              color: 'var(--color-text-bright)',
+              textTransform: 'uppercase',
+            }}
+          >
+            CREATE WORK ORDER
+          </span>
+          <button
+            onClick={onClose}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'none',
+              border: 'none',
+              color: 'var(--color-text-muted)',
+              cursor: 'pointer',
+              padding: 4,
+            }}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Form */}
+        <form
+          onSubmit={handleSubmit}
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            padding: 16,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 12,
+          }}
+        >
+          {error && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                padding: '8px 12px',
+                backgroundColor: 'var(--color-danger)15',
+                border: '1px solid var(--color-danger)',
+                borderRadius: 'var(--radius)',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 11,
+                color: 'var(--color-danger)',
+              }}
+            >
+              <AlertTriangle size={12} />
+              {error}
+            </div>
+          )}
+
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 12,
+            }}
+          >
+            {/* WO Number */}
+            <div>
+              <label style={labelStyle}>WORK ORDER #</label>
+              <input
+                style={inputStyle}
+                value={woNumber}
+                onChange={(e) => setWoNumber(e.target.value)}
+              />
+            </div>
+
+            {/* Priority */}
+            <div>
+              <label style={labelStyle}>PRIORITY</label>
+              <select
+                style={selectStyle}
+                value={priority}
+                onChange={(e) => setPriority(Number(e.target.value))}
+              >
+                <option value={1}>URGENT</option>
+                <option value={2}>PRIORITY</option>
+                <option value={3}>ROUTINE</option>
+              </select>
+            </div>
+
+            {/* Description */}
+            <div style={{ gridColumn: '1 / -1' }}>
+              <label style={labelStyle}>DESCRIPTION *</label>
+              <textarea
+                style={{ ...inputStyle, minHeight: 60, resize: 'vertical' }}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Describe the maintenance requirement..."
+                required
+              />
+            </div>
+
+            {/* Category */}
+            <div>
+              <label style={labelStyle}>CATEGORY</label>
+              <select
+                style={selectStyle}
+                value={category}
+                onChange={(e) => setCategory(e.target.value as WorkOrderCategory)}
+              >
+                <option value={WOCat.CORRECTIVE}>CORRECTIVE</option>
+                <option value={WOCat.PREVENTIVE}>PREVENTIVE</option>
+                <option value={WOCat.MODIFICATION}>MODIFICATION</option>
+                <option value={WOCat.INSPECTION}>INSPECTION</option>
+              </select>
+            </div>
+
+            {/* Equipment ID */}
+            <div>
+              <label style={labelStyle}>EQUIPMENT ID</label>
+              <input
+                style={inputStyle}
+                value={equipmentId}
+                onChange={(e) => setEquipmentId(e.target.value)}
+                placeholder="e.g., HQ-001"
+              />
+            </div>
+
+            {/* Unit ID */}
+            <div>
+              <label style={labelStyle}>UNIT ID</label>
+              <input
+                style={inputStyle}
+                value={unitId}
+                onChange={(e) => setUnitId(e.target.value)}
+                placeholder="e.g., 1/2 MAR"
+              />
+            </div>
+
+            {/* Assigned To */}
+            <div>
+              <label style={labelStyle}>ASSIGNED TO</label>
+              <input
+                style={inputStyle}
+                value={assignedTo}
+                onChange={(e) => setAssignedTo(e.target.value)}
+                placeholder="Mechanic name"
+              />
+            </div>
+
+            {/* Location */}
+            <div>
+              <label style={labelStyle}>LOCATION</label>
+              <input
+                style={inputStyle}
+                value={location}
+                onChange={(e) => setLocation(e.target.value)}
+                placeholder="e.g., Bay 3, Motor Pool"
+              />
+            </div>
+
+            {/* Est. Completion */}
+            <div>
+              <label style={labelStyle}>EST. COMPLETION</label>
+              <input
+                style={inputStyle}
+                type="date"
+                value={estimatedCompletion}
+                onChange={(e) => setEstimatedCompletion(e.target.value)}
+              />
+            </div>
+          </div>
+        </form>
+
+        {/* Footer */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 8,
+            padding: '12px 16px',
+            borderTop: '1px solid var(--color-border)',
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              fontWeight: 600,
+              letterSpacing: '1px',
+              padding: '8px 20px',
+              border: '1px solid var(--color-border)',
+              borderRadius: 'var(--radius)',
+              backgroundColor: 'transparent',
+              color: 'var(--color-text-muted)',
+              cursor: isSubmitting ? 'not-allowed' : 'pointer',
+              textTransform: 'uppercase',
+            }}
+          >
+            CANCEL
+          </button>
+          <button
+            type="submit"
+            onClick={handleSubmit}
+            disabled={isSubmitting}
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              fontWeight: 600,
+              letterSpacing: '1px',
+              padding: '8px 20px',
+              border: 'none',
+              borderRadius: 'var(--radius)',
+              backgroundColor: isSubmitting ? 'var(--color-text-muted)' : 'var(--color-accent)',
+              color: 'var(--color-bg)',
+              cursor: isSubmitting ? 'not-allowed' : 'pointer',
+              textTransform: 'uppercase',
+              opacity: isSubmitting ? 0.7 : 1,
+            }}
+          >
+            {isSubmitting ? 'CREATING...' : 'CREATE WORK ORDER'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/equipment/MaintenanceHistoryTab.tsx
+++ b/frontend/src/components/equipment/MaintenanceHistoryTab.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
-import { ChevronDown, ChevronRight, Wrench, Package, Clock, User } from 'lucide-react';
+import { ChevronDown, ChevronRight, Wrench, Package, Clock, User, ExternalLink, Plus } from 'lucide-react';
 import type { MaintenanceWorkOrder } from '@/lib/types';
 import { WorkOrderStatus } from '@/lib/types';
 import { formatDate, formatRelativeTime } from '@/lib/utils';
+import WorkOrderDetailModal from './WorkOrderDetailModal';
+import CreateWorkOrderModal from './CreateWorkOrderModal';
 
 interface MaintenanceHistoryTabProps {
   workOrders: MaintenanceWorkOrder[];
+  equipmentId?: string;
+  onRefresh?: () => void;
 }
 
 function getPriorityLabel(priority: number): string {
@@ -35,7 +39,7 @@ function getWOStatusColor(status: WorkOrderStatus): string {
   }
 }
 
-function WorkOrderRow({ wo }: { wo: MaintenanceWorkOrder }) {
+function WorkOrderRow({ wo, onViewDetails }: { wo: MaintenanceWorkOrder; onViewDetails: (wo: MaintenanceWorkOrder) => void }) {
   const [expanded, setExpanded] = useState(false);
   const totalParts = wo.parts.length;
   const totalLabor = wo.laborEntries.reduce((sum, l) => sum + l.hours, 0);
@@ -313,7 +317,7 @@ function WorkOrderRow({ wo }: { wo: MaintenanceWorkOrder }) {
                             borderBottom: '1px solid var(--color-border)',
                           }}
                         >
-                          {part.unitCost ? `$${(part.unitCost * part.quantity).toLocaleString()}` : '—'}
+                          {part.unitCost ? `$${(part.unitCost * part.quantity).toLocaleString()}` : '\u2014'}
                         </td>
                       </tr>
                     ))}
@@ -421,7 +425,7 @@ function WorkOrderRow({ wo }: { wo: MaintenanceWorkOrder }) {
                             borderBottom: '1px solid var(--color-border)',
                           }}
                         >
-                          {labor.notes || '—'}
+                          {labor.notes || '\u2014'}
                         </td>
                       </tr>
                     ))}
@@ -430,14 +434,47 @@ function WorkOrderRow({ wo }: { wo: MaintenanceWorkOrder }) {
               </div>
             </div>
           )}
+
+          {/* View Full Details Button */}
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onViewDetails(wo);
+              }}
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 9,
+                fontWeight: 600,
+                letterSpacing: '1px',
+                padding: '6px 16px',
+                border: '1px solid var(--color-border)',
+                borderRadius: 'var(--radius)',
+                backgroundColor: 'var(--color-bg-hover)',
+                color: 'var(--color-text-bright)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                transition: 'background-color var(--transition)',
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-bg-surface)')}
+              onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-bg-hover)')}
+            >
+              <ExternalLink size={10} />
+              VIEW FULL DETAILS
+            </button>
+          </div>
         </div>
       )}
     </div>
   );
 }
 
-export default function MaintenanceHistoryTab({ workOrders }: MaintenanceHistoryTabProps) {
+export default function MaintenanceHistoryTab({ workOrders, equipmentId, onRefresh }: MaintenanceHistoryTabProps) {
   const [sortBy, setSortBy] = useState<'date' | 'priority' | 'status'>('date');
+  const [modalWO, setModalWO] = useState<MaintenanceWorkOrder | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
 
   const sorted = [...workOrders].sort((a, b) => {
     switch (sortBy) {
@@ -461,6 +498,15 @@ export default function MaintenanceHistoryTab({ workOrders }: MaintenanceHistory
     0,
   );
 
+  const handleUpdate = () => {
+    setModalWO(null);
+    onRefresh?.();
+  };
+
+  const handleCreate = () => {
+    onRefresh?.();
+  };
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
       {/* Summary Bar */}
@@ -473,6 +519,7 @@ export default function MaintenanceHistoryTab({ workOrders }: MaintenanceHistory
           border: '1px solid var(--color-border)',
           borderRadius: 'var(--radius)',
           alignItems: 'center',
+          flexWrap: 'wrap',
         }}
       >
         <div>
@@ -545,8 +592,31 @@ export default function MaintenanceHistoryTab({ workOrders }: MaintenanceHistory
           </div>
         </div>
 
-        {/* Sort Controls */}
-        <div style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
+        {/* NEW WO Button + Sort Controls */}
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 6, alignItems: 'center' }}>
+          <button
+            onClick={() => setShowCreate(true)}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              fontFamily: 'var(--font-mono)',
+              fontSize: 9,
+              fontWeight: 600,
+              letterSpacing: '1px',
+              padding: '4px 10px',
+              border: '1px solid var(--color-accent)',
+              borderRadius: 'var(--radius)',
+              backgroundColor: 'transparent',
+              color: 'var(--color-accent)',
+              cursor: 'pointer',
+              textTransform: 'uppercase',
+            }}
+          >
+            <Plus size={10} />
+            NEW WO
+          </button>
+          <div style={{ width: 1, height: 20, backgroundColor: 'var(--color-border)', margin: '0 4px' }} />
           {(['date', 'priority', 'status'] as const).map((s) => (
             <button
               key={s}
@@ -586,8 +656,23 @@ export default function MaintenanceHistoryTab({ workOrders }: MaintenanceHistory
           No maintenance work orders found for this equipment.
         </div>
       ) : (
-        sorted.map((wo) => <WorkOrderRow key={wo.id} wo={wo} />)
+        sorted.map((wo) => (
+          <WorkOrderRow key={wo.id} wo={wo} onViewDetails={setModalWO} />
+        ))
       )}
+
+      <WorkOrderDetailModal
+        workOrder={modalWO}
+        onClose={() => setModalWO(null)}
+        onUpdate={handleUpdate}
+      />
+
+      <CreateWorkOrderModal
+        isOpen={showCreate}
+        onClose={() => setShowCreate(false)}
+        onCreate={handleCreate}
+        defaultEquipmentId={equipmentId}
+      />
     </div>
   );
 }

--- a/frontend/src/components/equipment/MaintenanceQueue.tsx
+++ b/frontend/src/components/equipment/MaintenanceQueue.tsx
@@ -1,177 +1,241 @@
-import { useState } from 'react';
-import { Wrench, Clock, Package } from 'lucide-react';
+import { useState, useEffect, useCallback } from 'react';
+import { Wrench, Clock, Package, Plus } from 'lucide-react';
 import Card from '@/components/ui/Card';
 import StatusDot from '@/components/ui/StatusDot';
 import { formatRelativeTime } from '@/lib/utils';
+import type { MaintenanceWorkOrder } from '@/lib/types';
+import { WorkOrderStatus } from '@/lib/types';
+import { getWorkOrders } from '@/api/maintenance';
+import WorkOrderDetailModal from './WorkOrderDetailModal';
+import CreateWorkOrderModal from './CreateWorkOrderModal';
 
-interface WorkOrder {
-  id: string;
-  equipment: string;
-  tamcn: string;
-  unit: string;
-  fault: string;
-  priority: 'URGENT' | 'PRIORITY' | 'ROUTINE';
-  status: 'OPEN' | 'IN_PROGRESS' | 'PARTS_ON_ORDER' | 'COMPLETE';
-  openedAt: string;
-  eta?: string;
-  partsCount: number;
-  laborHours: number;
+function getPriorityLabel(priority: number): string {
+  switch (priority) {
+    case 1: return 'URGENT';
+    case 2: return 'PRIORITY';
+    case 3: return 'ROUTINE';
+    default: return 'ROUTINE';
+  }
 }
 
-const demoOrders: WorkOrder[] = [
-  { id: 'WO-001', equipment: 'AAV #12', tamcn: 'E0902', unit: '1/1 BN', fault: 'Engine overheating - water pump failure', priority: 'URGENT', status: 'PARTS_ON_ORDER', openedAt: '2026-03-01T14:00:00Z', eta: '48hrs', partsCount: 2, laborHours: 6.5 },
-  { id: 'WO-002', equipment: 'AAV #08', tamcn: 'E0902', unit: '1/1 BN', fault: 'Transmission oil leak', priority: 'URGENT', status: 'IN_PROGRESS', openedAt: '2026-03-02T08:00:00Z', partsCount: 2, laborHours: 4.0 },
-  { id: 'WO-003', equipment: 'HMMWV #34', tamcn: 'D1092', unit: '1/1 BN', fault: 'Alternator replacement', priority: 'PRIORITY', status: 'IN_PROGRESS', openedAt: '2026-03-02T10:00:00Z', partsCount: 2, laborHours: 3.0 },
-  { id: 'WO-004', equipment: 'MTVR #18', tamcn: 'D0095', unit: '2/1 BN', fault: 'Brake line repair', priority: 'PRIORITY', status: 'OPEN', openedAt: '2026-03-03T06:00:00Z', partsCount: 1, laborHours: 1.0 },
-  { id: 'WO-005', equipment: 'JLTV #22', tamcn: 'D1200', unit: '1/1 BN', fault: 'CTIS fault', priority: 'ROUTINE', status: 'OPEN', openedAt: '2026-03-03T07:00:00Z', partsCount: 0, laborHours: 0.5 },
-];
-
-function getPriorityColor(priority: string) {
+function getPriorityColor(priority: number): string {
   switch (priority) {
-    case 'URGENT': return 'var(--color-danger)';
-    case 'PRIORITY': return 'var(--color-warning)';
+    case 1: return 'var(--color-danger)';
+    case 2: return 'var(--color-warning)';
     default: return 'var(--color-text-muted)';
   }
 }
 
-function getWOStatusColor(status: string) {
+function getWOStatusColor(status: WorkOrderStatus): string {
   switch (status) {
-    case 'COMPLETE': return 'GREEN';
-    case 'IN_PROGRESS': return 'AMBER';
-    case 'PARTS_ON_ORDER': return 'RED';
+    case WorkOrderStatus.COMPLETE: return 'GREEN';
+    case WorkOrderStatus.IN_PROGRESS: return 'AMBER';
+    case WorkOrderStatus.AWAITING_PARTS: return 'RED';
+    case WorkOrderStatus.OPEN: return 'AMBER';
     default: return 'AMBER';
   }
 }
 
 export default function MaintenanceQueue() {
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [workOrders, setWorkOrders] = useState<MaintenanceWorkOrder[]>([]);
+  const [selectedWO, setSelectedWO] = useState<MaintenanceWorkOrder | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const loadWorkOrders = useCallback(async () => {
+    try {
+      const result = await getWorkOrders({});
+      // Show only non-complete work orders in the queue
+      const openOrders = result.data.filter(
+        (wo) => wo.status !== WorkOrderStatus.COMPLETE,
+      );
+      setWorkOrders(openOrders);
+    } catch (err) {
+      console.error('Failed to load work orders:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadWorkOrders();
+  }, [loadWorkOrders]);
+
+  const handleUpdate = () => {
+    loadWorkOrders();
+    // If the selected WO was updated, refresh it from the reloaded list
+    setSelectedWO(null);
+  };
+
+  const handleCreate = () => {
+    loadWorkOrders();
+  };
 
   return (
     <Card
       title="MAINTENANCE WORK ORDERS"
       headerRight={
-        <span
-          style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: 10,
-            color: 'var(--color-text-muted)',
-          }}
-        >
-          {demoOrders.length} OPEN
-        </span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              color: 'var(--color-text-muted)',
+            }}
+          >
+            {workOrders.length} OPEN
+          </span>
+          <button
+            onClick={() => setShowCreate(true)}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              fontFamily: 'var(--font-mono)',
+              fontSize: 9,
+              fontWeight: 600,
+              letterSpacing: '1px',
+              padding: '4px 10px',
+              border: '1px solid var(--color-accent)',
+              borderRadius: 'var(--radius)',
+              backgroundColor: 'transparent',
+              color: 'var(--color-accent)',
+              cursor: 'pointer',
+              textTransform: 'uppercase',
+            }}
+          >
+            <Plus size={10} />
+            NEW WO
+          </button>
+        </div>
       }
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-        {demoOrders.map((wo) => (
-          <div
-            key={wo.id}
-            style={{
-              display: 'flex',
-              alignItems: 'flex-start',
-              gap: 10,
-              padding: '10px 12px',
-              backgroundColor: selectedId === wo.id ? 'var(--color-bg-hover)' : 'var(--color-bg-surface)',
-              border: selectedId === wo.id ? '1px solid var(--color-text-muted)' : '1px solid var(--color-border)',
-              borderLeft: `3px solid ${getPriorityColor(wo.priority)}`,
-              borderRadius: 'var(--radius)',
-              transition: 'background-color var(--transition)',
-              cursor: 'pointer',
-            }}
-            onClick={() => setSelectedId(selectedId === wo.id ? null : wo.id)}
-            onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-bg-hover)')}
-            onMouseLeave={(e) =>
-              (e.currentTarget.style.backgroundColor = selectedId === wo.id ? 'var(--color-bg-hover)' : 'var(--color-bg-surface)')
-            }
-          >
-            <Wrench size={14} style={{ color: 'var(--color-text-muted)', marginTop: 2, flexShrink: 0 }} />
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <span
-                    style={{
-                      fontFamily: 'var(--font-mono)',
-                      fontSize: 11,
-                      color: 'var(--color-text-bright)',
-                      fontWeight: 600,
-                    }}
-                  >
-                    {wo.equipment}
-                  </span>
-                  <span
-                    style={{
-                      fontFamily: 'var(--font-mono)',
-                      fontSize: 9,
-                      color: getPriorityColor(wo.priority),
-                      fontWeight: 600,
-                      letterSpacing: '1px',
-                    }}
-                  >
-                    {wo.priority}
-                  </span>
+        {workOrders.map((wo) => {
+          const totalLabor = wo.laborEntries.reduce((sum, l) => sum + l.hours, 0);
+          return (
+            <div
+              key={wo.id}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 10,
+                padding: '10px 12px',
+                backgroundColor: 'var(--color-bg-surface)',
+                border: '1px solid var(--color-border)',
+                borderLeft: `3px solid ${getPriorityColor(wo.priority)}`,
+                borderRadius: 'var(--radius)',
+                transition: 'background-color var(--transition)',
+                cursor: 'pointer',
+              }}
+              onClick={() => setSelectedWO(wo)}
+              onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-bg-hover)')}
+              onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-bg-surface)')}
+            >
+              <Wrench size={14} style={{ color: 'var(--color-text-muted)', marginTop: 2, flexShrink: 0 }} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span
+                      style={{
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 11,
+                        color: 'var(--color-text-bright)',
+                        fontWeight: 600,
+                      }}
+                    >
+                      {wo.workOrderNumber}
+                    </span>
+                    <span
+                      style={{
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 9,
+                        color: getPriorityColor(wo.priority),
+                        fontWeight: 600,
+                        letterSpacing: '1px',
+                      }}
+                    >
+                      {getPriorityLabel(wo.priority)}
+                    </span>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <StatusDot status={getWOStatusColor(wo.status)} size={6} />
+                    <span
+                      style={{
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 9,
+                        color: 'var(--color-text-muted)',
+                        letterSpacing: '0.5px',
+                      }}
+                    >
+                      {wo.status.replace(/_/g, ' ')}
+                    </span>
+                  </div>
                 </div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                  <StatusDot status={getWOStatusColor(wo.status)} size={6} />
-                  <span
-                    style={{
-                      fontFamily: 'var(--font-mono)',
-                      fontSize: 9,
-                      color: 'var(--color-text-muted)',
-                      letterSpacing: '0.5px',
-                    }}
-                  >
-                    {wo.status.replace(/_/g, ' ')}
-                  </span>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: 'var(--color-text-muted)',
+                    marginBottom: 4,
+                  }}
+                >
+                  {wo.description || '---'}
                 </div>
-              </div>
-              <div
-                style={{
-                  fontSize: 11,
-                  color: 'var(--color-text-muted)',
-                  marginBottom: 4,
-                }}
-              >
-                {wo.fault}
-              </div>
-              <div
-                style={{
-                  display: 'flex',
-                  gap: 12,
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 9,
-                  color: 'var(--color-text-muted)',
-                  marginBottom: 4,
-                }}
-              >
-                <span>{wo.id}</span>
-                <span>{wo.unit}</span>
-                <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-                  <Clock size={9} />
-                  {formatRelativeTime(wo.openedAt)}
-                </span>
-                {wo.eta && <span>ETA: {wo.eta}</span>}
-              </div>
-              <div
-                style={{
-                  display: 'flex',
-                  gap: 12,
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 9,
-                  color: 'var(--color-text-muted)',
-                }}
-              >
-                <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-                  <Package size={9} />
-                  {wo.partsCount} {wo.partsCount === 1 ? 'part' : 'parts'}
-                </span>
-                <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-                  <Clock size={9} />
-                  {wo.laborHours}h labor
-                </span>
+                <div
+                  style={{
+                    display: 'flex',
+                    gap: 12,
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 9,
+                    color: 'var(--color-text-muted)',
+                    marginBottom: 4,
+                  }}
+                >
+                  <span>{wo.workOrderNumber}</span>
+                  <span>{wo.unitId}</span>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+                    <Clock size={9} />
+                    {formatRelativeTime(wo.createdAt)}
+                  </span>
+                  {wo.estimatedCompletion && (
+                    <span>ETA: {formatRelativeTime(wo.estimatedCompletion)}</span>
+                  )}
+                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    gap: 12,
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 9,
+                    color: 'var(--color-text-muted)',
+                  }}
+                >
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+                    <Package size={9} />
+                    {wo.parts.length} {wo.parts.length === 1 ? 'part' : 'parts'}
+                  </span>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+                    <Clock size={9} />
+                    {totalLabor}h labor
+                  </span>
+                  {wo.assignedTo && (
+                    <span>{wo.assignedTo}</span>
+                  )}
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
+
+      <WorkOrderDetailModal
+        workOrder={selectedWO}
+        onClose={() => setSelectedWO(null)}
+        onUpdate={handleUpdate}
+      />
+
+      <CreateWorkOrderModal
+        isOpen={showCreate}
+        onClose={() => setShowCreate(false)}
+        onCreate={handleCreate}
+      />
     </Card>
   );
 }

--- a/frontend/src/components/equipment/WorkOrderDetailModal.tsx
+++ b/frontend/src/components/equipment/WorkOrderDetailModal.tsx
@@ -1,0 +1,1284 @@
+import { useState } from 'react';
+import { X, Package, Clock, Wrench, User, MapPin, Calendar, Tag, Pencil, Trash2, Plus, Check, AlertTriangle, RotateCcw } from 'lucide-react';
+import type { MaintenanceWorkOrder, MaintenancePart, MaintenanceLabor, WorkOrderCategory } from '@/lib/types';
+import { WorkOrderStatus, WorkOrderCategory as WOCat, PartSource, PartStatus, LaborType } from '@/lib/types';
+import { formatDate, formatRelativeTime } from '@/lib/utils';
+import { updateWorkOrder, deleteWorkOrder, addPart, updatePart, deletePart, addLabor, updateLabor, deleteLabor } from '@/api/maintenance';
+
+interface WorkOrderDetailModalProps {
+  workOrder: MaintenanceWorkOrder | null;
+  onClose: () => void;
+  onUpdate?: () => void;
+}
+
+function getStatusColor(status: WorkOrderStatus): string {
+  switch (status) {
+    case WorkOrderStatus.OPEN: return 'var(--color-warning)';
+    case WorkOrderStatus.IN_PROGRESS: return 'var(--color-accent)';
+    case WorkOrderStatus.AWAITING_PARTS: return '#e67e22';
+    case WorkOrderStatus.COMPLETE: return 'var(--color-success)';
+    default: return 'var(--color-text-muted)';
+  }
+}
+
+function getPriorityLabel(priority: number): string {
+  switch (priority) {
+    case 1: return 'URGENT';
+    case 2: return 'PRIORITY';
+    case 3: return 'ROUTINE';
+    default: return 'ROUTINE';
+  }
+}
+
+function getPriorityColor(priority: number): string {
+  switch (priority) {
+    case 1: return 'var(--color-danger)';
+    case 2: return 'var(--color-warning)';
+    default: return 'var(--color-text-muted)';
+  }
+}
+
+function getPartStatusColor(status: PartStatus): string {
+  switch (status) {
+    case PartStatus.NEEDED: return 'var(--color-warning)';
+    case PartStatus.ON_ORDER: return '#e67e22';
+    case PartStatus.RECEIVED: return 'var(--color-accent)';
+    case PartStatus.INSTALLED: return 'var(--color-success)';
+    default: return 'var(--color-text-muted)';
+  }
+}
+
+const badgeStyle = (color: string): React.CSSProperties => ({
+  fontFamily: 'var(--font-mono)',
+  fontSize: 9,
+  fontWeight: 600,
+  letterSpacing: '0.5px',
+  padding: '2px 8px',
+  borderRadius: 2,
+  border: `1px solid ${color}`,
+  color,
+  backgroundColor: `${color}15`,
+  whiteSpace: 'nowrap',
+});
+
+const sectionLabelStyle: React.CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 9,
+  color: 'var(--color-text-muted)',
+  textTransform: 'uppercase',
+  letterSpacing: '1px',
+  marginBottom: 4,
+};
+
+const valueStyle: React.CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 11,
+  color: 'var(--color-text-bright)',
+};
+
+const thStyle = (align: 'left' | 'right' = 'left'): React.CSSProperties => ({
+  fontFamily: 'var(--font-mono)',
+  fontSize: 9,
+  fontWeight: 600,
+  color: 'var(--color-text-muted)',
+  padding: '6px 10px',
+  textAlign: align,
+  borderBottom: '1px solid var(--color-border)',
+  letterSpacing: '1px',
+});
+
+const tdStyle = (mono = false, align: 'left' | 'right' = 'left'): React.CSSProperties => ({
+  fontFamily: mono ? 'var(--font-mono)' : 'inherit',
+  fontSize: 10,
+  padding: '6px 10px',
+  color: 'var(--color-text)',
+  borderBottom: '1px solid var(--color-border)',
+  textAlign: align,
+});
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '6px 8px',
+  backgroundColor: 'var(--color-bg)',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius)',
+  color: 'var(--color-text)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 11,
+};
+
+const formLabelStyle: React.CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10,
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: '1.5px',
+  color: 'var(--color-text-muted)',
+  marginBottom: 4,
+  display: 'block',
+};
+
+const selectStyle: React.CSSProperties = {
+  ...inputStyle,
+  appearance: 'none' as const,
+  backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%236b7280' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E")`,
+  backgroundRepeat: 'no-repeat',
+  backgroundPosition: 'right 8px center',
+  paddingRight: 28,
+};
+
+const smallBtnStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'none',
+  border: 'none',
+  color: 'var(--color-text-muted)',
+  cursor: 'pointer',
+  padding: 3,
+  borderRadius: 2,
+};
+
+const actionBtnStyle = (
+  bg: string,
+  fg: string,
+  disabled?: boolean,
+): React.CSSProperties => ({
+  fontFamily: 'var(--font-mono)',
+  fontSize: 9,
+  fontWeight: 600,
+  letterSpacing: '1px',
+  padding: '6px 14px',
+  border: 'none',
+  borderRadius: 'var(--radius)',
+  backgroundColor: disabled ? 'var(--color-text-muted)' : bg,
+  color: fg,
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  textTransform: 'uppercase',
+  opacity: disabled ? 0.6 : 1,
+  whiteSpace: 'nowrap',
+});
+
+const inlineTdInput: React.CSSProperties = {
+  ...inputStyle,
+  padding: '4px 6px',
+  fontSize: 10,
+};
+
+const inlineTdSelect: React.CSSProperties = {
+  ...selectStyle,
+  padding: '4px 6px',
+  fontSize: 10,
+};
+
+export default function WorkOrderDetailModal({ workOrder, onClose, onUpdate }: WorkOrderDetailModalProps) {
+  // ----- Local mutable WO state (so we can reflect mutations immediately) -----
+  const [wo, setWo] = useState<MaintenanceWorkOrder | null>(null);
+  const [statusLoading, setStatusLoading] = useState(false);
+  const [editMode, setEditMode] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // Edit fields
+  const [editDescription, setEditDescription] = useState('');
+  const [editPriority, setEditPriority] = useState(3);
+  const [editAssignedTo, setEditAssignedTo] = useState('');
+  const [editLocation, setEditLocation] = useState('');
+  const [editCategory, setEditCategory] = useState<WorkOrderCategory>(WOCat.CORRECTIVE);
+  const [editEstCompletion, setEditEstCompletion] = useState('');
+  const [editSaving, setEditSaving] = useState(false);
+
+  // Parts inline
+  const [addingPart, setAddingPart] = useState(false);
+  const [editingPartId, setEditingPartId] = useState<string | null>(null);
+  const [partForm, setPartForm] = useState({ partNumber: '', nsn: '', nomenclature: '', quantity: 1, unitCost: 0, source: PartSource.ON_HAND as PartSource, status: PartStatus.NEEDED as PartStatus });
+  const [partSaving, setPartSaving] = useState(false);
+
+  // Labor inline
+  const [addingLabor, setAddingLabor] = useState(false);
+  const [editingLaborId, setEditingLaborId] = useState<string | null>(null);
+  const [laborForm, setLaborForm] = useState({ personnelId: '', laborType: LaborType.REPAIR as LaborType, hours: 0, date: new Date().toISOString().split('T')[0], notes: '' });
+  const [laborSaving, setLaborSaving] = useState(false);
+
+  // Sync workOrder prop → local state
+  if (workOrder && (!wo || wo.id !== workOrder.id)) {
+    setWo(workOrder);
+    setEditMode(false);
+    setError(null);
+    setDeleteConfirm(false);
+    setAddingPart(false);
+    setEditingPartId(null);
+    setAddingLabor(false);
+    setEditingLaborId(null);
+  }
+  if (!workOrder && wo) {
+    setWo(null);
+  }
+
+  if (!wo) return null;
+
+  const totalLaborHours = wo.laborEntries.reduce((sum, l) => sum + l.hours, 0);
+  const totalPartsCost = wo.parts.reduce((sum, p) => sum + (p.unitCost ? p.unitCost * p.quantity : 0), 0);
+
+  // ---------- Status transitions ----------
+  const getTransitions = (): { label: string; target: WorkOrderStatus }[] => {
+    switch (wo.status) {
+      case WorkOrderStatus.OPEN:
+        return [{ label: 'START WORK', target: WorkOrderStatus.IN_PROGRESS }];
+      case WorkOrderStatus.IN_PROGRESS:
+        return [
+          { label: 'AWAITING PARTS', target: WorkOrderStatus.AWAITING_PARTS },
+          { label: 'COMPLETE', target: WorkOrderStatus.COMPLETE },
+        ];
+      case WorkOrderStatus.AWAITING_PARTS:
+        return [
+          { label: 'RESUME WORK', target: WorkOrderStatus.IN_PROGRESS },
+          { label: 'COMPLETE', target: WorkOrderStatus.COMPLETE },
+        ];
+      case WorkOrderStatus.COMPLETE:
+        return [{ label: 'REOPEN', target: WorkOrderStatus.OPEN }];
+      default:
+        return [];
+    }
+  };
+
+  const handleStatusChange = async (target: WorkOrderStatus) => {
+    setStatusLoading(true);
+    setError(null);
+    try {
+      const updated = await updateWorkOrder(wo.id, {
+        status: target,
+        ...(target === WorkOrderStatus.COMPLETE ? { completedAt: new Date().toISOString() } : {}),
+      });
+      setWo(updated);
+      onUpdate?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update status.');
+    } finally {
+      setStatusLoading(false);
+    }
+  };
+
+  // ---------- Edit WO fields ----------
+  const startEdit = () => {
+    setEditDescription(wo.description || '');
+    setEditPriority(wo.priority);
+    setEditAssignedTo(wo.assignedTo || '');
+    setEditLocation(wo.location || '');
+    setEditCategory(wo.category || WOCat.CORRECTIVE);
+    setEditEstCompletion(wo.estimatedCompletion ? wo.estimatedCompletion.split('T')[0] : '');
+    setEditMode(true);
+  };
+
+  const handleSaveEdit = async () => {
+    setEditSaving(true);
+    setError(null);
+    try {
+      const updated = await updateWorkOrder(wo.id, {
+        description: editDescription,
+        priority: editPriority,
+        assignedTo: editAssignedTo || undefined,
+        location: editLocation || undefined,
+        category: editCategory,
+        estimatedCompletion: editEstCompletion || undefined,
+      });
+      setWo(updated);
+      setEditMode(false);
+      onUpdate?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save changes.');
+    } finally {
+      setEditSaving(false);
+    }
+  };
+
+  // ---------- Delete WO ----------
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    setError(null);
+    try {
+      await deleteWorkOrder(wo.id);
+      onUpdate?.();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete work order.');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  // ---------- Parts CRUD ----------
+  const resetPartForm = () => {
+    setPartForm({ partNumber: '', nsn: '', nomenclature: '', quantity: 1, unitCost: 0, source: PartSource.ON_HAND, status: PartStatus.NEEDED });
+  };
+
+  const startAddPart = () => {
+    resetPartForm();
+    setAddingPart(true);
+    setEditingPartId(null);
+  };
+
+  const startEditPart = (part: MaintenancePart) => {
+    setPartForm({
+      partNumber: part.partNumber,
+      nsn: part.nsn || '',
+      nomenclature: part.nomenclature,
+      quantity: part.quantity,
+      unitCost: part.unitCost || 0,
+      source: part.source,
+      status: part.status,
+    });
+    setEditingPartId(part.id);
+    setAddingPart(false);
+  };
+
+  const handleSavePart = async () => {
+    setPartSaving(true);
+    setError(null);
+    try {
+      if (addingPart) {
+        const newPart = await addPart(wo.id, {
+          partNumber: partForm.partNumber,
+          nsn: partForm.nsn || undefined,
+          nomenclature: partForm.nomenclature,
+          quantity: partForm.quantity,
+          unitCost: partForm.unitCost || undefined,
+          source: partForm.source,
+          status: partForm.status,
+        });
+        setWo({ ...wo, parts: [...wo.parts, newPart] });
+        setAddingPart(false);
+      } else if (editingPartId) {
+        const updated = await updatePart(wo.id, editingPartId, {
+          partNumber: partForm.partNumber,
+          nsn: partForm.nsn || undefined,
+          nomenclature: partForm.nomenclature,
+          quantity: partForm.quantity,
+          unitCost: partForm.unitCost || undefined,
+          source: partForm.source,
+          status: partForm.status,
+        });
+        setWo({ ...wo, parts: wo.parts.map((p) => (p.id === editingPartId ? updated : p)) });
+        setEditingPartId(null);
+      }
+      resetPartForm();
+      onUpdate?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save part.');
+    } finally {
+      setPartSaving(false);
+    }
+  };
+
+  const handleDeletePart = async (partId: string) => {
+    setError(null);
+    try {
+      await deletePart(wo.id, partId);
+      setWo({ ...wo, parts: wo.parts.filter((p) => p.id !== partId) });
+      onUpdate?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete part.');
+    }
+  };
+
+  // ---------- Labor CRUD ----------
+  const resetLaborForm = () => {
+    setLaborForm({ personnelId: '', laborType: LaborType.REPAIR, hours: 0, date: new Date().toISOString().split('T')[0], notes: '' });
+  };
+
+  const startAddLabor = () => {
+    resetLaborForm();
+    setAddingLabor(true);
+    setEditingLaborId(null);
+  };
+
+  const startEditLabor = (labor: MaintenanceLabor) => {
+    setLaborForm({
+      personnelId: labor.personnelId,
+      laborType: labor.laborType,
+      hours: labor.hours,
+      date: labor.date,
+      notes: labor.notes || '',
+    });
+    setEditingLaborId(labor.id);
+    setAddingLabor(false);
+  };
+
+  const handleSaveLabor = async () => {
+    setLaborSaving(true);
+    setError(null);
+    try {
+      if (addingLabor) {
+        const newLabor = await addLabor(wo.id, {
+          personnelId: laborForm.personnelId,
+          laborType: laborForm.laborType,
+          hours: laborForm.hours,
+          date: laborForm.date,
+          notes: laborForm.notes || undefined,
+        });
+        setWo({ ...wo, laborEntries: [...wo.laborEntries, newLabor] });
+        setAddingLabor(false);
+      } else if (editingLaborId) {
+        const updated = await updateLabor(wo.id, editingLaborId, {
+          personnelId: laborForm.personnelId,
+          laborType: laborForm.laborType,
+          hours: laborForm.hours,
+          date: laborForm.date,
+          notes: laborForm.notes || undefined,
+        });
+        setWo({ ...wo, laborEntries: wo.laborEntries.map((l) => (l.id === editingLaborId ? updated : l)) });
+        setEditingLaborId(null);
+      }
+      resetLaborForm();
+      onUpdate?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save labor entry.');
+    } finally {
+      setLaborSaving(false);
+    }
+  };
+
+  const handleDeleteLabor = async (laborId: string) => {
+    setError(null);
+    try {
+      await deleteLabor(wo.id, laborId);
+      setWo({ ...wo, laborEntries: wo.laborEntries.filter((l) => l.id !== laborId) });
+      onUpdate?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete labor entry.');
+    }
+  };
+
+  // ---------- Part form row component ----------
+  const renderPartFormRow = (isNew: boolean) => (
+    <tr>
+      <td style={tdStyle(true)}>
+        <input style={inlineTdInput} value={partForm.partNumber} onChange={(e) => setPartForm({ ...partForm, partNumber: e.target.value })} placeholder="Part #" />
+      </td>
+      <td style={tdStyle(true)}>
+        <input style={inlineTdInput} value={partForm.nsn} onChange={(e) => setPartForm({ ...partForm, nsn: e.target.value })} placeholder="NSN" />
+      </td>
+      <td style={tdStyle()}>
+        <input style={inlineTdInput} value={partForm.nomenclature} onChange={(e) => setPartForm({ ...partForm, nomenclature: e.target.value })} placeholder="Name" />
+      </td>
+      <td style={tdStyle(true, 'right')}>
+        <input style={{ ...inlineTdInput, width: 50, textAlign: 'right' }} type="number" min={1} value={partForm.quantity} onChange={(e) => setPartForm({ ...partForm, quantity: Number(e.target.value) })} />
+      </td>
+      <td style={tdStyle(true)}>
+        <select style={inlineTdSelect} value={partForm.source} onChange={(e) => setPartForm({ ...partForm, source: e.target.value as PartSource })}>
+          {Object.values(PartSource).map((s) => <option key={s} value={s}>{s.replace(/_/g, ' ')}</option>)}
+        </select>
+      </td>
+      <td style={tdStyle(true)}>
+        <select style={inlineTdSelect} value={partForm.status} onChange={(e) => setPartForm({ ...partForm, status: e.target.value as PartStatus })}>
+          {Object.values(PartStatus).map((s) => <option key={s} value={s}>{s.replace(/_/g, ' ')}</option>)}
+        </select>
+      </td>
+      <td style={tdStyle(true, 'right')}>
+        <input style={{ ...inlineTdInput, width: 60, textAlign: 'right' }} type="number" min={0} step={0.01} value={partForm.unitCost} onChange={(e) => setPartForm({ ...partForm, unitCost: Number(e.target.value) })} />
+      </td>
+      <td style={{ ...tdStyle(), whiteSpace: 'nowrap' }}>
+        <button style={smallBtnStyle} disabled={partSaving} onClick={handleSavePart} title="Save">
+          <Check size={12} style={{ color: 'var(--color-success)' }} />
+        </button>
+        <button style={smallBtnStyle} onClick={() => { isNew ? setAddingPart(false) : setEditingPartId(null); resetPartForm(); }} title="Cancel">
+          <X size={12} style={{ color: 'var(--color-danger)' }} />
+        </button>
+      </td>
+    </tr>
+  );
+
+  // ---------- Labor form row component ----------
+  const renderLaborFormRow = (isNew: boolean) => (
+    <tr>
+      <td style={tdStyle(true)}>
+        <input style={inlineTdInput} type="date" value={laborForm.date} onChange={(e) => setLaborForm({ ...laborForm, date: e.target.value })} />
+      </td>
+      <td style={tdStyle(true)}>
+        <input style={inlineTdInput} value={laborForm.personnelId} onChange={(e) => setLaborForm({ ...laborForm, personnelId: e.target.value })} placeholder="Personnel ID" />
+      </td>
+      <td style={tdStyle(true)}>
+        <select style={inlineTdSelect} value={laborForm.laborType} onChange={(e) => setLaborForm({ ...laborForm, laborType: e.target.value as LaborType })}>
+          {Object.values(LaborType).map((t) => <option key={t} value={t}>{t}</option>)}
+        </select>
+      </td>
+      <td style={tdStyle(true, 'right')}>
+        <input style={{ ...inlineTdInput, width: 50, textAlign: 'right' }} type="number" min={0} step={0.5} value={laborForm.hours} onChange={(e) => setLaborForm({ ...laborForm, hours: Number(e.target.value) })} />
+      </td>
+      <td style={tdStyle()}>
+        <input style={inlineTdInput} value={laborForm.notes} onChange={(e) => setLaborForm({ ...laborForm, notes: e.target.value })} placeholder="Notes" />
+      </td>
+      <td style={{ ...tdStyle(), whiteSpace: 'nowrap' }}>
+        <button style={smallBtnStyle} disabled={laborSaving} onClick={handleSaveLabor} title="Save">
+          <Check size={12} style={{ color: 'var(--color-success)' }} />
+        </button>
+        <button style={smallBtnStyle} onClick={() => { isNew ? setAddingLabor(false) : setEditingLaborId(null); resetLaborForm(); }} title="Cancel">
+          <X size={12} style={{ color: 'var(--color-danger)' }} />
+        </button>
+      </td>
+    </tr>
+  );
+
+  const transitions = getTransitions();
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 3000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0, 0, 0, 0.85)',
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        style={{
+          width: '90%',
+          maxWidth: 860,
+          maxHeight: '90vh',
+          backgroundColor: 'var(--color-bg-card)',
+          border: '1px solid var(--color-border-strong)',
+          borderRadius: 'var(--radius)',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {/* ── Header ─────────────────────────────────────────────────── */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '14px 16px',
+            borderBottom: '1px solid var(--color-border)',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 14,
+                fontWeight: 700,
+                letterSpacing: '1.5px',
+                color: 'var(--color-text-bright)',
+              }}
+            >
+              {wo.workOrderNumber}
+            </span>
+            <span style={badgeStyle(getStatusColor(wo.status))}>
+              {wo.status.replace(/_/g, ' ')}
+            </span>
+            <span style={badgeStyle(getPriorityColor(wo.priority))}>
+              {getPriorityLabel(wo.priority)}
+            </span>
+            {wo.category && (
+              <span style={badgeStyle('var(--color-text-muted)')}>
+                {wo.category}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'none',
+              border: 'none',
+              color: 'var(--color-text-muted)',
+              cursor: 'pointer',
+              padding: 4,
+            }}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* ── Status transition bar ────────────────────────────────── */}
+        {transitions.length > 0 && (
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              padding: '10px 16px',
+              borderBottom: '1px solid var(--color-border)',
+              backgroundColor: 'var(--color-bg-elevated)',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 9,
+                color: 'var(--color-text-muted)',
+                letterSpacing: '1px',
+                textTransform: 'uppercase',
+                marginRight: 4,
+              }}
+            >
+              TRANSITION:
+            </span>
+            {transitions.map((t) => (
+              <button
+                key={t.target}
+                disabled={statusLoading}
+                onClick={() => handleStatusChange(t.target)}
+                style={actionBtnStyle(
+                  t.target === WorkOrderStatus.COMPLETE ? 'var(--color-success)' :
+                  t.target === WorkOrderStatus.OPEN ? 'var(--color-warning)' :
+                  'var(--color-accent)',
+                  'var(--color-bg)',
+                  statusLoading,
+                )}
+              >
+                {statusLoading ? 'UPDATING...' : t.label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* ── Error bar ───────────────────────────────────────────── */}
+        {error && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '8px 16px',
+              backgroundColor: 'var(--color-danger)15',
+              borderBottom: '1px solid var(--color-danger)',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--color-danger)',
+            }}
+          >
+            <AlertTriangle size={12} />
+            {error}
+            <button
+              onClick={() => setError(null)}
+              style={{ ...smallBtnStyle, marginLeft: 'auto', color: 'var(--color-danger)' }}
+            >
+              <X size={12} />
+            </button>
+          </div>
+        )}
+
+        {/* ── Scrollable body ────────────────────────────────────────── */}
+        <div
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            padding: '16px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 20,
+          }}
+        >
+          {/* Edit toggle */}
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            {!editMode ? (
+              <button
+                onClick={startEdit}
+                style={{
+                  ...actionBtnStyle('var(--color-bg-hover)', 'var(--color-text-bright)'),
+                  border: '1px solid var(--color-border)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 6,
+                }}
+              >
+                <Pencil size={10} />
+                EDIT
+              </button>
+            ) : (
+              <div style={{ display: 'flex', gap: 6 }}>
+                <button
+                  onClick={handleSaveEdit}
+                  disabled={editSaving}
+                  style={actionBtnStyle('var(--color-accent)', 'var(--color-bg)', editSaving)}
+                >
+                  {editSaving ? 'SAVING...' : 'SAVE'}
+                </button>
+                <button
+                  onClick={() => setEditMode(false)}
+                  disabled={editSaving}
+                  style={{
+                    ...actionBtnStyle('transparent', 'var(--color-text-muted)'),
+                    border: '1px solid var(--color-border)',
+                  }}
+                >
+                  CANCEL
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Description */}
+          {editMode ? (
+            <div>
+              <label style={formLabelStyle}>DESCRIPTION</label>
+              <textarea
+                style={{ ...inputStyle, minHeight: 60, resize: 'vertical' }}
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+              />
+            </div>
+          ) : (
+            wo.description && (
+              <div
+                style={{
+                  fontSize: 12,
+                  color: 'var(--color-text)',
+                  lineHeight: 1.5,
+                  padding: '10px 12px',
+                  backgroundColor: 'var(--color-bg-hover)',
+                  border: '1px solid var(--color-border)',
+                  borderRadius: 'var(--radius)',
+                }}
+              >
+                {wo.description}
+              </div>
+            )
+          )}
+
+          {/* Info Grid */}
+          {editMode ? (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+                gap: 12,
+              }}
+            >
+              <div>
+                <label style={formLabelStyle}>PRIORITY</label>
+                <select
+                  style={selectStyle}
+                  value={editPriority}
+                  onChange={(e) => setEditPriority(Number(e.target.value))}
+                >
+                  <option value={1}>URGENT</option>
+                  <option value={2}>PRIORITY</option>
+                  <option value={3}>ROUTINE</option>
+                </select>
+              </div>
+              <div>
+                <label style={formLabelStyle}>CATEGORY</label>
+                <select
+                  style={selectStyle}
+                  value={editCategory}
+                  onChange={(e) => setEditCategory(e.target.value as WorkOrderCategory)}
+                >
+                  <option value={WOCat.CORRECTIVE}>CORRECTIVE</option>
+                  <option value={WOCat.PREVENTIVE}>PREVENTIVE</option>
+                  <option value={WOCat.MODIFICATION}>MODIFICATION</option>
+                  <option value={WOCat.INSPECTION}>INSPECTION</option>
+                </select>
+              </div>
+              <div>
+                <label style={formLabelStyle}>ASSIGNED TO</label>
+                <input
+                  style={inputStyle}
+                  value={editAssignedTo}
+                  onChange={(e) => setEditAssignedTo(e.target.value)}
+                  placeholder="Mechanic name"
+                />
+              </div>
+              <div>
+                <label style={formLabelStyle}>LOCATION</label>
+                <input
+                  style={inputStyle}
+                  value={editLocation}
+                  onChange={(e) => setEditLocation(e.target.value)}
+                  placeholder="Bay / Motor Pool"
+                />
+              </div>
+              <div>
+                <label style={formLabelStyle}>EST. COMPLETION</label>
+                <input
+                  style={inputStyle}
+                  type="date"
+                  value={editEstCompletion}
+                  onChange={(e) => setEditEstCompletion(e.target.value)}
+                />
+              </div>
+            </div>
+          ) : (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+                gap: 16,
+              }}
+            >
+              <div>
+                <div style={sectionLabelStyle}>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <Tag size={9} />
+                    Equipment ID
+                  </span>
+                </div>
+                <div style={valueStyle}>
+                  {wo.individualEquipmentId || wo.equipmentId || '---'}
+                </div>
+              </div>
+
+              <div>
+                <div style={sectionLabelStyle}>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <User size={9} />
+                    Assigned To
+                  </span>
+                </div>
+                <div style={valueStyle}>{wo.assignedTo || '---'}</div>
+              </div>
+
+              <div>
+                <div style={sectionLabelStyle}>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <MapPin size={9} />
+                    Location
+                  </span>
+                </div>
+                <div style={valueStyle}>{wo.location || '---'}</div>
+              </div>
+
+              <div>
+                <div style={sectionLabelStyle}>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <Calendar size={9} />
+                    Created
+                  </span>
+                </div>
+                <div style={valueStyle}>{formatDate(wo.createdAt)}</div>
+              </div>
+
+              <div>
+                <div style={sectionLabelStyle}>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <Clock size={9} />
+                    Est. Completion
+                  </span>
+                </div>
+                <div style={valueStyle}>
+                  {wo.estimatedCompletion ? formatRelativeTime(wo.estimatedCompletion) : '---'}
+                </div>
+              </div>
+
+              <div>
+                <div style={sectionLabelStyle}>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <Wrench size={9} />
+                    Actual Hours
+                  </span>
+                </div>
+                <div style={valueStyle}>{wo.actualHours ?? totalLaborHours}h</div>
+              </div>
+
+              {wo.completedAt && (
+                <div>
+                  <div style={sectionLabelStyle}>
+                    <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                      <Calendar size={9} />
+                      Completed
+                    </span>
+                  </div>
+                  <div style={valueStyle}>{formatDate(wo.completedAt)}</div>
+                </div>
+              )}
+
+              <div>
+                <div style={sectionLabelStyle}>Unit</div>
+                <div style={valueStyle}>{wo.unitId}</div>
+              </div>
+            </div>
+          )}
+
+          {/* ── Parts Table ──────────────────────────────────────────── */}
+          <div>
+            <div
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 9,
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                letterSpacing: '1.5px',
+                color: 'var(--color-text-muted)',
+                marginBottom: 8,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
+            >
+              <Package size={10} />
+              PARTS ({wo.parts.length})
+              <button
+                onClick={startAddPart}
+                disabled={addingPart}
+                style={{
+                  ...smallBtnStyle,
+                  marginLeft: 8,
+                  border: '1px solid var(--color-border)',
+                  borderRadius: 'var(--radius)',
+                  padding: '2px 8px',
+                  gap: 4,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  color: 'var(--color-accent)',
+                  fontSize: 9,
+                  fontFamily: 'var(--font-mono)',
+                  fontWeight: 600,
+                  letterSpacing: '0.5px',
+                  cursor: addingPart ? 'not-allowed' : 'pointer',
+                }}
+              >
+                <Plus size={9} />
+                ADD PART
+              </button>
+            </div>
+            <div
+              style={{
+                backgroundColor: 'var(--color-bg-elevated)',
+                border: '1px solid var(--color-border)',
+                borderRadius: 'var(--radius)',
+                overflow: 'hidden',
+              }}
+            >
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr>
+                    <th style={thStyle()}>PART #</th>
+                    <th style={thStyle()}>NSN</th>
+                    <th style={thStyle()}>NOMENCLATURE</th>
+                    <th style={thStyle('right')}>QTY</th>
+                    <th style={thStyle()}>SOURCE</th>
+                    <th style={thStyle()}>STATUS</th>
+                    <th style={thStyle('right')}>COST</th>
+                    <th style={thStyle()}>ACTIONS</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {wo.parts.map((part) =>
+                    editingPartId === part.id ? (
+                      renderPartFormRow(false)
+                    ) : (
+                      <tr key={part.id}>
+                        <td style={{ ...tdStyle(true), color: 'var(--color-text-bright)' }}>
+                          {part.partNumber}
+                        </td>
+                        <td style={{ ...tdStyle(true), color: 'var(--color-text-muted)', fontSize: 9 }}>
+                          {part.nsn || '---'}
+                        </td>
+                        <td style={tdStyle()}>
+                          {part.nomenclature}
+                        </td>
+                        <td style={tdStyle(true, 'right')}>
+                          {part.quantity}
+                        </td>
+                        <td style={{ ...tdStyle(true), fontSize: 9, color: 'var(--color-text-muted)' }}>
+                          {part.source.replace(/_/g, ' ')}
+                        </td>
+                        <td style={{ ...tdStyle(true), fontSize: 9, color: getPartStatusColor(part.status) }}>
+                          {part.status.replace(/_/g, ' ')}
+                        </td>
+                        <td style={{ ...tdStyle(true, 'right'), color: 'var(--color-text)' }}>
+                          {part.unitCost ? `$${(part.unitCost * part.quantity).toLocaleString()}` : '---'}
+                        </td>
+                        <td style={{ ...tdStyle(), whiteSpace: 'nowrap' }}>
+                          <button style={smallBtnStyle} onClick={() => startEditPart(part)} title="Edit Part">
+                            <Pencil size={11} style={{ color: 'var(--color-accent)' }} />
+                          </button>
+                          <button style={smallBtnStyle} onClick={() => handleDeletePart(part.id)} title="Delete Part">
+                            <Trash2 size={11} style={{ color: 'var(--color-danger)' }} />
+                          </button>
+                        </td>
+                      </tr>
+                    ),
+                  )}
+                  {addingPart && renderPartFormRow(true)}
+                  {wo.parts.length === 0 && !addingPart && (
+                    <tr>
+                      <td colSpan={8} style={{ ...tdStyle(), textAlign: 'center', color: 'var(--color-text-muted)', padding: '12px 10px' }}>
+                        No parts recorded.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+                {wo.parts.length > 0 && (
+                  <tfoot>
+                    <tr>
+                      <td
+                        colSpan={6}
+                        style={{
+                          fontFamily: 'var(--font-mono)',
+                          fontSize: 9,
+                          fontWeight: 600,
+                          padding: '8px 10px',
+                          textAlign: 'right',
+                          color: 'var(--color-text-muted)',
+                          letterSpacing: '1px',
+                        }}
+                      >
+                        TOTAL
+                      </td>
+                      <td
+                        style={{
+                          fontFamily: 'var(--font-mono)',
+                          fontSize: 11,
+                          fontWeight: 600,
+                          padding: '8px 10px',
+                          textAlign: 'right',
+                          color: 'var(--color-text-bright)',
+                        }}
+                      >
+                        ${totalPartsCost.toLocaleString()}
+                      </td>
+                      <td />
+                    </tr>
+                  </tfoot>
+                )}
+              </table>
+            </div>
+          </div>
+
+          {/* ── Labor Table ──────────────────────────────────────────── */}
+          <div>
+            <div
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 9,
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                letterSpacing: '1.5px',
+                color: 'var(--color-text-muted)',
+                marginBottom: 8,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
+            >
+              <Wrench size={10} />
+              LABOR ({wo.laborEntries.length} entries, {totalLaborHours}h total)
+              <button
+                onClick={startAddLabor}
+                disabled={addingLabor}
+                style={{
+                  ...smallBtnStyle,
+                  marginLeft: 8,
+                  border: '1px solid var(--color-border)',
+                  borderRadius: 'var(--radius)',
+                  padding: '2px 8px',
+                  gap: 4,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  color: 'var(--color-accent)',
+                  fontSize: 9,
+                  fontFamily: 'var(--font-mono)',
+                  fontWeight: 600,
+                  letterSpacing: '0.5px',
+                  cursor: addingLabor ? 'not-allowed' : 'pointer',
+                }}
+              >
+                <Plus size={9} />
+                ADD LABOR
+              </button>
+            </div>
+            <div
+              style={{
+                backgroundColor: 'var(--color-bg-elevated)',
+                border: '1px solid var(--color-border)',
+                borderRadius: 'var(--radius)',
+                overflow: 'hidden',
+              }}
+            >
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr>
+                    <th style={thStyle()}>DATE</th>
+                    <th style={thStyle()}>PERSONNEL</th>
+                    <th style={thStyle()}>TYPE</th>
+                    <th style={thStyle('right')}>HOURS</th>
+                    <th style={thStyle()}>NOTES</th>
+                    <th style={thStyle()}>ACTIONS</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {wo.laborEntries.map((labor) =>
+                    editingLaborId === labor.id ? (
+                      renderLaborFormRow(false)
+                    ) : (
+                      <tr key={labor.id}>
+                        <td style={{ ...tdStyle(true), whiteSpace: 'nowrap' }}>
+                          {labor.date}
+                        </td>
+                        <td style={{ ...tdStyle(true), color: 'var(--color-text-muted)', fontSize: 9 }}>
+                          {labor.personnelId}
+                        </td>
+                        <td style={{ ...tdStyle(true), fontSize: 9, textTransform: 'uppercase', color: 'var(--color-text-muted)' }}>
+                          {labor.laborType}
+                        </td>
+                        <td style={{ ...tdStyle(true, 'right'), color: 'var(--color-text-bright)', fontWeight: 600 }}>
+                          {labor.hours}h
+                        </td>
+                        <td style={tdStyle()}>
+                          {labor.notes || '---'}
+                        </td>
+                        <td style={{ ...tdStyle(), whiteSpace: 'nowrap' }}>
+                          <button style={smallBtnStyle} onClick={() => startEditLabor(labor)} title="Edit Labor">
+                            <Pencil size={11} style={{ color: 'var(--color-accent)' }} />
+                          </button>
+                          <button style={smallBtnStyle} onClick={() => handleDeleteLabor(labor.id)} title="Delete Labor">
+                            <Trash2 size={11} style={{ color: 'var(--color-danger)' }} />
+                          </button>
+                        </td>
+                      </tr>
+                    ),
+                  )}
+                  {addingLabor && renderLaborFormRow(true)}
+                  {wo.laborEntries.length === 0 && !addingLabor && (
+                    <tr>
+                      <td colSpan={6} style={{ ...tdStyle(), textAlign: 'center', color: 'var(--color-text-muted)', padding: '12px 10px' }}>
+                        No labor entries recorded.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+                {wo.laborEntries.length > 0 && (
+                  <tfoot>
+                    <tr>
+                      <td
+                        colSpan={3}
+                        style={{
+                          fontFamily: 'var(--font-mono)',
+                          fontSize: 9,
+                          fontWeight: 600,
+                          padding: '8px 10px',
+                          textAlign: 'right',
+                          color: 'var(--color-text-muted)',
+                          letterSpacing: '1px',
+                        }}
+                      >
+                        TOTAL
+                      </td>
+                      <td
+                        style={{
+                          fontFamily: 'var(--font-mono)',
+                          fontSize: 11,
+                          fontWeight: 600,
+                          padding: '8px 10px',
+                          textAlign: 'right',
+                          color: 'var(--color-text-bright)',
+                        }}
+                      >
+                        {totalLaborHours}h
+                      </td>
+                      <td colSpan={2} style={{ borderBottom: 'none' }} />
+                    </tr>
+                  </tfoot>
+                )}
+              </table>
+            </div>
+          </div>
+
+          {/* ── Delete Work Order ──────────────────────────────────── */}
+          <div
+            style={{
+              marginTop: 12,
+              padding: '12px 16px',
+              border: '1px solid var(--color-border)',
+              borderRadius: 'var(--radius)',
+              backgroundColor: 'var(--color-bg-elevated)',
+            }}
+          >
+            {!deleteConfirm ? (
+              <button
+                onClick={() => setDeleteConfirm(true)}
+                style={{
+                  ...actionBtnStyle('transparent', 'var(--color-danger)'),
+                  border: '1px solid var(--color-danger)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 6,
+                }}
+              >
+                <Trash2 size={10} />
+                DELETE WORK ORDER
+              </button>
+            ) : (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 10,
+                    color: 'var(--color-danger)',
+                    fontWeight: 600,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                  }}
+                >
+                  <AlertTriangle size={12} />
+                  PERMANENTLY DELETE {wo.workOrderNumber}?
+                </span>
+                <button
+                  onClick={handleDelete}
+                  disabled={isDeleting}
+                  style={actionBtnStyle('var(--color-danger)', '#fff', isDeleting)}
+                >
+                  {isDeleting ? 'DELETING...' : 'CONFIRM DELETE'}
+                </button>
+                <button
+                  onClick={() => setDeleteConfirm(false)}
+                  disabled={isDeleting}
+                  style={{
+                    ...actionBtnStyle('transparent', 'var(--color-text-muted)'),
+                    border: '1px solid var(--color-border)',
+                  }}
+                >
+                  <RotateCcw size={10} />
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* ── Footer ─────────────────────────────────────────────────── */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            padding: '12px 16px',
+            borderTop: '1px solid var(--color-border)',
+          }}
+        >
+          <button
+            onClick={onClose}
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              fontWeight: 600,
+              letterSpacing: '1px',
+              padding: '8px 24px',
+              border: '1px solid var(--color-border)',
+              borderRadius: 'var(--radius)',
+              backgroundColor: 'var(--color-bg-hover)',
+              color: 'var(--color-text-bright)',
+              cursor: 'pointer',
+              transition: 'background-color var(--transition)',
+            }}
+          >
+            CLOSE
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/EquipmentDetailPage.tsx
+++ b/frontend/src/pages/EquipmentDetailPage.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, AlertTriangle, Users, Wrench, Truck, MapPin } from 'lucide-react';
+import { ArrowLeft, AlertTriangle, Users, Wrench, Truck, MapPin, Plus, Check, X } from 'lucide-react';
 import type {
   EquipmentItem,
   MaintenanceWorkOrder,
@@ -9,7 +9,7 @@ import type {
 } from '@/lib/types';
 import { FaultSeverity } from '@/lib/types';
 import { isDemoMode, mockApi } from '@/api/mockClient';
-import { getIndividualEquipmentById } from '@/api/equipment';
+import { getIndividualEquipmentById, reportFault, updateFault, assignDriver, updateDriverAssignment } from '@/api/equipment';
 import EquipmentOverviewTab from '@/components/equipment/EquipmentOverviewTab';
 import MaintenanceHistoryTab from '@/components/equipment/MaintenanceHistoryTab';
 import { formatDate, formatRelativeTime } from '@/lib/utils';
@@ -45,6 +45,61 @@ function getItemStatusColor(status: string): string {
   }
 }
 
+// Shared form styles
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 10px',
+  backgroundColor: 'var(--color-bg)',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius)',
+  color: 'var(--color-text)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 12,
+};
+
+const formLabelStyle: React.CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10,
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: '1.5px',
+  color: 'var(--color-text-muted)',
+  marginBottom: 4,
+  display: 'block',
+};
+
+const selectStyle: React.CSSProperties = {
+  ...inputStyle,
+  appearance: 'none' as const,
+  backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%236b7280' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E")`,
+  backgroundRepeat: 'no-repeat',
+  backgroundPosition: 'right 8px center',
+  paddingRight: 28,
+};
+
+const actionBtnStyle = (
+  bg: string,
+  fg: string,
+  disabled?: boolean,
+): React.CSSProperties => ({
+  fontFamily: 'var(--font-mono)',
+  fontSize: 9,
+  fontWeight: 600,
+  letterSpacing: '1px',
+  padding: '6px 14px',
+  border: 'none',
+  borderRadius: 'var(--radius)',
+  backgroundColor: disabled ? 'var(--color-text-muted)' : bg,
+  color: fg,
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  textTransform: 'uppercase',
+  opacity: disabled ? 0.6 : 1,
+  whiteSpace: 'nowrap',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 5,
+});
+
 export default function EquipmentDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -55,33 +110,42 @@ export default function EquipmentDetailPage() {
   const [drivers, setDrivers] = useState<EquipmentDriverAssignment[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
+  const loadData = useCallback(async () => {
     if (!id) return;
+    setLoading(true);
+    try {
+      const eq = await getIndividualEquipmentById(id);
+      setEquipment(eq);
 
-    async function loadData() {
-      setLoading(true);
-      try {
-        const eq = await getIndividualEquipmentById(id!);
-        setEquipment(eq);
-
-        if (isDemoMode) {
-          const [wos, fs, ds] = await Promise.all([
-            mockApi.getEquipmentHistory(id!),
-            mockApi.getEquipmentFaults(id!),
-            mockApi.getEquipmentDrivers(id!),
-          ]);
-          setWorkOrders(wos);
-          setFaults(fs);
-          setDrivers(ds);
-        }
-      } catch (err) {
-        console.error('Failed to load equipment detail:', err);
-      } finally {
-        setLoading(false);
+      if (isDemoMode) {
+        const [wos, fs, ds] = await Promise.all([
+          mockApi.getEquipmentHistory(id),
+          mockApi.getEquipmentFaults(id),
+          mockApi.getEquipmentDrivers(id),
+        ]);
+        setWorkOrders(wos);
+        setFaults(fs);
+        setDrivers(ds);
       }
+    } catch (err) {
+      console.error('Failed to load equipment detail:', err);
+    } finally {
+      setLoading(false);
     }
+  }, [id]);
 
+  useEffect(() => {
     loadData();
+  }, [loadData]);
+
+  const refreshMaintenance = useCallback(async () => {
+    if (!id || !isDemoMode) return;
+    try {
+      const wos = await mockApi.getEquipmentHistory(id);
+      setWorkOrders(wos);
+    } catch (err) {
+      console.error('Failed to refresh maintenance data:', err);
+    }
   }, [id]);
 
   const currentDriver = drivers.find((d) => d.isPrimary && !d.releasedAt);
@@ -286,15 +350,19 @@ export default function EquipmentDetailPage() {
         )}
 
         {activeTab === 'maintenance' && (
-          <MaintenanceHistoryTab workOrders={workOrders} />
+          <MaintenanceHistoryTab
+            workOrders={workOrders}
+            equipmentId={id}
+            onRefresh={refreshMaintenance}
+          />
         )}
 
         {activeTab === 'faults' && (
-          <FaultsTab faults={faults} />
+          <FaultsTab faults={faults} equipmentId={id!} onFaultsChange={setFaults} />
         )}
 
         {activeTab === 'drivers' && (
-          <DriversTab drivers={drivers} />
+          <DriversTab drivers={drivers} equipmentId={id!} onDriversChange={setDrivers} />
         )}
 
         {activeTab === 'convoys' && (
@@ -309,31 +377,224 @@ export default function EquipmentDetailPage() {
 // Faults Tab (inline)
 // ---------------------------------------------------------------------------
 
-function FaultsTab({ faults }: { faults: EquipmentFault[] }) {
+function FaultsTab({
+  faults,
+  equipmentId,
+  onFaultsChange,
+}: {
+  faults: EquipmentFault[];
+  equipmentId: string;
+  onFaultsChange: (faults: EquipmentFault[]) => void;
+}) {
+  const [showForm, setShowForm] = useState(false);
+  const [faultDesc, setFaultDesc] = useState('');
+  const [faultSeverity, setFaultSeverity] = useState<FaultSeverity>(FaultSeverity.MINOR);
+  const [faultReportedBy, setFaultReportedBy] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
   const sorted = [...faults].sort(
     (a, b) => new Date(b.reportedAt).getTime() - new Date(a.reportedAt).getTime(),
   );
 
-  if (sorted.length === 0) {
-    return (
-      <div
-        style={{
-          padding: 32,
-          textAlign: 'center',
-          color: 'var(--color-text-muted)',
-          fontSize: 12,
-          backgroundColor: 'var(--color-bg-elevated)',
-          border: '1px solid var(--color-border)',
-          borderRadius: 'var(--radius)',
-        }}
-      >
-        No faults reported for this equipment.
-      </div>
-    );
-  }
+  const handleReportFault = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!faultDesc.trim()) return;
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const newFault = await reportFault(equipmentId, {
+        faultDescription: faultDesc.trim(),
+        severity: faultSeverity,
+        reportedBy: faultReportedBy.trim() || 'System',
+      });
+      onFaultsChange([...faults, newFault]);
+      setFaultDesc('');
+      setFaultSeverity(FaultSeverity.MINOR);
+      setFaultReportedBy('');
+      setShowForm(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to report fault.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleResolveFault = async (faultId: string) => {
+    setResolvingId(faultId);
+    setError(null);
+    try {
+      const updated = await updateFault(equipmentId, faultId, {
+        resolvedAt: new Date().toISOString(),
+      });
+      onFaultsChange(faults.map((f) => (f.id === faultId ? updated : f)));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to resolve fault.');
+    } finally {
+      setResolvingId(null);
+    }
+  };
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {/* Header with action */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 9,
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '1.5px',
+            color: 'var(--color-text-muted)',
+          }}
+        >
+          {faults.length} FAULTS RECORDED
+        </span>
+        {!showForm && (
+          <button
+            onClick={() => setShowForm(true)}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              fontFamily: 'var(--font-mono)',
+              fontSize: 9,
+              fontWeight: 600,
+              letterSpacing: '1px',
+              padding: '4px 10px',
+              border: '1px solid var(--color-accent)',
+              borderRadius: 'var(--radius)',
+              backgroundColor: 'transparent',
+              color: 'var(--color-accent)',
+              cursor: 'pointer',
+              textTransform: 'uppercase',
+            }}
+          >
+            <Plus size={10} />
+            REPORT FAULT
+          </button>
+        )}
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '8px 12px',
+            backgroundColor: 'var(--color-danger)15',
+            border: '1px solid var(--color-danger)',
+            borderRadius: 'var(--radius)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            color: 'var(--color-danger)',
+          }}
+        >
+          <AlertTriangle size={12} />
+          {error}
+        </div>
+      )}
+
+      {/* Report Fault Form */}
+      {showForm && (
+        <form
+          onSubmit={handleReportFault}
+          style={{
+            padding: '12px 16px',
+            backgroundColor: 'var(--color-bg-elevated)',
+            border: '1px solid var(--color-accent)',
+            borderRadius: 'var(--radius)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+          }}
+        >
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              fontWeight: 600,
+              color: 'var(--color-text-bright)',
+              letterSpacing: '1px',
+              textTransform: 'uppercase',
+            }}
+          >
+            REPORT NEW FAULT
+          </span>
+          <div>
+            <label style={formLabelStyle}>DESCRIPTION *</label>
+            <textarea
+              style={{ ...inputStyle, minHeight: 50, resize: 'vertical' }}
+              value={faultDesc}
+              onChange={(e) => setFaultDesc(e.target.value)}
+              placeholder="Describe the fault..."
+              required
+            />
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+            <div>
+              <label style={formLabelStyle}>SEVERITY</label>
+              <select
+                style={selectStyle}
+                value={faultSeverity}
+                onChange={(e) => setFaultSeverity(e.target.value as FaultSeverity)}
+              >
+                {Object.values(FaultSeverity).map((s) => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label style={formLabelStyle}>REPORTED BY</label>
+              <input
+                style={inputStyle}
+                value={faultReportedBy}
+                onChange={(e) => setFaultReportedBy(e.target.value)}
+                placeholder="Name"
+              />
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+            <button
+              type="button"
+              onClick={() => setShowForm(false)}
+              disabled={isSubmitting}
+              style={actionBtnStyle('transparent', 'var(--color-text-muted)')}
+            >
+              CANCEL
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              style={actionBtnStyle('var(--color-accent)', 'var(--color-bg)', isSubmitting)}
+            >
+              {isSubmitting ? 'SUBMITTING...' : 'SUBMIT FAULT'}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Fault List */}
+      {sorted.length === 0 && !showForm && (
+        <div
+          style={{
+            padding: 32,
+            textAlign: 'center',
+            color: 'var(--color-text-muted)',
+            fontSize: 12,
+            backgroundColor: 'var(--color-bg-elevated)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius)',
+          }}
+        >
+          No faults reported for this equipment.
+        </div>
+      )}
+
       {sorted.map((fault) => (
         <div
           key={fault.id}
@@ -387,15 +648,34 @@ function FaultsTab({ faults }: { faults: EquipmentFault[] }) {
                   </span>
                 )}
               </div>
-              <span
-                style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 9,
-                  color: 'var(--color-text-muted)',
-                }}
-              >
-                {formatRelativeTime(fault.reportedAt)}
-              </span>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 9,
+                    color: 'var(--color-text-muted)',
+                  }}
+                >
+                  {formatRelativeTime(fault.reportedAt)}
+                </span>
+                {!fault.resolvedAt && (
+                  <button
+                    onClick={() => handleResolveFault(fault.id)}
+                    disabled={resolvingId === fault.id}
+                    style={{
+                      ...actionBtnStyle(
+                        'var(--color-success)',
+                        '#fff',
+                        resolvingId === fault.id,
+                      ),
+                      padding: '3px 10px',
+                    }}
+                  >
+                    <Check size={9} />
+                    {resolvingId === fault.id ? 'RESOLVING...' : 'RESOLVE'}
+                  </button>
+                )}
+              </div>
             </div>
             <div
               style={{
@@ -441,7 +721,23 @@ function FaultsTab({ faults }: { faults: EquipmentFault[] }) {
 // Drivers Tab (inline)
 // ---------------------------------------------------------------------------
 
-function DriversTab({ drivers }: { drivers: EquipmentDriverAssignment[] }) {
+function DriversTab({
+  drivers,
+  equipmentId,
+  onDriversChange,
+}: {
+  drivers: EquipmentDriverAssignment[];
+  equipmentId: string;
+  onDriversChange: (drivers: EquipmentDriverAssignment[]) => void;
+}) {
+  const [showForm, setShowForm] = useState(false);
+  const [personnelId, setPersonnelId] = useState('');
+  const [personnelName, setPersonnelName] = useState('');
+  const [isPrimary, setIsPrimary] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [releasingId, setReleasingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
   const sorted = [...drivers].sort((a, b) => {
     // Current (no releasedAt) first, then by assignedAt desc
     if (!a.releasedAt && b.releasedAt) return -1;
@@ -449,142 +745,361 @@ function DriversTab({ drivers }: { drivers: EquipmentDriverAssignment[] }) {
     return new Date(b.assignedAt).getTime() - new Date(a.assignedAt).getTime();
   });
 
-  if (sorted.length === 0) {
-    return (
-      <div
-        style={{
-          padding: 32,
-          textAlign: 'center',
-          color: 'var(--color-text-muted)',
-          fontSize: 12,
-          backgroundColor: 'var(--color-bg-elevated)',
-          border: '1px solid var(--color-border)',
-          borderRadius: 'var(--radius)',
-        }}
-      >
-        No driver assignments on record.
-      </div>
-    );
-  }
+  const handleAssignDriver = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!personnelId.trim()) return;
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const newAssignment = await assignDriver(equipmentId, {
+        personnelId: personnelId.trim(),
+        personnelName: personnelName.trim() || undefined,
+        isPrimary,
+      });
+      onDriversChange([...drivers, newAssignment]);
+      setPersonnelId('');
+      setPersonnelName('');
+      setIsPrimary(false);
+      setShowForm(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to assign driver.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleRelease = async (assignmentId: string) => {
+    setReleasingId(assignmentId);
+    setError(null);
+    try {
+      const updated = await updateDriverAssignment(equipmentId, assignmentId, {
+        releasedAt: new Date().toISOString(),
+      });
+      onDriversChange(drivers.map((d) => (d.id === assignmentId ? updated : d)));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to release driver.');
+    } finally {
+      setReleasingId(null);
+    }
+  };
 
   return (
-    <div
-      className="responsive-table-wrapper"
-      style={{
-        backgroundColor: 'var(--color-bg-elevated)',
-        border: '1px solid var(--color-border)',
-        borderRadius: 'var(--radius)',
-        overflow: 'hidden',
-      }}
-    >
-      <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 500 }}>
-        <thead>
-          <tr>
-            {['STATUS', 'NAME', 'ROLE', 'ASSIGNED', 'RELEASED'].map((h) => (
-              <th
-                key={h}
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {/* Header with action */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 9,
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '1.5px',
+            color: 'var(--color-text-muted)',
+          }}
+        >
+          {drivers.filter((d) => !d.releasedAt).length} ACTIVE / {drivers.length} TOTAL
+        </span>
+        {!showForm && (
+          <button
+            onClick={() => setShowForm(true)}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              fontFamily: 'var(--font-mono)',
+              fontSize: 9,
+              fontWeight: 600,
+              letterSpacing: '1px',
+              padding: '4px 10px',
+              border: '1px solid var(--color-accent)',
+              borderRadius: 'var(--radius)',
+              backgroundColor: 'transparent',
+              color: 'var(--color-accent)',
+              cursor: 'pointer',
+              textTransform: 'uppercase',
+            }}
+          >
+            <Plus size={10} />
+            ASSIGN DRIVER
+          </button>
+        )}
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '8px 12px',
+            backgroundColor: 'var(--color-danger)15',
+            border: '1px solid var(--color-danger)',
+            borderRadius: 'var(--radius)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            color: 'var(--color-danger)',
+          }}
+        >
+          <AlertTriangle size={12} />
+          {error}
+        </div>
+      )}
+
+      {/* Assign Driver Form */}
+      {showForm && (
+        <form
+          onSubmit={handleAssignDriver}
+          style={{
+            padding: '12px 16px',
+            backgroundColor: 'var(--color-bg-elevated)',
+            border: '1px solid var(--color-accent)',
+            borderRadius: 'var(--radius)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+          }}
+        >
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              fontWeight: 600,
+              color: 'var(--color-text-bright)',
+              letterSpacing: '1px',
+              textTransform: 'uppercase',
+            }}
+          >
+            ASSIGN NEW DRIVER
+          </span>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+            <div>
+              <label style={formLabelStyle}>PERSONNEL ID *</label>
+              <input
+                style={inputStyle}
+                value={personnelId}
+                onChange={(e) => setPersonnelId(e.target.value)}
+                placeholder="e.g., 1234567890"
+                required
+              />
+            </div>
+            <div>
+              <label style={formLabelStyle}>NAME</label>
+              <input
+                style={inputStyle}
+                value={personnelName}
+                onChange={(e) => setPersonnelName(e.target.value)}
+                placeholder="Full name"
+              />
+            </div>
+          </div>
+          <div>
+            <label style={formLabelStyle}>PRIMARY DRIVER</label>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                padding: '4px 0',
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={isPrimary}
+                onChange={(e) => setIsPrimary(e.target.checked)}
+                style={{ accentColor: 'var(--color-accent)' }}
+              />
+              <span
                 style={{
                   fontFamily: 'var(--font-mono)',
-                  fontSize: 10,
-                  fontWeight: 600,
-                  textTransform: 'uppercase',
-                  letterSpacing: '1.5px',
-                  color: 'var(--color-text-muted)',
-                  padding: '10px 12px',
-                  textAlign: 'left',
-                  borderBottom: '1px solid var(--color-border)',
+                  fontSize: 11,
+                  color: 'var(--color-text)',
                 }}
               >
-                {h}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {sorted.map((d) => {
-            const isCurrent = !d.releasedAt;
-            return (
-              <tr
-                key={d.id}
-                style={{
-                  backgroundColor: isCurrent ? 'var(--color-success)08' : 'transparent',
-                  transition: 'background-color var(--transition)',
-                }}
-                onMouseEnter={(e) =>
-                  (e.currentTarget.style.backgroundColor = 'var(--color-bg-hover)')
-                }
-                onMouseLeave={(e) =>
-                  (e.currentTarget.style.backgroundColor = isCurrent ? 'var(--color-success)08' : 'transparent')
-                }
-              >
-                <td
-                  style={{
-                    padding: '8px 12px',
-                    borderBottom: '1px solid var(--color-border)',
-                  }}
-                >
-                  <span
+                {isPrimary ? 'Primary' : 'A-Driver'}
+              </span>
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+            <button
+              type="button"
+              onClick={() => setShowForm(false)}
+              disabled={isSubmitting}
+              style={actionBtnStyle('transparent', 'var(--color-text-muted)')}
+            >
+              CANCEL
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              style={actionBtnStyle('var(--color-accent)', 'var(--color-bg)', isSubmitting)}
+            >
+              {isSubmitting ? 'ASSIGNING...' : 'ASSIGN'}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Drivers Table */}
+      {sorted.length === 0 && !showForm ? (
+        <div
+          style={{
+            padding: 32,
+            textAlign: 'center',
+            color: 'var(--color-text-muted)',
+            fontSize: 12,
+            backgroundColor: 'var(--color-bg-elevated)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius)',
+          }}
+        >
+          No driver assignments on record.
+        </div>
+      ) : sorted.length > 0 && (
+        <div
+          className="responsive-table-wrapper"
+          style={{
+            backgroundColor: 'var(--color-bg-elevated)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius)',
+            overflow: 'hidden',
+          }}
+        >
+          <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 500 }}>
+            <thead>
+              <tr>
+                {['STATUS', 'NAME', 'ROLE', 'ASSIGNED', 'RELEASED', 'ACTIONS'].map((h) => (
+                  <th
+                    key={h}
                     style={{
-                      display: 'inline-block',
-                      width: 8,
-                      height: 8,
-                      borderRadius: '50%',
-                      backgroundColor: isCurrent ? 'var(--color-success)' : 'var(--color-text-muted)',
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 10,
+                      fontWeight: 600,
+                      textTransform: 'uppercase',
+                      letterSpacing: '1.5px',
+                      color: 'var(--color-text-muted)',
+                      padding: '10px 12px',
+                      textAlign: 'left',
+                      borderBottom: '1px solid var(--color-border)',
                     }}
-                  />
-                </td>
-                <td
-                  style={{
-                    fontFamily: 'var(--font-mono)',
-                    fontSize: 12,
-                    padding: '8px 12px',
-                    color: isCurrent ? 'var(--color-text-bright)' : 'var(--color-text)',
-                    fontWeight: isCurrent ? 600 : 400,
-                    borderBottom: '1px solid var(--color-border)',
-                  }}
-                >
-                  {d.personnelName || d.personnelId}
-                </td>
-                <td
-                  style={{
-                    fontFamily: 'var(--font-mono)',
-                    fontSize: 10,
-                    padding: '8px 12px',
-                    color: 'var(--color-text-muted)',
-                    borderBottom: '1px solid var(--color-border)',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px',
-                  }}
-                >
-                  {d.isPrimary ? 'PRIMARY' : 'A-DRIVER'}
-                </td>
-                <td
-                  style={{
-                    fontFamily: 'var(--font-mono)',
-                    fontSize: 10,
-                    padding: '8px 12px',
-                    color: 'var(--color-text)',
-                    borderBottom: '1px solid var(--color-border)',
-                  }}
-                >
-                  {formatDate(d.assignedAt, 'dd MMM yyyy')}
-                </td>
-                <td
-                  style={{
-                    fontFamily: 'var(--font-mono)',
-                    fontSize: 10,
-                    padding: '8px 12px',
-                    color: d.releasedAt ? 'var(--color-text-muted)' : 'var(--color-success)',
-                    borderBottom: '1px solid var(--color-border)',
-                  }}
-                >
-                  {d.releasedAt ? formatDate(d.releasedAt, 'dd MMM yyyy') : 'CURRENT'}
-                </td>
+                  >
+                    {h}
+                  </th>
+                ))}
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            </thead>
+            <tbody>
+              {sorted.map((d) => {
+                const isCurrent = !d.releasedAt;
+                return (
+                  <tr
+                    key={d.id}
+                    style={{
+                      backgroundColor: isCurrent ? 'var(--color-success)08' : 'transparent',
+                      transition: 'background-color var(--transition)',
+                    }}
+                    onMouseEnter={(e) =>
+                      (e.currentTarget.style.backgroundColor = 'var(--color-bg-hover)')
+                    }
+                    onMouseLeave={(e) =>
+                      (e.currentTarget.style.backgroundColor = isCurrent ? 'var(--color-success)08' : 'transparent')
+                    }
+                  >
+                    <td
+                      style={{
+                        padding: '8px 12px',
+                        borderBottom: '1px solid var(--color-border)',
+                      }}
+                    >
+                      <span
+                        style={{
+                          display: 'inline-block',
+                          width: 8,
+                          height: 8,
+                          borderRadius: '50%',
+                          backgroundColor: isCurrent ? 'var(--color-success)' : 'var(--color-text-muted)',
+                        }}
+                      />
+                    </td>
+                    <td
+                      style={{
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 12,
+                        padding: '8px 12px',
+                        color: isCurrent ? 'var(--color-text-bright)' : 'var(--color-text)',
+                        fontWeight: isCurrent ? 600 : 400,
+                        borderBottom: '1px solid var(--color-border)',
+                      }}
+                    >
+                      {d.personnelName || d.personnelId}
+                    </td>
+                    <td
+                      style={{
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 10,
+                        padding: '8px 12px',
+                        color: 'var(--color-text-muted)',
+                        borderBottom: '1px solid var(--color-border)',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.5px',
+                      }}
+                    >
+                      {d.isPrimary ? 'PRIMARY' : 'A-DRIVER'}
+                    </td>
+                    <td
+                      style={{
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 10,
+                        padding: '8px 12px',
+                        color: 'var(--color-text)',
+                        borderBottom: '1px solid var(--color-border)',
+                      }}
+                    >
+                      {formatDate(d.assignedAt, 'dd MMM yyyy')}
+                    </td>
+                    <td
+                      style={{
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 10,
+                        padding: '8px 12px',
+                        color: d.releasedAt ? 'var(--color-text-muted)' : 'var(--color-success)',
+                        borderBottom: '1px solid var(--color-border)',
+                      }}
+                    >
+                      {d.releasedAt ? formatDate(d.releasedAt, 'dd MMM yyyy') : 'CURRENT'}
+                    </td>
+                    <td
+                      style={{
+                        padding: '8px 12px',
+                        borderBottom: '1px solid var(--color-border)',
+                      }}
+                    >
+                      {isCurrent && (
+                        <button
+                          onClick={() => handleRelease(d.id)}
+                          disabled={releasingId === d.id}
+                          style={{
+                            ...actionBtnStyle(
+                              'transparent',
+                              'var(--color-warning)',
+                              releasingId === d.id,
+                            ),
+                            border: '1px solid var(--color-warning)',
+                            padding: '3px 10px',
+                          }}
+                        >
+                          <X size={9} />
+                          {releasingId === d.id ? 'RELEASING...' : 'RELEASE'}
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **WorkOrderDetailModal**: Transformed from read-only to full CRUD — status transitions (Open→In Progress→Awaiting Parts→Complete), inline edit mode for all fields, add/edit/delete parts and labor entries, delete WO with confirmation
- **CreateWorkOrderModal**: New work order creation form with auto-generated WO number, all fields, validation
- **MaintenanceQueue**: "NEW WO" button, data refresh after mutations
- **MaintenanceHistoryTab**: "NEW WO" button with equipment ID pre-fill, onRefresh callback
- **EquipmentDetailPage**: Faults tab gets Report Fault form + Resolve button; Drivers tab gets Assign Driver form + Release button

## Test plan
- [ ] Click work order in MaintenanceQueue → modal opens with full details
- [ ] Click status transition buttons → status changes and badge updates
- [ ] Toggle edit mode → fields become editable, save persists changes
- [ ] Add/edit/delete parts and labor entries
- [ ] Create new WO from MaintenanceQueue and MaintenanceHistoryTab
- [ ] Report fault and resolve it in equipment detail Faults tab
- [ ] Assign and release driver in equipment detail Drivers tab
- [ ] `cd frontend && npx tsc -b` passes
- [ ] `cd frontend && npx vitest run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)