### PR TITLE
feat: unit filtering, scenario admin, report export, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,12 @@ KEYSTONE tracks the complete logistics picture: supply levels across all 10 NATO
 - Convoy personnel assignments with roles
 
 ### Report Generation
-- LOGSTAT reports (automated from current supply data)
-- Readiness reports
-- Supply status summaries
-- Higher HQ roll-up reports
-- Draft/Final workflow
+- 7 report types: LOGSTAT, Readiness, Supply Status, Equipment Status, Maintenance Summary, Movement Summary, Personnel Strength
+- Structured report viewer with type-specific sections, summary statistics, and tabular breakdowns
+- Draft/Final workflow with finalization tracking
+- Export to file (text/JSON) for offline distribution or higher HQ submission
+- Unit-scoped reporting with date range selection
+- Automated data aggregation from current supply, equipment, maintenance, movement, and personnel records
 
 ### Alert System
 - Automatic alerts: low days-of-supply, low readiness, convoy delayed, anomaly detection
@@ -139,10 +140,14 @@ KEYSTONE tracks the complete logistics picture: supply levels across all 10 NATO
 
 ### Simulator
 - Event-driven simulation engine with configurable speed multiplier
-- **3 USMC exercise scenarios** with realistic phase progressions:
-  - **Steel Guardian** -- 7-day battalion FEX at 29 Palms (1/1 Marines + CLB-1, 5 phases)
-  - **Pacific Fury** -- 135-day 26th MEU pre-deployment training and embark cycle (6 phases)
-  - **Iron Forge** -- 90-day III MEF garrison steady-state operations in Okinawa (5 phases)
+- **20 USMC exercise scenarios** organized by region and type:
+  - **Pre-Deployment Training (CONUS)**: Steel Guardian (7-day battalion FEX, 29 Palms), ITX (Integrated Training Exercise), Steel Knight (MAGTF combined arms), COMPTUEX (MEU composite training)
+  - **Indo-Pacific**: Cobra Gold, Balikatan, Resolute Dragon, Ssang Yong, Kamandag, Valiant Shield, RIMPAC, Island Sentinel
+  - **Europe / Africa / Middle East**: African Lion, Cold Response, Native Fury
+  - **Americas / Maritime**: UNITAS
+  - **Crisis Response**: Trident Spear
+  - **Reserve Component**: Reserve ITX
+  - **Deployment / Garrison**: Pacific Fury (135-day MEU cycle), Iron Forge (90-day III MEF Okinawa)
 - Simulated events: supply consumption, equipment breakdowns, resupply convoys, LOGSTAT/readiness reports, phase transitions
 - Breakdown probability scaled to operational tempo (LOW 3%, MEDIUM 8%, HIGH 15% per unit/day)
 
@@ -151,6 +156,12 @@ KEYSTONE tracks the complete logistics picture: supply levels across all 10 NATO
 - All three MEFs (I, II, III), MARFORRES, MARSOC, Supporting Establishment
 - Echelons from HQMC down to company level (with infantry company details)
 - Unit Identification Codes (UICs), geographic coordinates, MGRS
+
+### Admin Panel
+- **User Management**: Create, edit, activate/deactivate users with role and unit assignment
+- **Unit Hierarchy**: Interactive tree view of the complete USMC organizational structure with unit creation and editing
+- **Classification Settings**: Configure classification level (UNCLASSIFIED through TS//SCI) with live banner preview and color-coded reference
+- **Map Tile Settings**: Configure tile layer sources for OSM, satellite, and topographic layers (supports online and offline tile servers)
 
 ### Access Control
 - 6 roles: ADMIN, COMMANDER, S4, S3, OPERATOR, VIEWER
@@ -163,11 +174,23 @@ KEYSTONE tracks the complete logistics picture: supply levels across all 10 NATO
 - Color-coded banners at top and bottom of viewport per IC/DoD standards
 - Admin-configurable via settings API
 
+### Responsive Design
+- Responsive layout optimized for desktop, tablet, and mobile viewports
+- Collapsible sidebar with hamburger menu on small screens
+- Responsive grid layouts that reflow from multi-column to single-column
+- Full-screen map mode for tactical use on tablets
+- Scrollable tables with horizontal overflow on narrow displays
+
 ### Demo Mode
 - Full static site deployment with mock data (no backend required)
 - Auto-deployed to GitHub Pages via CI
 - All pages functional with realistic USMC logistics data
 - Toggle via `VITE_DEMO_MODE=true` build flag
+
+### Future Capabilities (Planned)
+- **GCSS-MC Integration**: Direct data feed from Global Combat Support System -- Marine Corps for automated supply and equipment synchronization
+- **Predictive Analytics**: ML-based consumption forecasting and failure prediction models
+- **Offline-First PWA**: Service worker support for disconnected field operations with background sync
 
 ---
 
@@ -413,7 +436,7 @@ keystone/
 │   ├── simulator/              # Mock data simulator engine
 │   │   ├── cli.py              # CLI interface
 │   │   ├── engine.py           # Simulation loop
-│   │   ├── scenario.py         # Scenario definitions (3 exercises)
+│   │   ├── scenario.py         # Scenario definitions (20 exercises)
 │   │   ├── events/             # Event types, queue, handlers
 │   │   ├── generators/         # Data generators (mIRC, Excel, TAK, manual)
 │   │   └── feeders/            # Data feed adapters
@@ -483,6 +506,25 @@ All endpoints are prefixed with `/api/v1`. Authentication is via JWT bearer toke
 | **Units** | `/units` | USMC unit hierarchy (read) |
 
 Interactive API documentation is available at `/docs` (Swagger UI) and `/redoc` when the backend is running.
+
+---
+
+## Security Features
+
+KEYSTONE is designed for deployment across classification domains with defense-in-depth security:
+
+| Feature | Implementation |
+|---------|---------------|
+| **Authentication** | JWT bearer tokens with configurable expiry (default 8 hours, HS256) |
+| **Authorization** | Role-based access control (6 roles) with unit hierarchy scoping |
+| **Container Hardening** | Non-root users, read-only filesystems, `no-new-privileges`, minimal capabilities per DoD Container Hardening Guide |
+| **TLS** | nginx terminates TLS with HSTS, CSP, X-Frame-Options, X-Content-Type-Options headers |
+| **Image Signing** | Cosign keyless signing with SBOM attestation in CI pipeline |
+| **Vulnerability Scanning** | Grype + Trivy CVE scans, Semgrep SAST, CodeQL, ZAP DAST on every push |
+| **Classification Banners** | Configurable UNCLASSIFIED through TS//SCI with IC/DoD standard color coding |
+| **Tile Proxy** | All external tile requests proxied through nginx to prevent CSP violations and data leakage |
+| **Input Validation** | Pydantic 2 schema validation on all API inputs; parameterized SQL via SQLAlchemy |
+| **Secrets Management** | Environment variable injection; no hardcoded credentials; seed users blocked outside development mode |
 
 ---
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,154 @@
+# KEYSTONE Backend
+
+FastAPI backend for the USMC Logistics Common Operating Picture.
+
+## Tech Stack
+
+- **Python 3.11**
+- **FastAPI** (async REST API framework)
+- **SQLAlchemy 2.0** (async ORM via `asyncpg`)
+- **Pydantic 2** (request/response validation)
+- **Uvicorn** (ASGI server)
+- **Celery 5.3** + **Redis 7** (async task queue)
+- **PostgreSQL 15** + **PostGIS 3.4** (geospatial database)
+- **spaCy** (NLP for mIRC chat log parsing)
+- **Alembic** (database migrations)
+
+## Quick Start
+
+```bash
+cd backend
+
+# Create virtual environment
+python -m venv .venv
+source .venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+# (Optional) Download spaCy NLP model for mIRC parsing
+python -m spacy download en_core_web_sm
+
+# Start PostgreSQL + Redis via Docker
+docker compose up db redis -d
+
+# Run the backend (auto-creates tables and seeds data in dev mode)
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+The API is available at `http://localhost:8000` with Swagger docs at `http://localhost:8000/docs`.
+
+## Scripts
+
+```bash
+# Lint and format check
+ruff check .
+ruff format --check .
+
+# Type checking (with SQLAlchemy false-positive suppressions)
+mypy app/ --ignore-missing-imports \
+  --disable-error-code arg-type \
+  --disable-error-code assignment \
+  --disable-error-code var-annotated
+
+# Unit tests (uses SQLite in-memory, no PostgreSQL required)
+pytest tests/ -v --cov=app
+
+# Run Celery worker
+celery -A app.tasks:celery_app worker --loglevel=info
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_URL` | `postgresql+asyncpg://keystone:keystone_dev@localhost:5432/keystone` | Async database connection |
+| `DATABASE_URL_SYNC` | `postgresql://keystone:keystone_dev@localhost:5432/keystone` | Sync connection for Celery |
+| `REDIS_URL` | `redis://localhost:6379/0` | Redis connection |
+| `SECRET_KEY` | `dev-secret-key-change-in-production` | JWT signing key (MUST change in prod) |
+| `ENV_MODE` | `development` | `development` or `production` |
+| `CORS_ORIGINS` | `["http://localhost:5173"]` | Allowed CORS origins |
+| `JWT_ALGORITHM` | `HS256` | JWT algorithm |
+| `ACCESS_TOKEN_EXPIRE_MINUTES` | `480` | JWT token expiry (8 hours) |
+| `ALLOW_PRIVATE_TAK_HOSTS` | `true` | Allow TAK connections to RFC1918 |
+| `ALLOWED_DATA_DIRS` | `["/data","/uploads","/import"]` | Allowed file ingestion dirs |
+
+## Project Structure
+
+```
+app/
+  api/              # REST endpoints (18 route modules)
+  models/           # SQLAlchemy models (25+ models, 1.x Column() style)
+  schemas/          # Pydantic request/response schemas
+  core/             # Auth, permissions, military logic
+  ingestion/        # Parsers: mIRC, Excel, TAK, routes
+  analytics/        # Consumption, readiness, sustainability, anomaly detection
+  seeds/            # Canonical field definitions
+  utils/            # Coordinate conversion, helpers
+  config.py         # pydantic-settings configuration
+  database.py       # SQLAlchemy async engine + session
+  main.py           # FastAPI app entry point
+  tasks.py          # Celery task definitions
+
+seed/               # Unit hierarchy (~403 units), users, sample data
+simulator/          # Mock data simulator engine (see below)
+alembic/            # Database migrations
+tests/              # pytest test suite
+```
+
+## API Endpoints
+
+All endpoints are prefixed with `/api/v1`. Authentication is via JWT bearer token.
+
+| Route Group | Base Path | Description |
+|-------------|-----------|-------------|
+| Auth | `/auth` | Login, token refresh, user management |
+| Dashboard | `/dashboard` | Commander overview, readiness, sustainability |
+| Supply | `/supply` | Supply status CRUD, class I-X tracking |
+| Equipment | `/equipment` | Fleet readiness aggregates by TAMCN |
+| Equipment Individual | `/equipment/individual` | Per-asset tracking: faults, drivers, history |
+| Maintenance | `/maintenance` | Work orders (full CRUD), parts, labor tracking |
+| Transportation | `/transportation` | Movement lifecycle, convoy manifests |
+| Personnel | `/personnel` | Personnel roster, weapons, ammo loads |
+| Map | `/map` | Geospatial: unit positions, supply points, routes, convoys |
+| Reports | `/reports` | Generate/list/finalize 7 report types |
+| Alerts | `/alerts` | Alert management and acknowledgement |
+| Ingestion | `/ingestion` | File upload: mIRC, Excel, route files |
+| Data Sources | `/data-sources` | External source config and monitoring |
+| Schema Mapping | `/schema-mapping` | Canonical field mapping for ingestion |
+| TAK | `/tak` | TAK server connections and CoT data |
+| Settings | `/settings` | System settings (classification, etc.) |
+| Units | `/units` | USMC unit hierarchy (read) |
+
+## Simulator
+
+The simulator generates realistic logistics data streams for demos and testing:
+
+```bash
+# List all 20 available scenarios
+python -m simulator list
+
+# Run Steel Guardian at 60x speed
+python -m simulator run --scenario=steel_guardian --speed=60
+
+# Run against a remote instance
+python -m simulator run --scenario=pacific_fury --speed=120 --url=https://keystone.example.mil
+```
+
+See `simulator/` directory for engine, scenario definitions, event types, and generators.
+
+## Testing Notes
+
+- Tests use `sqlite+aiosqlite://` (not PostgreSQL) for in-memory testing
+- Models use SQLAlchemy 1.x `Column()` style (not 2.0 `Mapped[]`)
+- mypy runs with `--disable-error-code arg-type,assignment,var-annotated` for SQLAlchemy compatibility
+- Ruff is the linter and formatter (no flake8/black/isort)
+
+## Docker
+
+The backend Dockerfile is a multi-stage build:
+
+1. **Builder stage**: Python 3.11, installs dependencies
+2. **Production stage**: Non-root user (UID 1001), read-only filesystem, minimal attack surface
+
+The same image is used for the `backend`, `celery_worker`, and `simulator` services with different entry commands.

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -20,6 +20,7 @@ from app.api.map import router as map_router
 from app.api.personnel import router as personnel_router
 from app.api.convoy_manifest import router as convoy_manifest_router
 from app.api.maintenance import router as maintenance_router
+from app.api.simulator import router as simulator_router
 
 api_router = APIRouter()
 
@@ -54,4 +55,7 @@ api_router.include_router(
 )
 api_router.include_router(
     maintenance_router, prefix="/maintenance", tags=["Maintenance"]
+)
+api_router.include_router(
+    simulator_router, prefix="/simulator", tags=["Simulator"]
 )

--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -1,11 +1,13 @@
-"""Report generation and management endpoints."""
+"""Report generation, management, and export endpoints."""
 
 import json
 import logging
 from datetime import datetime
 from typing import List, Optional
 
+import httpx
 from fastapi import APIRouter, Depends, Query
+from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,9 +15,19 @@ from app.core.auth import get_current_user
 from app.core.exceptions import BadRequestError, NotFoundError
 from app.core.permissions import check_unit_access, get_accessible_units, require_role
 from app.database import get_db
-from app.models.report import Report, ReportStatus, ReportType
+from app.models.report import Report, ReportExportDestination, ReportStatus, ReportType
 from app.models.user import Role, User
-from app.schemas.report import ReportCreate, ReportResponse
+from app.schemas.report import (
+    ApiExportRequest,
+    ApiExportResponse,
+    ApiExportResultItem,
+    ExportDestinationCreate,
+    ExportDestinationResponse,
+    ExportDestinationUpdate,
+    ReportCreate,
+    ReportResponse,
+)
+from app.services.pdf_generator import generate_report_pdf
 from app.services.report_generator import generate_and_save_report
 
 logger = logging.getLogger(__name__)
@@ -199,3 +211,237 @@ async def finalize_report(
     await db.flush()
     await db.refresh(report)
     return report
+
+
+# ---------------------------------------------------------------------------
+# PDF Export
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{report_id}/export/pdf")
+async def export_report_pdf(
+    report_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Export a report as a PDF download."""
+    result = await db.execute(select(Report).where(Report.id == report_id))
+    report = result.scalar_one_or_none()
+    if not report:
+        raise NotFoundError("Report", report_id)
+
+    await check_unit_access(current_user, report.unit_id, db)
+
+    if not report.content:
+        raise BadRequestError("Report has no content to export")
+
+    try:
+        content = json.loads(report.content)
+    except (json.JSONDecodeError, TypeError):
+        raise BadRequestError("Report content is not valid JSON")
+
+    report_type = report.report_type.value if report.report_type else "UNKNOWN"
+    pdf_bytes = generate_report_pdf(
+        title=report.title,
+        report_type=report_type,
+        content=content,
+    )
+
+    safe_title = "".join(c for c in report.title if c.isalnum() or c in " -_").strip()
+    filename = f"{safe_title or 'report'}.pdf"
+
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Export Destinations (CRUD)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/export-destinations", response_model=List[ExportDestinationResponse])
+async def list_export_destinations(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List all configured export destinations."""
+    result = await db.execute(
+        select(ReportExportDestination).order_by(ReportExportDestination.name)
+    )
+    return result.scalars().all()
+
+
+@router.post(
+    "/export-destinations",
+    response_model=ExportDestinationResponse,
+    status_code=201,
+)
+async def create_export_destination(
+    data: ExportDestinationCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role([Role.ADMIN])),
+):
+    """Create a new export destination. Admin only."""
+    dest = ReportExportDestination(
+        name=data.name,
+        url=data.url,
+        auth_type=data.auth_type,
+        auth_value=data.auth_value,
+        headers=data.headers,
+        is_active=data.is_active,
+    )
+    db.add(dest)
+    await db.flush()
+    await db.refresh(dest)
+    return dest
+
+
+@router.put(
+    "/export-destinations/{destination_id}",
+    response_model=ExportDestinationResponse,
+)
+async def update_export_destination(
+    destination_id: int,
+    data: ExportDestinationUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role([Role.ADMIN])),
+):
+    """Update an export destination. Admin only."""
+    result = await db.execute(
+        select(ReportExportDestination).where(ReportExportDestination.id == destination_id)
+    )
+    dest = result.scalar_one_or_none()
+    if not dest:
+        raise NotFoundError("ExportDestination", destination_id)
+
+    update_data = data.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(dest, field, value)
+
+    await db.flush()
+    await db.refresh(dest)
+    return dest
+
+
+@router.delete("/export-destinations/{destination_id}", status_code=204)
+async def delete_export_destination(
+    destination_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role([Role.ADMIN])),
+):
+    """Delete an export destination. Admin only."""
+    result = await db.execute(
+        select(ReportExportDestination).where(ReportExportDestination.id == destination_id)
+    )
+    dest = result.scalar_one_or_none()
+    if not dest:
+        raise NotFoundError("ExportDestination", destination_id)
+
+    await db.delete(dest)
+    await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# API Export (send report to configured destinations)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{report_id}/export/api", response_model=ApiExportResponse)
+async def export_report_to_api(
+    report_id: int,
+    body: ApiExportRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Export report JSON to one or more configured API destinations."""
+    # Fetch report
+    result = await db.execute(select(Report).where(Report.id == report_id))
+    report = result.scalar_one_or_none()
+    if not report:
+        raise NotFoundError("Report", report_id)
+
+    await check_unit_access(current_user, report.unit_id, db)
+
+    if not report.content:
+        raise BadRequestError("Report has no content to export")
+
+    try:
+        report_content = json.loads(report.content)
+    except (json.JSONDecodeError, TypeError):
+        raise BadRequestError("Report content is not valid JSON")
+
+    # Fetch requested destinations
+    result = await db.execute(
+        select(ReportExportDestination).where(
+            ReportExportDestination.id.in_(body.destination_ids),
+            ReportExportDestination.is_active.is_(True),
+        )
+    )
+    destinations = result.scalars().all()
+
+    if not destinations:
+        raise BadRequestError("No active destinations found for the provided IDs")
+
+    # Build export payload
+    payload = {
+        "report_id": report.id,
+        "title": report.title,
+        "report_type": report.report_type.value if report.report_type else None,
+        "generated_at": report.generated_at.isoformat() if report.generated_at else None,
+        "status": report.status.value if report.status else None,
+        "content": report_content,
+    }
+
+    results: List[ApiExportResultItem] = []
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        for dest in destinations:
+            try:
+                # Build headers
+                req_headers: dict = {"Content-Type": "application/json"}
+                if dest.headers:
+                    req_headers.update(dest.headers)
+
+                # Apply authentication
+                if dest.auth_type == "bearer" and dest.auth_value:
+                    req_headers["Authorization"] = f"Bearer {dest.auth_value}"
+                elif dest.auth_type == "api_key" and dest.auth_value:
+                    req_headers["X-API-Key"] = dest.auth_value
+                elif dest.auth_type == "basic" and dest.auth_value:
+                    req_headers["Authorization"] = f"Basic {dest.auth_value}"
+
+                resp = await client.post(
+                    dest.url,
+                    json=payload,
+                    headers=req_headers,
+                )
+                results.append(
+                    ApiExportResultItem(
+                        destination_id=dest.id,
+                        destination_name=dest.name,
+                        success=200 <= resp.status_code < 300,
+                        status_code=resp.status_code,
+                    )
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Export to destination %s (%s) failed: %s",
+                    dest.name,
+                    dest.url,
+                    exc,
+                )
+                results.append(
+                    ApiExportResultItem(
+                        destination_id=dest.id,
+                        destination_name=dest.name,
+                        success=False,
+                        error=str(exc)[:200],
+                    )
+                )
+
+    return ApiExportResponse(report_id=report.id, results=results)

--- a/backend/app/api/simulator.py
+++ b/backend/app/api/simulator.py
@@ -1,0 +1,328 @@
+"""Simulator management endpoints: list scenarios, start/stop/pause simulations."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+router = APIRouter()
+logger = logging.getLogger("app.api.simulator")
+
+# ---------------------------------------------------------------------------
+# Module-level state for tracking a running simulation process
+# ---------------------------------------------------------------------------
+
+_sim_process: Optional[subprocess.Popen[str]] = None
+_sim_meta: dict[str, Any] = {}  # scenario_name, speed, started_at, status
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+
+class StartRequest(BaseModel):
+    scenario_name: str
+    speed: float = 60.0
+
+
+class SpeedRequest(BaseModel):
+    speed: float
+
+
+# ---------------------------------------------------------------------------
+# Helpers — import scenario module (it lives outside the app package)
+# ---------------------------------------------------------------------------
+
+
+def _get_scenario_module():
+    """Lazily import the simulator.scenario module."""
+    try:
+        from simulator.scenario import get_scenario, list_scenarios
+        return get_scenario, list_scenarios
+    except ImportError as exc:
+        raise HTTPException(
+            status_code=501,
+            detail=f"Simulator module not available: {exc}",
+        )
+
+
+def _get_areas_module():
+    """Lazily import the simulator areas_of_operation module."""
+    try:
+        from simulator.areas_of_operation import SCENARIO_AO
+        return SCENARIO_AO
+    except ImportError:
+        return {}
+
+
+def _get_cli_categories():
+    """Return scenario category mapping from the CLI module."""
+    try:
+        from simulator.cli import _SCENARIO_CATEGORIES
+        return _SCENARIO_CATEGORIES
+    except ImportError:
+        return []
+
+
+def _build_category_map() -> dict[str, str]:
+    """Build a name -> category mapping from cli categories."""
+    categories = _get_cli_categories()
+    result: dict[str, str] = {}
+    for category_name, names in categories:
+        for name in names:
+            result[name] = category_name
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/scenarios")
+async def list_all_scenarios():
+    """List all available simulation scenarios."""
+    get_scenario, list_scenarios = _get_scenario_module()
+    raw = list_scenarios()
+    category_map = _build_category_map()
+
+    results = []
+    for s in raw:
+        duration_str = s["duration"]  # e.g. "168 hours"
+        hours = float(duration_str.replace(" hours", ""))
+        results.append({
+            "name": s["name"],
+            "display_name": s["display_name"],
+            "description": s["description"],
+            "duration_days": round(hours / 24, 1),
+            "phase_count": int(s["phases"]),
+            "unit_count": int(s["units"]),
+            "category": category_map.get(s["name"], "Other"),
+        })
+
+    return results
+
+
+@router.get("/scenarios/{name}")
+async def get_scenario_detail(name: str):
+    """Get detailed information about a specific scenario."""
+    get_scenario, _ = _get_scenario_module()
+    scenario_ao = _get_areas_module()
+
+    try:
+        scenario = get_scenario(name)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    category_map = _build_category_map()
+
+    phases = []
+    for p in scenario.phases:
+        phases.append({
+            "name": p.name,
+            "offset_h": p.start_offset_hours,
+            "duration_h": p.duration_hours,
+            "tempo": p.tempo,
+            "description": p.description,
+        })
+
+    units = []
+    for u in scenario.units:
+        units.append({
+            "name": u.unit_name,
+            "type": u.echelon,
+            "callsign": u.callsigns[0] if u.callsigns else u.abbreviation,
+        })
+
+    ao_info = None
+    ao_data = scenario_ao.get(name)
+    if ao_data:
+        center = ao_data.get("center")
+        radius = ao_data.get("radius_km")
+        if center and radius:
+            ao_info = {
+                "name": name.replace("_", " ").title(),
+                "center": list(center) if isinstance(center, tuple) else center,
+                "radius_km": radius,
+            }
+
+    return {
+        "name": scenario.name,
+        "display_name": scenario.display_name,
+        "description": scenario.description,
+        "duration_days": round(scenario.duration_hours / 24, 1),
+        "phase_count": len(scenario.phases),
+        "unit_count": len(scenario.units),
+        "category": category_map.get(name, "Other"),
+        "phases": phases,
+        "units": units,
+        "area_of_operation": ao_info,
+    }
+
+
+@router.post("/start")
+async def start_simulation(req: StartRequest):
+    """Start a simulation as a subprocess."""
+    global _sim_process, _sim_meta
+
+    if _sim_process is not None and _sim_process.poll() is None:
+        raise HTTPException(
+            status_code=409,
+            detail="A simulation is already running. Stop it first.",
+        )
+
+    # Validate the scenario name before launching
+    get_scenario, _ = _get_scenario_module()
+    try:
+        get_scenario(req.scenario_name)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    # Launch as a subprocess using python -m simulator run
+    cmd = [
+        sys.executable,
+        "-m", "simulator",
+        "run",
+        f"--scenario={req.scenario_name}",
+        f"--speed={req.speed}",
+        "--log-level=INFO",
+    ]
+
+    try:
+        _sim_process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            cwd=str(__import__("pathlib").Path(__file__).resolve().parents[2]),
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to start simulator process: {exc}",
+        )
+
+    started_at = datetime.now(timezone.utc).isoformat()
+    _sim_meta = {
+        "scenario_name": req.scenario_name,
+        "speed": req.speed,
+        "started_at": started_at,
+        "status": "running",
+    }
+
+    logger.info(
+        f"Simulator started: scenario={req.scenario_name}, speed={req.speed}x, pid={_sim_process.pid}"
+    )
+
+    return {
+        "status": "running",
+        "scenario_name": req.scenario_name,
+        "speed": req.speed,
+        "started_at": started_at,
+    }
+
+
+@router.post("/stop")
+async def stop_simulation():
+    """Stop the running simulation."""
+    global _sim_process, _sim_meta
+
+    if _sim_process is None or _sim_process.poll() is not None:
+        _sim_meta["status"] = "stopped"
+        return {"status": "stopped"}
+
+    _sim_process.terminate()
+    try:
+        _sim_process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        _sim_process.kill()
+
+    _sim_meta["status"] = "stopped"
+    logger.info("Simulator stopped")
+
+    return {"status": "stopped"}
+
+
+@router.post("/pause")
+async def pause_simulation():
+    """Pause the running simulation (sends SIGSTOP on Unix)."""
+    global _sim_process, _sim_meta
+
+    if _sim_process is None or _sim_process.poll() is not None:
+        raise HTTPException(status_code=409, detail="No simulation is running.")
+
+    import signal
+    try:
+        _sim_process.send_signal(signal.SIGSTOP)
+        _sim_meta["status"] = "paused"
+    except (OSError, AttributeError) as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Cannot pause process: {exc}",
+        )
+
+    return {"status": "paused"}
+
+
+@router.post("/resume")
+async def resume_simulation():
+    """Resume a paused simulation (sends SIGCONT on Unix)."""
+    global _sim_process, _sim_meta
+
+    if _sim_process is None or _sim_process.poll() is not None:
+        raise HTTPException(status_code=409, detail="No simulation is running.")
+
+    import signal
+    try:
+        _sim_process.send_signal(signal.SIGCONT)
+        _sim_meta["status"] = "running"
+    except (OSError, AttributeError) as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Cannot resume process: {exc}",
+        )
+
+    return {"status": "running"}
+
+
+@router.post("/speed")
+async def set_speed(req: SpeedRequest):
+    """Change simulation speed (note: only effective for new process starts)."""
+    global _sim_meta
+    _sim_meta["speed"] = req.speed
+    return {"speed": req.speed}
+
+
+@router.get("/status")
+async def get_status():
+    """Get the current simulation status."""
+    global _sim_process, _sim_meta
+
+    if _sim_process is None:
+        return {"status": "idle"}
+
+    # Check if process is still running
+    poll = _sim_process.poll()
+    if poll is not None:
+        _sim_meta["status"] = "stopped"
+        return {
+            "status": "stopped",
+            "scenario_name": _sim_meta.get("scenario_name"),
+            "speed": _sim_meta.get("speed"),
+            "started_at": _sim_meta.get("started_at"),
+        }
+
+    return {
+        "status": _sim_meta.get("status", "running"),
+        "scenario_name": _sim_meta.get("scenario_name"),
+        "speed": _sim_meta.get("speed"),
+        "started_at": _sim_meta.get("started_at"),
+    }

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -22,7 +22,7 @@ from app.models.maintenance import (
     MaintenanceLabor,
     LaborType,
 )
-from app.models.report import Report, ReportType, ReportStatus
+from app.models.report import Report, ReportType, ReportStatus, ReportExportDestination, AuthType
 from app.models.raw_data import RawData, SourceType, ParseStatus
 from app.models.alert import Alert, AlertType, AlertSeverity
 from app.models.canonical_schema import CanonicalField
@@ -83,6 +83,8 @@ __all__ = [
     "Report",
     "ReportType",
     "ReportStatus",
+    "ReportExportDestination",
+    "AuthType",
     "RawData",
     "SourceType",
     "ParseStatus",

--- a/backend/app/models/report.py
+++ b/backend/app/models/report.py
@@ -3,6 +3,7 @@
 import enum
 
 from sqlalchemy import (
+    Boolean,
     Column,
     DateTime,
     Enum as SQLEnum,
@@ -11,6 +12,7 @@ from sqlalchemy import (
     String,
     Text,
 )
+from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.sql import func
 
 from app.database import Base
@@ -46,3 +48,23 @@ class Report(Base):
     generated_by = Column(Integer, ForeignKey("users.id"), nullable=True)
     period_start = Column(DateTime(timezone=True), nullable=True)
     period_end = Column(DateTime(timezone=True), nullable=True)
+
+
+class AuthType(str, enum.Enum):
+    NONE = "none"
+    BEARER = "bearer"
+    API_KEY = "api_key"
+    BASIC = "basic"
+
+
+class ReportExportDestination(Base):
+    __tablename__ = "report_export_destinations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False)
+    url = Column(String(500), nullable=False)
+    auth_type = Column(String(20), default="none")
+    auth_value = Column(String(500), nullable=True)
+    headers = Column(JSON, nullable=True)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/schemas/report.py
+++ b/backend/app/schemas/report.py
@@ -1,7 +1,7 @@
 """Report schemas."""
 
 from datetime import datetime
-from typing import Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -28,3 +28,52 @@ class ReportResponse(ReportBase):
     generated_by: Optional[int] = None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+# --- Export Destination schemas ---
+
+
+class ExportDestinationBase(BaseModel):
+    name: str = Field(..., max_length=100)
+    url: str = Field(..., max_length=500)
+    auth_type: str = Field(default="none", max_length=20)
+    auth_value: Optional[str] = Field(None, max_length=500)
+    headers: Optional[Dict[str, str]] = None
+    is_active: bool = True
+
+
+class ExportDestinationCreate(ExportDestinationBase):
+    pass
+
+
+class ExportDestinationUpdate(BaseModel):
+    name: Optional[str] = Field(None, max_length=100)
+    url: Optional[str] = Field(None, max_length=500)
+    auth_type: Optional[str] = Field(None, max_length=20)
+    auth_value: Optional[str] = Field(None, max_length=500)
+    headers: Optional[Dict[str, str]] = None
+    is_active: Optional[bool] = None
+
+
+class ExportDestinationResponse(ExportDestinationBase):
+    id: int
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ApiExportRequest(BaseModel):
+    destination_ids: List[int]
+
+
+class ApiExportResultItem(BaseModel):
+    destination_id: int
+    destination_name: str
+    success: bool
+    status_code: Optional[int] = None
+    error: Optional[str] = None
+
+
+class ApiExportResponse(BaseModel):
+    report_id: int
+    results: List[ApiExportResultItem]

--- a/backend/app/services/pdf_generator.py
+++ b/backend/app/services/pdf_generator.py
@@ -1,0 +1,453 @@
+"""PDF report generation using fpdf2.
+
+Converts structured report JSON content into a formatted PDF document
+with headers, tables, metadata, classification banners, and page numbers.
+"""
+
+import io
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from fpdf import FPDF
+
+logger = logging.getLogger(__name__)
+
+# Classification default (configurable per deployment)
+CLASSIFICATION = "UNCLASSIFIED"
+
+
+class ReportPDF(FPDF):
+    """Custom PDF class with header/footer for KEYSTONE reports."""
+
+    def __init__(self, title: str, classification: str = CLASSIFICATION):
+        super().__init__()
+        self.report_title = title
+        self.classification = classification
+
+    def header(self):
+        # Classification banner
+        self.set_font("Helvetica", "B", 8)
+        self.set_text_color(255, 0, 0)
+        self.cell(0, 5, self.classification, align="C", new_x="LMARGIN", new_y="NEXT")
+        self.set_text_color(0, 0, 0)
+        self.ln(1)
+
+    def footer(self):
+        self.set_y(-15)
+        self.set_font("Helvetica", "I", 7)
+        self.set_text_color(100, 100, 100)
+        self.cell(0, 5, f"KEYSTONE - {self.classification}", align="L")
+        self.cell(0, 5, f"Page {self.page_no()}/{{nb}}", align="R")
+
+
+def generate_report_pdf(
+    title: str,
+    report_type: str,
+    content: Dict[str, Any],
+    classification: str = CLASSIFICATION,
+) -> bytes:
+    """Generate a PDF document from structured report content.
+
+    Returns the PDF as raw bytes suitable for streaming as a response.
+    """
+    pdf = ReportPDF(title=title, classification=classification)
+    pdf.alias_nb_pages()
+    pdf.add_page()
+    pdf.set_auto_page_break(auto=True, margin=20)
+
+    # ---- Title block ----
+    pdf.set_font("Helvetica", "B", 16)
+    pdf.cell(0, 10, title, align="C", new_x="LMARGIN", new_y="NEXT")
+    pdf.ln(2)
+
+    # ---- Metadata ----
+    pdf.set_font("Helvetica", "", 9)
+    unit = content.get("unit")
+    if unit:
+        unit_str = f"{unit.get('name', '')} ({unit.get('abbreviation', '')})"
+        if unit.get("uic"):
+            unit_str += f" - UIC: {unit['uic']}"
+        _add_meta_line(pdf, "Unit", unit_str)
+
+    _add_meta_line(pdf, "Report Type", report_type)
+
+    gen_at = content.get("generated_at") or content.get("as_of")
+    if gen_at:
+        _add_meta_line(pdf, "Generated", _format_dt(gen_at))
+
+    dtg = content.get("dtg")
+    if dtg:
+        _add_meta_line(pdf, "DTG", dtg)
+
+    period_start = content.get("period_start")
+    period_end = content.get("period_end")
+    if period_start or period_end:
+        period_str = f"{_format_dt(period_start) if period_start else 'N/A'} to {_format_dt(period_end) if period_end else 'N/A'}"
+        _add_meta_line(pdf, "Period", period_str)
+
+    pdf.ln(4)
+    _add_separator(pdf)
+    pdf.ln(4)
+
+    # ---- Type-specific content ----
+    renderer = _RENDERERS.get(report_type, _render_generic)
+    renderer(pdf, content)
+
+    # Output bytes
+    buf = io.BytesIO()
+    pdf.output(buf)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _add_meta_line(pdf: FPDF, label: str, value: str):
+    pdf.set_font("Helvetica", "B", 9)
+    pdf.cell(35, 5, f"{label}:", new_x="END")
+    pdf.set_font("Helvetica", "", 9)
+    pdf.cell(0, 5, value, new_x="LMARGIN", new_y="NEXT")
+
+
+def _add_separator(pdf: FPDF):
+    y = pdf.get_y()
+    pdf.set_draw_color(180, 180, 180)
+    pdf.line(pdf.l_margin, y, pdf.w - pdf.r_margin, y)
+
+
+def _section_heading(pdf: FPDF, text: str):
+    pdf.ln(4)
+    pdf.set_font("Helvetica", "B", 11)
+    pdf.set_text_color(30, 80, 160)
+    pdf.cell(0, 7, text.upper(), new_x="LMARGIN", new_y="NEXT")
+    pdf.set_text_color(0, 0, 0)
+    pdf.ln(1)
+
+
+def _stat_line(pdf: FPDF, label: str, value: Any):
+    pdf.set_font("Helvetica", "B", 9)
+    pdf.cell(55, 5, f"{label}:", new_x="END")
+    pdf.set_font("Helvetica", "", 9)
+    pdf.cell(0, 5, str(value), new_x="LMARGIN", new_y="NEXT")
+
+
+def _format_dt(val: Optional[str]) -> str:
+    if not val:
+        return "N/A"
+    try:
+        dt = datetime.fromisoformat(val.replace("Z", "+00:00"))
+        return dt.strftime("%d %b %Y %H:%M UTC")
+    except (ValueError, AttributeError):
+        return str(val)
+
+
+def _add_table(pdf: FPDF, headers: List[str], rows: List[List[str]], col_widths: Optional[List[float]] = None):
+    """Draw a simple table."""
+    if not rows:
+        return
+    page_w = pdf.w - pdf.l_margin - pdf.r_margin
+    if col_widths is None:
+        col_widths = [page_w / len(headers)] * len(headers)
+
+    # Ensure widths fit page
+    total = sum(col_widths)
+    if total > page_w:
+        scale = page_w / total
+        col_widths = [w * scale for w in col_widths]
+
+    # Header row
+    pdf.set_font("Helvetica", "B", 8)
+    pdf.set_fill_color(230, 235, 245)
+    for i, h in enumerate(headers):
+        pdf.cell(col_widths[i], 6, h, border=1, fill=True, new_x="END")
+    pdf.ln()
+
+    # Data rows
+    pdf.set_font("Helvetica", "", 8)
+    for row in rows:
+        # Check if we need a new page
+        if pdf.get_y() > pdf.h - 25:
+            pdf.add_page()
+            # Re-draw header
+            pdf.set_font("Helvetica", "B", 8)
+            pdf.set_fill_color(230, 235, 245)
+            for i, h in enumerate(headers):
+                pdf.cell(col_widths[i], 6, h, border=1, fill=True, new_x="END")
+            pdf.ln()
+            pdf.set_font("Helvetica", "", 8)
+
+        for i, cell_val in enumerate(row):
+            w = col_widths[i] if i < len(col_widths) else col_widths[-1]
+            pdf.cell(w, 5, str(cell_val)[:50], border=1, new_x="END")
+        pdf.ln()
+
+
+def _status_str(val: str) -> str:
+    return val.replace("_", " ") if val else "N/A"
+
+
+# ---------------------------------------------------------------------------
+# Report-type renderers
+# ---------------------------------------------------------------------------
+
+
+def _render_logstat(pdf: FPDF, content: Dict[str, Any]):
+    # Key metrics
+    _section_heading(pdf, "Key Metrics")
+    eq = content.get("equipment_readiness", {})
+    _stat_line(pdf, "Equipment Readiness", f"{eq.get('readiness_pct', 0)}% ({eq.get('status', 'N/A')})")
+    _stat_line(pdf, "Total Possessed", eq.get("total_possessed", 0))
+    _stat_line(pdf, "Mission Capable", eq.get("total_mission_capable", 0))
+    _stat_line(pdf, "Open Work Orders", content.get("open_work_orders", 0))
+    _stat_line(pdf, "Active Movements", content.get("active_movements", 0))
+    _stat_line(pdf, "Personnel Strength", content.get("personnel_strength", 0))
+    _stat_line(pdf, "Total Supply Items", content.get("total_supply_items", 0))
+
+    # Supply status table
+    supply = content.get("supply_status", [])
+    if supply:
+        _section_heading(pdf, "Supply Status by Class")
+        headers = ["CLASS", "NAME", "ITEMS", "STATUS"]
+        rows = []
+        for s in supply:
+            rows.append([
+                s.get("class", ""),
+                s.get("class_name", ""),
+                str(len(s.get("items", []))),
+                s.get("overall_status", "N/A"),
+            ])
+        _add_table(pdf, headers, rows, [20, 60, 30, 30])
+
+
+def _render_readiness(pdf: FPDF, content: Dict[str, Any]):
+    _section_heading(pdf, "Overall Readiness")
+    _stat_line(pdf, "Overall Readiness", f"{content.get('overall_readiness_pct', 0)}%")
+    _stat_line(pdf, "Status", content.get("overall_status", "N/A"))
+    _stat_line(pdf, "Total Possessed", content.get("total_possessed", 0))
+    _stat_line(pdf, "Mission Capable", content.get("total_mission_capable", 0))
+    _stat_line(pdf, "Not MC", content.get("total_nmc", 0))
+
+    eq_types = content.get("equipment_types", [])
+    if eq_types:
+        _section_heading(pdf, "Equipment by Type")
+        headers = ["TAMCN", "NOMENCLATURE", "POSS", "MC", "NMC-M", "NMC-S", "RATE", "STATUS"]
+        rows = []
+        for e in eq_types:
+            rows.append([
+                e.get("tamcn", ""),
+                e.get("nomenclature", ""),
+                str(e.get("total_possessed", 0)),
+                str(e.get("mission_capable", 0)),
+                str(e.get("nmc_maintenance", "-")),
+                str(e.get("nmc_supply", "-")),
+                f"{e.get('readiness_pct', 0)}%",
+                e.get("status", ""),
+            ])
+        _add_table(pdf, headers, rows, [20, 40, 15, 15, 18, 18, 18, 22])
+
+    deadlined = content.get("deadlined_items", [])
+    if deadlined:
+        _section_heading(pdf, "Deadlined Items")
+        headers = ["BUMPER", "TYPE", "TAMCN"]
+        rows = [[d.get("bumper_number", ""), d.get("equipment_type", ""), d.get("tamcn", "")] for d in deadlined]
+        _add_table(pdf, headers, rows, [40, 60, 40])
+
+
+def _render_supply_status(pdf: FPDF, content: Dict[str, Any]):
+    _section_heading(pdf, "Supply Overview")
+    _stat_line(pdf, "Overall Health", content.get("overall_health", "N/A"))
+    _stat_line(pdf, "Classes Tracked", content.get("total_classes_tracked", 0))
+    _stat_line(pdf, "Red Classes", content.get("red_classes", 0))
+    _stat_line(pdf, "Amber Classes", content.get("amber_classes", 0))
+
+    summaries = content.get("class_summaries", [])
+    if summaries:
+        _section_heading(pdf, "Class Breakdown")
+        headers = ["CLASS", "NAME", "ON HAND", "REQUIRED", "FILL%", "AVG DOS", "RED", "STATUS"]
+        rows = []
+        for c in summaries:
+            rows.append([
+                c.get("supply_class", ""),
+                c.get("class_name", ""),
+                str(c.get("total_on_hand", 0)),
+                str(c.get("total_required", 0)),
+                f"{c.get('fill_rate_pct', 0)}%",
+                str(c.get("avg_dos", 0)),
+                str(c.get("red_items", 0)),
+                c.get("status", ""),
+            ])
+        _add_table(pdf, headers, rows, [18, 40, 22, 22, 18, 20, 14, 22])
+
+        # Critical items
+        has_critical = any(c.get("critical_items") for c in summaries)
+        if has_critical:
+            _section_heading(pdf, "Critical Items (Red Status)")
+            headers = ["CLASS", "ITEM", "ON HAND", "REQUIRED", "DOS"]
+            rows = []
+            for c in summaries:
+                for ci in c.get("critical_items", []):
+                    rows.append([
+                        c.get("supply_class", ""),
+                        ci.get("item", ""),
+                        str(ci.get("on_hand", 0)),
+                        str(ci.get("required", 0)),
+                        str(ci.get("dos", 0)),
+                    ])
+            _add_table(pdf, headers, rows, [20, 60, 25, 25, 25])
+
+
+def _render_equipment_status(pdf: FPDF, content: Dict[str, Any]):
+    fr = content.get("fleet_readiness", {})
+    if fr:
+        _section_heading(pdf, "Fleet Readiness")
+        _stat_line(pdf, "Readiness", f"{fr.get('readiness_pct', 0)}% ({fr.get('status', 'N/A')})")
+        _stat_line(pdf, "Total Possessed", fr.get("total_possessed", 0))
+        _stat_line(pdf, "Mission Capable", fr.get("total_mission_capable", 0))
+        _stat_line(pdf, "NMC Maintenance", fr.get("total_nmc_maintenance", 0))
+        _stat_line(pdf, "NMC Supply", fr.get("total_nmc_supply", 0))
+
+    fleet = content.get("fleet_by_type", [])
+    if fleet:
+        _section_heading(pdf, "Fleet by Type")
+        headers = ["TAMCN", "NOMENCLATURE", "POSS", "MC", "NMC-M", "NMC-S", "RATE", "STATUS"]
+        rows = []
+        for e in fleet:
+            rows.append([
+                e.get("tamcn", ""),
+                e.get("nomenclature", ""),
+                str(e.get("total_possessed", 0)),
+                str(e.get("mission_capable", 0)),
+                str(e.get("nmc_maintenance", "-")),
+                str(e.get("nmc_supply", "-")),
+                f"{e.get('readiness_pct', 0)}%",
+                e.get("status", ""),
+            ])
+        _add_table(pdf, headers, rows, [20, 40, 15, 15, 18, 18, 18, 22])
+
+    breakdown = content.get("individual_status_breakdown", {})
+    if breakdown:
+        _section_heading(pdf, f"Individual Equipment Status ({content.get('individual_total', 0)} total)")
+        for status, count in breakdown.items():
+            _stat_line(pdf, _status_str(status), count)
+
+    deadlined = content.get("top_deadlined_items", [])
+    if deadlined:
+        _section_heading(pdf, "Top Deadlined Items")
+        headers = ["BUMPER", "TYPE", "TAMCN", "FAULT", "SEVERITY"]
+        rows = [
+            [
+                d.get("bumper_number", ""),
+                d.get("equipment_type", ""),
+                d.get("tamcn", ""),
+                (d.get("fault") or "N/A")[:40],
+                d.get("fault_severity") or "N/A",
+            ]
+            for d in deadlined
+        ]
+        _add_table(pdf, headers, rows, [25, 30, 20, 55, 25])
+
+
+def _render_maintenance_summary(pdf: FPDF, content: Dict[str, Any]):
+    _section_heading(pdf, "Maintenance Overview")
+    _stat_line(pdf, "Total Work Orders", content.get("total_work_orders", 0))
+    _stat_line(pdf, "Avg Completion Time", f"{content.get('avg_completion_time_hours', 0)}h")
+    _stat_line(pdf, "Total Labor Hours", content.get("total_labor_hours", 0))
+    _stat_line(pdf, "Parts on Order", content.get("parts_on_order", 0))
+
+    wo_counts = content.get("work_order_counts", {})
+    if wo_counts:
+        _section_heading(pdf, "Work Order Status Breakdown")
+        for status, count in wo_counts.items():
+            _stat_line(pdf, _status_str(status), count)
+
+    top_issues = content.get("top_issues", [])
+    if top_issues:
+        _section_heading(pdf, "Top Maintenance Issues")
+        headers = ["EQUIPMENT TYPE", "OPEN WOs"]
+        rows = [[i.get("equipment_type", ""), str(i.get("open_work_orders", 0))] for i in top_issues]
+        _add_table(pdf, headers, rows, [100, 40])
+
+
+def _render_movement_summary(pdf: FPDF, content: Dict[str, Any]):
+    _section_heading(pdf, "Movement Overview")
+    _stat_line(pdf, "Total Movements", content.get("total_movements", 0))
+    _stat_line(pdf, "Vehicles in Transit", content.get("total_vehicles_in_transit", 0))
+    _stat_line(pdf, "Personnel in Transit", content.get("total_personnel_in_transit", 0))
+
+    sc = content.get("status_counts", {})
+    if sc:
+        _section_heading(pdf, "Movement Status Breakdown")
+        for status, count in sc.items():
+            _stat_line(pdf, _status_str(status), count)
+
+    completions = content.get("recent_completions", [])
+    if completions:
+        _section_heading(pdf, "Recent Completions")
+        headers = ["CONVOY", "ORIGIN", "DESTINATION", "VEHICLES", "ARRIVAL"]
+        rows = [
+            [
+                c.get("convoy_id") or "N/A",
+                c.get("origin", ""),
+                c.get("destination", ""),
+                str(c.get("vehicle_count", 0)),
+                _format_dt(c.get("arrival")),
+            ]
+            for c in completions
+        ]
+        _add_table(pdf, headers, rows, [30, 35, 35, 25, 35])
+
+
+def _render_personnel_strength(pdf: FPDF, content: Dict[str, Any]):
+    _section_heading(pdf, "Personnel Overview")
+    _stat_line(pdf, "Total Assigned", content.get("total_assigned", 0))
+    _stat_line(pdf, "Total Active", content.get("total_active", 0))
+    inactive = (content.get("total_assigned", 0) or 0) - (content.get("total_active", 0) or 0)
+    _stat_line(pdf, "Inactive", inactive)
+
+    sb = content.get("status_breakdown", {})
+    if sb:
+        _section_heading(pdf, "Status Breakdown")
+        for status, count in sb.items():
+            _stat_line(pdf, _status_str(status), count)
+
+    rb = content.get("rank_breakdown", {})
+    if rb:
+        _section_heading(pdf, "By Rank")
+        headers = ["RANK", "COUNT"]
+        rows = sorted([[r, str(c)] for r, c in rb.items()], key=lambda x: int(x[1]), reverse=True)
+        _add_table(pdf, headers, rows, [80, 40])
+
+    mb = content.get("mos_breakdown", {})
+    if mb:
+        _section_heading(pdf, "By MOS")
+        headers = ["MOS", "COUNT"]
+        rows = sorted([[m, str(c)] for m, c in mb.items()], key=lambda x: int(x[1]), reverse=True)
+        _add_table(pdf, headers, rows, [80, 40])
+
+
+def _render_generic(pdf: FPDF, content: Dict[str, Any]):
+    """Fallback renderer: dump all key-value pairs."""
+    _section_heading(pdf, "Report Data")
+    skip_keys = {"report_type", "unit", "generated_at", "dtg", "as_of", "period_start", "period_end"}
+    for key, val in content.items():
+        if key in skip_keys:
+            continue
+        if isinstance(val, (dict, list)):
+            _stat_line(pdf, key.replace("_", " ").title(), json.dumps(val, default=str)[:200])
+        else:
+            _stat_line(pdf, key.replace("_", " ").title(), str(val))
+
+
+_RENDERERS = {
+    "LOGSTAT": _render_logstat,
+    "READINESS": _render_readiness,
+    "SUPPLY_STATUS": _render_supply_status,
+    "EQUIPMENT_STATUS": _render_equipment_status,
+    "MAINTENANCE_SUMMARY": _render_maintenance_summary,
+    "MOVEMENT_SUMMARY": _render_movement_summary,
+    "PERSONNEL_STRENGTH": _render_personnel_strength,
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,5 +18,6 @@ pandas==2.1.4
 httpx==0.26.0
 defusedxml==0.7.1
 mgrs==1.5.4
+fpdf2==2.7.9
 pytest==7.4.4
 pytest-asyncio==0.23.3

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,120 @@
+# KEYSTONE Frontend
+
+React SPA for the USMC Logistics Common Operating Picture.
+
+## Tech Stack
+
+- **React 18** with TypeScript 5.3
+- **Vite 5** (build and dev server)
+- **Tailwind CSS** (utility-first styling)
+- **Zustand** (state management)
+- **TanStack Query** (server state / data fetching)
+- **TanStack Table** (data tables)
+- **react-leaflet** + **milsymbol** (maps with APP-6D military symbology)
+- **Recharts** (charts and visualizations)
+- **Lucide React** (icons)
+
+## Quick Start
+
+```bash
+# Install dependencies
+npm ci
+
+# Start development server (proxies /api to localhost:8000)
+npm run dev
+
+# Access at http://localhost:5173
+```
+
+Ensure the backend is running at `http://localhost:8000` or use demo mode (see below).
+
+## Scripts
+
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Start Vite dev server with HMR |
+| `npm run build` | Production build to `dist/` |
+| `npm run preview` | Preview production build locally |
+| `npx tsc -b` | Full TypeScript type check (no emit) |
+| `npx vitest run` | Run unit tests |
+| `npx vitest run --coverage` | Run tests with coverage report |
+
+## Demo Mode
+
+Build a fully functional static site with mock data (no backend required):
+
+```bash
+VITE_DEMO_MODE=true npm run build
+```
+
+The demo build uses the mock API client (`src/api/mockClient.ts`) which provides realistic USMC logistics data for all pages. This mode is automatically deployed to GitHub Pages.
+
+## Environment Variables
+
+Set at build time via Vite:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VITE_DEMO_MODE` | `false` | Build as static demo site with mock data |
+| `VITE_BASE_PATH` | `/` | Base URL path (set to `/keystone/` for GitHub Pages) |
+
+## Project Structure
+
+```
+src/
+  pages/           # 12 route pages (Dashboard, Map, Supply, Equipment, etc.)
+  components/      # UI components organized by domain
+    dashboard/     # Readiness cards, supply charts, Commander/S4/S3 views
+    map/           # Leaflet map, symbology, layers, overlays
+    equipment/     # Readiness tables, maintenance queue, work orders
+    transportation/# Convoy map, movement tracker, route planner
+    supply/        # Supply tables, class breakdowns, DOS calculator
+    reports/       # Report generator and structured viewer
+    admin/         # User management, unit tree, tile settings
+    layout/        # Sidebar, header, main layout
+    ui/            # Classification banner, demo banner, shared components
+  api/             # API client + mock data for demo mode
+  stores/          # Zustand stores (auth, dashboard, map, alerts, classification, reports)
+  hooks/           # Custom React hooks
+  lib/             # Types, utilities, constants
+```
+
+## Routing
+
+All routes are protected by JWT authentication (redirect to `/login` if not authenticated):
+
+| Path | Page | Description |
+|------|------|-------------|
+| `/dashboard` | DashboardPage | Commander, S-4, S-3 views |
+| `/map` | MapPage | Interactive COP map |
+| `/supply` | SupplyPage | Supply class tracking |
+| `/equipment` | EquipmentPage | Fleet readiness |
+| `/equipment/:id` | EquipmentDetailPage | Individual asset detail (5 tabs) |
+| `/transportation` | TransportationPage | Convoy and movement management |
+| `/ingestion` | IngestionPage | File upload and parsing |
+| `/data-sources` | DataSourcesPage | External source configuration |
+| `/reports` | ReportsPage | Report generation and viewing |
+| `/alerts` | AlertsPage | Alert management |
+| `/admin` | AdminPage | System administration |
+| `/docs` | DocsPage | Interactive documentation |
+
+## Docker
+
+The frontend Dockerfile is a multi-stage build:
+
+1. **Build stage**: Node 20, installs deps, runs `npm run build`
+2. **Production stage**: `nginx-unprivileged` with TLS, API proxy, and tile proxy
+
+The nginx config (`nginx.conf`) handles:
+- TLS termination (self-signed cert via `generate-cert.sh`)
+- `/api/*` proxy to the backend container
+- `/tiles/*` proxy for map tile sources
+- SPA fallback routing
+- Security headers (HSTS, CSP, X-Frame-Options, etc.)
+
+## Notes
+
+- No ESLint configured -- type checking is handled by `tsc -b`
+- milsymbol requires 15-character SIDCs and `monoColor` (not `colorMode`) for hex colors
+- Tailwind config is in `tailwind.config.js`
+- Vite config includes tile proxy for development in `vite.config.ts`

--- a/frontend/src/api/mockClient.ts
+++ b/frontend/src/api/mockClient.ts
@@ -41,11 +41,16 @@ import type {
   PersonnelSummary,
   ConvoyManifest,
   ConvoyRole,
+  ExportDestination,
+  ExportDestinationCreate,
+  ExportDestinationUpdate,
+  ApiExportResponse,
 } from '@/lib/types';
 
 import {
   ReportType,
   WorkOrderStatus,
+  SupplyStatus,
 } from '@/lib/types';
 
 import {
@@ -94,10 +99,71 @@ let demoUnits = [...DEMO_UNITS];
 let demoReports = [...DEMO_REPORTS];
 let demoMovements = [...DEMO_MOVEMENTS];
 let demoPersonnel = [...DEMO_PERSONNEL];
+
+let demoExportDestinations: ExportDestination[] = [
+  {
+    id: 1,
+    name: 'GCSS-MC API',
+    url: 'https://gcss-mc.example.mil/api/v2/reports/ingest',
+    auth_type: 'bearer',
+    auth_value: 'demo-token-gcss',
+    headers: null,
+    is_active: true,
+    created_at: '2026-01-15T08:00:00Z',
+  },
+  {
+    id: 2,
+    name: 'Higher HQ',
+    url: 'https://higher-hq.example.mil/logistics/reports',
+    auth_type: 'api_key',
+    auth_value: 'demo-api-key-hq',
+    headers: { 'X-Unit-ID': 'IMEF' },
+    is_active: true,
+    created_at: '2026-02-01T12:00:00Z',
+  },
+  {
+    id: 3,
+    name: 'Archive Server',
+    url: 'https://archive.example.mil/reports/store',
+    auth_type: 'none',
+    auth_value: null,
+    headers: null,
+    is_active: false,
+    created_at: '2026-02-10T09:30:00Z',
+  },
+];
 let demoWorkOrders = [...DEMO_WORK_ORDERS];
 let demoIndividualEquipment = [...DEMO_INDIVIDUAL_EQUIPMENT];
 let demoFaults = [...DEMO_EQUIPMENT_FAULTS];
 let demoDriverAssignments = [...DEMO_DRIVER_ASSIGNMENTS];
+
+// ---------------------------------------------------------------------------
+// Helper: hierarchical unit filtering — walks the unit tree to find
+// all descendants of a given unit ID so that selecting a parent unit
+// (e.g. "I MEF") also shows data for all child/grandchild units.
+// ---------------------------------------------------------------------------
+
+function getDescendantUnitIds(unitId: string): string[] {
+  const ids = new Set<string>([unitId]);
+  let added = true;
+  while (added) {
+    added = false;
+    for (const u of DEMO_UNITS) {
+      if (u.parentId && ids.has(u.parentId) && !ids.has(u.id)) {
+        ids.add(u.id);
+        added = true;
+      }
+    }
+  }
+  return Array.from(ids);
+}
+
+function matchesUnitFilter(recordUnitId: string | undefined, filterUnitId?: string): boolean {
+  if (!filterUnitId) return true;
+  if (!recordUnitId) return false;
+  const validIds = getDescendantUnitIds(filterUnitId);
+  return validIds.includes(recordUnitId);
+}
 
 // ---------------------------------------------------------------------------
 // Helper: convert time range string to number of days
@@ -155,34 +221,158 @@ export const mockApi = {
   // Dashboard
   // -------------------------------------------------------------------------
 
-  async getDashboardSummary(_unitId?: string, _timeRange?: string): Promise<DashboardSummary> {
+  async getDashboardSummary(unitId?: string, _timeRange?: string): Promise<DashboardSummary> {
     await mockDelay();
-    return DEMO_DASHBOARD_SUMMARY;
+    if (!unitId) return DEMO_DASHBOARD_SUMMARY;
+
+    // Recompute summary from underlying records for the selected unit hierarchy
+    const supplyRecords = DEMO_SUPPLY_RECORDS.filter((r) => matchesUnitFilter(r.unitId, unitId));
+    const equipmentRecords = DEMO_EQUIPMENT.filter((r) => matchesUnitFilter(r.unitId, unitId));
+    const alerts = demoAlerts.filter((a) => matchesUnitFilter(a.unitId, unitId));
+    const movements = demoMovements.filter((m) => {
+      // Match movements where origin or destination unit name contains a matching unit name
+      const validIds = getDescendantUnitIds(unitId);
+      const unitNames = DEMO_UNITS.filter((u) => validIds.includes(u.id)).map((u) => u.abbreviation);
+      return unitNames.some((n) => m.originUnit.includes(n) || m.destinationUnit.includes(n));
+    });
+
+    // Compute supply status by class
+    const supplyByClass = new Map<string, { onHand: number; authorized: number }>();
+    for (const r of supplyRecords) {
+      const existing = supplyByClass.get(r.supplyClass) || { onHand: 0, authorized: 0 };
+      existing.onHand += r.onHand;
+      existing.authorized += r.authorized;
+      supplyByClass.set(r.supplyClass, existing);
+    }
+    const supplyStatus = DEMO_DASHBOARD_SUMMARY.supplyStatus
+      .map((s) => {
+        const data = supplyByClass.get(s.supplyClass);
+        if (!data) return null;
+        const pct = Math.round((data.onHand / data.authorized) * 100);
+        const status: SupplyStatus = pct >= 80 ? SupplyStatus.GREEN : pct >= 60 ? SupplyStatus.AMBER : SupplyStatus.RED;
+        return { ...s, percentage: pct, onHand: data.onHand, authorized: data.authorized, status } as SupplyClassSummary;
+      })
+      .filter((s): s is SupplyClassSummary => s !== null);
+
+    // Compute equipment readiness
+    const totalAuth = equipmentRecords.reduce((s, e) => s + e.authorized, 0);
+    const totalMC = equipmentRecords.reduce((s, e) => s + e.missionCapable, 0);
+    const overallReadiness = totalAuth > 0 ? Math.round((totalMC / totalAuth) * 1000) / 10 : 0;
+
+    const unitInfo = DEMO_UNITS.find((u) => u.id === unitId);
+
+    return {
+      ...DEMO_DASHBOARD_SUMMARY,
+      unitId: unitId,
+      unitName: unitInfo?.abbreviation || DEMO_DASHBOARD_SUMMARY.unitName,
+      overallReadiness,
+      supplyStatus: supplyStatus.length > 0 ? supplyStatus : DEMO_DASHBOARD_SUMMARY.supplyStatus,
+      equipmentReadiness: {
+        ...DEMO_DASHBOARD_SUMMARY.equipmentReadiness,
+        overall: overallReadiness,
+      },
+      activeMovements: movements.length,
+      criticalAlerts: alerts.filter((a) => a.severity === 'CRITICAL' && !a.acknowledged).length,
+      warningAlerts: alerts.filter((a) => a.severity === 'WARNING' && !a.acknowledged).length,
+    };
   },
 
-  async getSupplyOverview(_unitId?: string, _timeRange?: string): Promise<SupplyClassSummary[]> {
+  async getSupplyOverview(unitId?: string, _timeRange?: string): Promise<SupplyClassSummary[]> {
     await mockDelay();
-    return DEMO_DASHBOARD_SUMMARY.supplyStatus;
+    if (!unitId) return DEMO_DASHBOARD_SUMMARY.supplyStatus;
+
+    const supplyRecords = DEMO_SUPPLY_RECORDS.filter((r) => matchesUnitFilter(r.unitId, unitId));
+    const supplyByClass = new Map<string, { onHand: number; authorized: number }>();
+    for (const r of supplyRecords) {
+      const existing = supplyByClass.get(r.supplyClass) || { onHand: 0, authorized: 0 };
+      existing.onHand += r.onHand;
+      existing.authorized += r.authorized;
+      supplyByClass.set(r.supplyClass, existing);
+    }
+    return DEMO_DASHBOARD_SUMMARY.supplyStatus
+      .map((s) => {
+        const data = supplyByClass.get(s.supplyClass);
+        if (!data) return null;
+        const pct = Math.round((data.onHand / data.authorized) * 100);
+        const status: SupplyStatus = pct >= 80 ? SupplyStatus.GREEN : pct >= 60 ? SupplyStatus.AMBER : SupplyStatus.RED;
+        return { ...s, percentage: pct, onHand: data.onHand, authorized: data.authorized, status } as SupplyClassSummary;
+      })
+      .filter((s): s is SupplyClassSummary => s !== null);
   },
 
-  async getReadinessOverview(_unitId?: string, _timeRange?: string): Promise<ReadinessSummary> {
+  async getReadinessOverview(unitId?: string, _timeRange?: string): Promise<ReadinessSummary> {
     await mockDelay();
-    return DEMO_DASHBOARD_SUMMARY.equipmentReadiness;
+    if (!unitId) return DEMO_DASHBOARD_SUMMARY.equipmentReadiness;
+
+    const equipmentRecords = DEMO_EQUIPMENT.filter((r) => matchesUnitFilter(r.unitId, unitId));
+    const totalAuth = equipmentRecords.reduce((s, e) => s + e.authorized, 0);
+    const totalMC = equipmentRecords.reduce((s, e) => s + e.missionCapable, 0);
+    const overall = totalAuth > 0 ? Math.round((totalMC / totalAuth) * 1000) / 10 : 0;
+
+    // Group by type
+    const byTypeMap = new Map<string, { authorized: number; mc: number }>();
+    for (const e of equipmentRecords) {
+      const existing = byTypeMap.get(e.type) || { authorized: 0, mc: 0 };
+      existing.authorized += e.authorized;
+      existing.mc += e.missionCapable;
+      byTypeMap.set(e.type, existing);
+    }
+    const byType = Array.from(byTypeMap.entries()).map(([type, data]) => {
+      const pct = Math.round((data.mc / data.authorized) * 1000) / 10;
+      const status: SupplyStatus = pct >= 90 ? SupplyStatus.GREEN : pct >= 75 ? SupplyStatus.AMBER : SupplyStatus.RED;
+      return { type, authorized: data.authorized, missionCapable: data.mc, readinessPercent: pct, status };
+    });
+
+    const overallStatus: SupplyStatus = overall >= 90 ? SupplyStatus.GREEN : overall >= 75 ? SupplyStatus.AMBER : SupplyStatus.RED;
+    return {
+      overall,
+      byType,
+      status: overallStatus,
+      trend: DEMO_DASHBOARD_SUMMARY.equipmentReadiness.trend,
+    };
   },
 
   async getSustainability(
-    _unitId?: string,
+    unitId?: string,
     _timeRange?: string,
   ): Promise<SustainabilityProjection[]> {
     await mockDelay();
-    return DEMO_SUSTAINABILITY;
+    if (!unitId) return DEMO_SUSTAINABILITY;
+
+    // Recompute sustainability from supply records for the filtered unit
+    const supplyRecords = DEMO_SUPPLY_RECORDS.filter((r) => matchesUnitFilter(r.unitId, unitId));
+    if (supplyRecords.length === 0) return [];
+
+    const supplyByClass = new Map<string, { onHand: number; authorized: number; rate: number }>();
+    for (const r of supplyRecords) {
+      const existing = supplyByClass.get(r.supplyClass) || { onHand: 0, authorized: 0, rate: 0 };
+      existing.onHand += r.onHand;
+      existing.authorized += r.authorized;
+      existing.rate += r.consumptionRate;
+      supplyByClass.set(r.supplyClass, existing);
+    }
+
+    return DEMO_SUSTAINABILITY
+      .map((s) => {
+        const data = supplyByClass.get(s.supplyClass);
+        if (!data || data.rate === 0) return null;
+        const currentDOS = Math.round((data.onHand / data.rate) * 10) / 10;
+        const projectedDOS = Math.round(currentDOS * 0.7 * 10) / 10;
+        const status: SupplyStatus = currentDOS >= s.criticalThreshold * 2 ? SupplyStatus.GREEN : currentDOS >= s.criticalThreshold ? SupplyStatus.AMBER : SupplyStatus.RED;
+        return { ...s, currentDOS, projectedDOS, status } as SustainabilityProjection;
+      })
+      .filter((s): s is SustainabilityProjection => s !== null);
   },
 
-  async getDashboardAlerts(_unitId?: string, _timeRange?: string): Promise<Alert[]> {
+  async getDashboardAlerts(unitId?: string, _timeRange?: string): Promise<Alert[]> {
     await mockDelay();
     const days = timeRangeToDays(_timeRange);
     const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-    return demoAlerts.filter((a) => !a.acknowledged && new Date(a.createdAt) >= cutoff).slice(0, 5);
+    let alerts = demoAlerts.filter((a) => !a.acknowledged && new Date(a.createdAt) >= cutoff);
+    if (unitId) {
+      alerts = alerts.filter((a) => matchesUnitFilter(a.unitId, unitId));
+    }
+    return alerts.slice(0, 5);
   },
 
   // -------------------------------------------------------------------------
@@ -196,7 +386,7 @@ export const mockApi = {
     let records = [...DEMO_SUPPLY_RECORDS];
 
     if (filters?.unitId) {
-      records = records.filter((r) => r.unitId === filters.unitId);
+      records = records.filter((r) => matchesUnitFilter(r.unitId, filters.unitId));
     }
     if (filters?.supplyClass) {
       records = records.filter((r) => r.supplyClass === filters.supplyClass);
@@ -275,7 +465,7 @@ export const mockApi = {
     let records = [...DEMO_EQUIPMENT];
 
     if (filters?.unitId) {
-      records = records.filter((r) => r.unitId === filters.unitId);
+      records = records.filter((r) => matchesUnitFilter(r.unitId, filters.unitId));
     }
     if (filters?.type) {
       records = records.filter((r) =>
@@ -342,10 +532,15 @@ export const mockApi = {
   // -------------------------------------------------------------------------
 
   async getMovements(
-    _filters?: Record<string, unknown>,
+    filters?: { unitId?: string },
   ): Promise<Movement[]> {
     await mockDelay();
-    return demoMovements;
+    if (!filters?.unitId) return demoMovements;
+    const validIds = getDescendantUnitIds(filters.unitId);
+    const unitNames = DEMO_UNITS.filter((u) => validIds.includes(u.id)).map((u) => u.abbreviation);
+    return demoMovements.filter((m) =>
+      unitNames.some((n) => m.originUnit.includes(n) || m.destinationUnit.includes(n)),
+    );
   },
 
   async createMovement(data: Partial<Movement>): Promise<Movement> {
@@ -382,12 +577,12 @@ export const mockApi = {
 
   async getUnitEquipment(unitId: string): Promise<EquipmentRecord[]> {
     await mockDelay();
-    return DEMO_EQUIPMENT.filter((r) => r.unitId === unitId);
+    return DEMO_EQUIPMENT.filter((r) => matchesUnitFilter(r.unitId, unitId));
   },
 
   async getUnitSupply(unitId: string): Promise<SupplyRecord[]> {
     await mockDelay();
-    return DEMO_SUPPLY_RECORDS.filter((r) => r.unitId === unitId);
+    return DEMO_SUPPLY_RECORDS.filter((r) => matchesUnitFilter(r.unitId, unitId));
   },
 
   // -------------------------------------------------------------------------
@@ -403,7 +598,7 @@ export const mockApi = {
     let alerts = [...demoAlerts];
 
     if (params?.unitId) {
-      alerts = alerts.filter((a) => a.unitId === params.unitId);
+      alerts = alerts.filter((a) => matchesUnitFilter(a.unitId, params.unitId));
     }
     if (params?.severity) {
       alerts = alerts.filter((a) => a.severity === params.severity);
@@ -446,7 +641,7 @@ export const mockApi = {
     let reports = [...demoReports];
 
     if (filters?.unitId) {
-      reports = reports.filter((r) => r.unitId === filters.unitId);
+      reports = reports.filter((r) => matchesUnitFilter(r.unitId, filters.unitId));
     }
     if (filters?.type) {
       reports = reports.filter((r) => r.type === filters.type);
@@ -503,6 +698,68 @@ export const mockApi = {
         : r,
     );
     return demoReports.find((r) => r.id === id) || demoReports[0];
+  },
+
+  // -------------------------------------------------------------------------
+  // Report Export (PDF, API destinations)
+  // -------------------------------------------------------------------------
+
+  async exportReportPdf(_reportId: string): Promise<Blob> {
+    await mockDelay(400);
+    // Return a minimal mock blob — in demo mode, the user will see a download trigger
+    const text = 'KEYSTONE Report PDF (Demo Mode)\n\nThis is a placeholder PDF in demo mode.';
+    return new Blob([text], { type: 'application/pdf' });
+  },
+
+  async getExportDestinations(): Promise<ExportDestination[]> {
+    await mockDelay();
+    return [...demoExportDestinations];
+  },
+
+  async createExportDestination(data: ExportDestinationCreate): Promise<ExportDestination> {
+    await mockDelay();
+    const dest: ExportDestination = {
+      id: Date.now(),
+      name: data.name,
+      url: data.url,
+      auth_type: data.auth_type,
+      auth_value: data.auth_value ?? null,
+      headers: data.headers ?? null,
+      is_active: data.is_active ?? true,
+      created_at: new Date().toISOString(),
+    };
+    demoExportDestinations.push(dest);
+    return dest;
+  },
+
+  async updateExportDestination(id: number, data: ExportDestinationUpdate): Promise<ExportDestination> {
+    await mockDelay();
+    demoExportDestinations = demoExportDestinations.map((d) =>
+      d.id === id ? { ...d, ...data } as ExportDestination : d,
+    );
+    return demoExportDestinations.find((d) => d.id === id) || demoExportDestinations[0];
+  },
+
+  async deleteExportDestination(id: number): Promise<void> {
+    await mockDelay();
+    demoExportDestinations = demoExportDestinations.filter((d) => d.id !== id);
+  },
+
+  async exportReportToApi(reportId: string, destinationIds: number[]): Promise<ApiExportResponse> {
+    await mockDelay(600);
+    return {
+      report_id: parseInt(reportId) || 0,
+      results: destinationIds.map((destId) => {
+        const dest = demoExportDestinations.find((d) => d.id === destId);
+        return {
+          destination_id: destId,
+          destination_name: dest?.name || 'Unknown',
+          success: true,
+          status_code: 200,
+          error: null,
+        };
+      }),
+    };
   },
 
   // -------------------------------------------------------------------------
@@ -616,7 +873,10 @@ export const mockApi = {
   async getPersonnel(filters?: { unitId?: string; status?: string; search?: string }): Promise<Personnel[]> {
     await mockDelay(200);
     let results = [...demoPersonnel];
-    if (filters?.unitId) results = results.filter(p => p.unitId === filters.unitId);
+    if (filters?.unitId) {
+      const uid = filters.unitId;
+      results = results.filter(p => matchesUnitFilter(p.unitId, uid));
+    }
     if (filters?.status) results = results.filter(p => p.status === filters.status);
     if (filters?.search) {
       const q = filters.search.toLowerCase();
@@ -682,7 +942,7 @@ export const mockApi = {
   ): Promise<PaginatedResponse<EquipmentItem>> {
     await mockDelay();
     let items = [...demoIndividualEquipment];
-    if (filters?.unitId) items = items.filter((i) => i.unitId === filters.unitId);
+    if (filters?.unitId) items = items.filter((i) => matchesUnitFilter(i.unitId, filters.unitId));
     if (filters?.equipmentType) {
       const t = filters.equipmentType.toLowerCase();
       items = items.filter((i) => i.equipmentType.toLowerCase().includes(t));
@@ -802,7 +1062,7 @@ export const mockApi = {
   ): Promise<PaginatedResponse<MaintenanceWorkOrder>> {
     await mockDelay();
     let orders = [...demoWorkOrders];
-    if (filters?.unitId) orders = orders.filter((o) => o.unitId === filters.unitId);
+    if (filters?.unitId) orders = orders.filter((o) => matchesUnitFilter(o.unitId, filters.unitId));
     if (filters?.equipmentId) orders = orders.filter((o) => o.individualEquipmentId === filters.equipmentId);
     if (filters?.status) orders = orders.filter((o) => o.status === filters.status);
     if (filters?.priority) orders = orders.filter((o) => o.priority === filters.priority);

--- a/frontend/src/api/reports.ts
+++ b/frontend/src/api/reports.ts
@@ -5,6 +5,10 @@ import type {
   ReportFilters,
   GenerateReportParams,
   PaginatedResponse,
+  ExportDestination,
+  ExportDestinationCreate,
+  ExportDestinationUpdate,
+  ApiExportResponse,
 } from '@/lib/types';
 
 export async function getReports(filters?: ReportFilters): Promise<PaginatedResponse<Report>> {
@@ -38,5 +42,50 @@ export async function getReport(id: string): Promise<Report> {
 export async function finalizeReport(id: string): Promise<Report> {
   if (isDemoMode) return mockApi.finalizeReport(id);
   const response = await apiClient.put<Report>(`/reports/${id}/finalize`);
+  return response.data;
+}
+
+// --- PDF Export ---
+
+export async function exportReportPdf(reportId: string): Promise<Blob> {
+  if (isDemoMode) return mockApi.exportReportPdf(reportId);
+  const response = await apiClient.get(`/reports/${reportId}/export/pdf`, {
+    responseType: 'blob',
+  });
+  return response.data as Blob;
+}
+
+// --- Export Destinations ---
+
+export async function getExportDestinations(): Promise<ExportDestination[]> {
+  if (isDemoMode) return mockApi.getExportDestinations();
+  const response = await apiClient.get<ExportDestination[]>('/reports/export-destinations');
+  return response.data;
+}
+
+export async function createExportDestination(data: ExportDestinationCreate): Promise<ExportDestination> {
+  if (isDemoMode) return mockApi.createExportDestination(data);
+  const response = await apiClient.post<ExportDestination>('/reports/export-destinations', data);
+  return response.data;
+}
+
+export async function updateExportDestination(id: number, data: ExportDestinationUpdate): Promise<ExportDestination> {
+  if (isDemoMode) return mockApi.updateExportDestination(id, data);
+  const response = await apiClient.put<ExportDestination>(`/reports/export-destinations/${id}`, data);
+  return response.data;
+}
+
+export async function deleteExportDestination(id: number): Promise<void> {
+  if (isDemoMode) return mockApi.deleteExportDestination(id);
+  await apiClient.delete(`/reports/export-destinations/${id}`);
+}
+
+// --- API Export ---
+
+export async function exportReportToApi(reportId: string, destinationIds: number[]): Promise<ApiExportResponse> {
+  if (isDemoMode) return mockApi.exportReportToApi(reportId, destinationIds);
+  const response = await apiClient.post<ApiExportResponse>(`/reports/${reportId}/export/api`, {
+    destination_ids: destinationIds,
+  });
   return response.data;
 }

--- a/frontend/src/api/simulator.ts
+++ b/frontend/src/api/simulator.ts
@@ -1,0 +1,389 @@
+import apiClient from './client';
+import { isDemoMode } from './mockClient';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ScenarioSummary {
+  name: string;
+  display_name: string;
+  description: string;
+  duration_days: number;
+  phase_count: number;
+  unit_count: number;
+  category: string;
+}
+
+export interface ScenarioPhase {
+  name: string;
+  offset_h: number;
+  duration_h: number;
+  tempo: 'LOW' | 'MEDIUM' | 'HIGH';
+  description: string;
+}
+
+export interface ScenarioUnit {
+  name: string;
+  type: string;
+  callsign: string;
+}
+
+export interface ScenarioDetail extends ScenarioSummary {
+  phases: ScenarioPhase[];
+  units: ScenarioUnit[];
+  area_of_operation?: {
+    name: string;
+    center: [number, number];
+    radius_km: number;
+  };
+}
+
+export interface SimulatorStatus {
+  status: 'idle' | 'running' | 'paused' | 'stopped';
+  scenario_name?: string;
+  sim_time?: string;
+  speed?: number;
+  events_processed?: number;
+  started_at?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Mock data for demo mode
+// ---------------------------------------------------------------------------
+
+const MOCK_SCENARIOS: ScenarioSummary[] = [
+  // Pre-Deployment Training (CONUS)
+  {
+    name: 'steel_guardian',
+    display_name: 'Exercise Steel Guardian',
+    description: '7-day battalion-level FEX at 29 Palms MCAGCC. 1/1 Marines with CLB-1 support.',
+    duration_days: 7,
+    phase_count: 5,
+    unit_count: 8,
+    category: 'Pre-Deployment Training (CONUS)',
+  },
+  {
+    name: 'itx',
+    display_name: 'Integrated Training Exercise',
+    description: 'Regimental-level ITX at 29 Palms. Combined arms live-fire with MAGTF integration.',
+    duration_days: 19,
+    phase_count: 6,
+    unit_count: 14,
+    category: 'Pre-Deployment Training (CONUS)',
+  },
+  {
+    name: 'steel_knight',
+    display_name: 'Steel Knight',
+    description: 'Division-level exercise across Southern California. Multi-domain operations.',
+    duration_days: 10,
+    phase_count: 5,
+    unit_count: 16,
+    category: 'Pre-Deployment Training (CONUS)',
+  },
+  {
+    name: 'comptuex',
+    display_name: 'MEU COMPTUEX',
+    description: 'Composite Training Unit Exercise. Final certification for MEU deployment.',
+    duration_days: 14,
+    phase_count: 5,
+    unit_count: 12,
+    category: 'Pre-Deployment Training (CONUS)',
+  },
+
+  // Indo-Pacific
+  {
+    name: 'cobra_gold',
+    display_name: 'Cobra Gold',
+    description: 'Multinational exercise in Thailand. Combined amphibious and HA/DR operations.',
+    duration_days: 10,
+    phase_count: 4,
+    unit_count: 10,
+    category: 'Indo-Pacific',
+  },
+  {
+    name: 'balikatan',
+    display_name: 'Balikatan',
+    description: 'US-Philippines bilateral exercise. Island defense and maritime security.',
+    duration_days: 14,
+    phase_count: 5,
+    unit_count: 12,
+    category: 'Indo-Pacific',
+  },
+  {
+    name: 'resolute_dragon',
+    display_name: 'Resolute Dragon',
+    description: 'US-Japan bilateral exercise in Okinawa. Integrated island defense operations.',
+    duration_days: 10,
+    phase_count: 4,
+    unit_count: 10,
+    category: 'Indo-Pacific',
+  },
+  {
+    name: 'ssang_yong',
+    display_name: 'Ssang Yong',
+    description: 'US-Korea combined amphibious exercise. Large-scale forcible entry operations.',
+    duration_days: 10,
+    phase_count: 4,
+    unit_count: 12,
+    category: 'Indo-Pacific',
+  },
+  {
+    name: 'kamandag',
+    display_name: 'Kamandag',
+    description: 'US-Philippines marine exercise. Littoral operations and humanitarian assistance.',
+    duration_days: 10,
+    phase_count: 4,
+    unit_count: 8,
+    category: 'Indo-Pacific',
+  },
+  {
+    name: 'valiant_shield',
+    display_name: 'Valiant Shield',
+    description: 'Tri-service exercise in the Marianas. Joint force integration and combined arms.',
+    duration_days: 12,
+    phase_count: 4,
+    unit_count: 10,
+    category: 'Indo-Pacific',
+  },
+  {
+    name: 'rimpac',
+    display_name: 'RIMPAC',
+    description: 'Multinational maritime exercise in Hawaii. Largest international naval warfare exercise.',
+    duration_days: 21,
+    phase_count: 5,
+    unit_count: 14,
+    category: 'Indo-Pacific',
+  },
+  {
+    name: 'island_sentinel',
+    display_name: 'Island Sentinel',
+    description: 'First Island Chain EAB operations. Expeditionary advanced base distributed operations.',
+    duration_days: 14,
+    phase_count: 5,
+    unit_count: 10,
+    category: 'Indo-Pacific',
+  },
+
+  // Europe / Africa / Middle East
+  {
+    name: 'african_lion',
+    display_name: 'African Lion',
+    description: 'US-Morocco combined exercise. Desert warfare and humanitarian assistance.',
+    duration_days: 10,
+    phase_count: 4,
+    unit_count: 10,
+    category: 'Europe / Africa / Middle East',
+  },
+  {
+    name: 'cold_response',
+    display_name: 'Cold Response',
+    description: 'NATO exercise in northern Norway. Arctic and cold weather operations.',
+    duration_days: 14,
+    phase_count: 5,
+    unit_count: 12,
+    category: 'Europe / Africa / Middle East',
+  },
+  {
+    name: 'native_fury',
+    display_name: 'Native Fury',
+    description: 'US-UAE combined exercise. Amphibious operations and desert warfare.',
+    duration_days: 10,
+    phase_count: 4,
+    unit_count: 10,
+    category: 'Europe / Africa / Middle East',
+  },
+
+  // Americas / Maritime
+  {
+    name: 'unitas',
+    display_name: 'UNITAS',
+    description: 'Multinational maritime exercise with South American navies. Naval cooperation.',
+    duration_days: 14,
+    phase_count: 4,
+    unit_count: 8,
+    category: 'Americas / Maritime',
+  },
+
+  // Crisis Response
+  {
+    name: 'trident_spear',
+    display_name: 'Trident Spear',
+    description: 'NEO and crisis response exercise. Embassy reinforcement and civilian evacuation.',
+    duration_days: 5,
+    phase_count: 4,
+    unit_count: 8,
+    category: 'Crisis Response',
+  },
+
+  // Reserve Component
+  {
+    name: 'reserve_itx',
+    display_name: 'Reserve ITX',
+    description: 'Reserve component Integrated Training Exercise at 29 Palms.',
+    duration_days: 14,
+    phase_count: 5,
+    unit_count: 10,
+    category: 'Reserve Component',
+  },
+
+  // Deployment / Garrison
+  {
+    name: 'pacific_fury',
+    display_name: 'Pacific Fury',
+    description: '26th MEU Pre-Deployment Training and Embark, Camp Lejeune.',
+    duration_days: 134,
+    phase_count: 4,
+    unit_count: 12,
+    category: 'Deployment / Garrison',
+  },
+  {
+    name: 'iron_forge',
+    display_name: 'Iron Forge',
+    description: 'MCAS / Camp Garrison Operations on Okinawa. Sustained logistics ops.',
+    duration_days: 90,
+    phase_count: 3,
+    unit_count: 10,
+    category: 'Deployment / Garrison',
+  },
+];
+
+const MOCK_SCENARIO_DETAILS: Record<string, ScenarioDetail> = {
+  steel_guardian: {
+    ...MOCK_SCENARIOS[0],
+    phases: [
+      { name: 'Phase 0 -- Deployment & Assembly', offset_h: 0, duration_h: 24, tempo: 'LOW', description: 'Units deploy from Camp Pendleton to 29 Palms MCAGCC.' },
+      { name: 'Phase I -- Defense', offset_h: 24, duration_h: 48, tempo: 'MEDIUM', description: 'Establish defensive positions. Conduct security patrols.' },
+      { name: 'Phase II -- Offensive Operations', offset_h: 72, duration_h: 48, tempo: 'HIGH', description: 'Conduct offensive operations to seize OBJ GRANITE and OBJ IRON.' },
+      { name: 'Phase III -- Stability Operations', offset_h: 120, duration_h: 36, tempo: 'MEDIUM', description: 'Consolidate gains. Focus on resupply and equipment recovery.' },
+      { name: 'Phase IV -- Redeployment', offset_h: 156, duration_h: 12, tempo: 'LOW', description: 'LACE report, LOGSTAT final, equipment accountability.' },
+    ],
+    units: [
+      { name: '1st Battalion, 1st Marines', type: 'BN', callsign: 'WARHORSE' },
+      { name: 'Alpha Company, 1/1', type: 'CO', callsign: 'ALPHA' },
+      { name: 'Bravo Company, 1/1', type: 'CO', callsign: 'BRAVO' },
+      { name: 'Charlie Company, 1/1', type: 'CO', callsign: 'CHARLIE' },
+      { name: 'Weapons Company, 1/1', type: 'CO', callsign: 'WEAPONS' },
+      { name: 'H&S Company, 1/1', type: 'CO', callsign: 'HEADHUNTER' },
+      { name: 'CLB-1', type: 'BN', callsign: 'IRONHORSE' },
+      { name: 'Alpha Co, CLB-1', type: 'CO', callsign: 'SUPPLY' },
+    ],
+    area_of_operation: {
+      name: '29 Palms MCAGCC',
+      center: [34.2367, -116.0542],
+      radius_km: 30,
+    },
+  },
+};
+
+// Demo mode local simulation state
+let _demoStatus: SimulatorStatus = { status: 'idle' };
+let _demoStartTime: number | null = null;
+
+// ---------------------------------------------------------------------------
+// API functions
+// ---------------------------------------------------------------------------
+
+const mockDelay = (ms = 100 + Math.random() * 100): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+export async function getScenarios(): Promise<ScenarioSummary[]> {
+  if (isDemoMode) {
+    await mockDelay();
+    return MOCK_SCENARIOS;
+  }
+  const response = await apiClient.get<ScenarioSummary[]>('/simulator/scenarios');
+  return response.data;
+}
+
+export async function getScenarioDetail(name: string): Promise<ScenarioDetail> {
+  if (isDemoMode) {
+    await mockDelay();
+    const detail = MOCK_SCENARIO_DETAILS[name];
+    if (detail) return detail;
+    // Fallback: return summary with empty phases/units
+    const summary = MOCK_SCENARIOS.find((s) => s.name === name);
+    if (!summary) throw new Error(`Scenario not found: ${name}`);
+    return {
+      ...summary,
+      phases: [
+        { name: 'Phase I', offset_h: 0, duration_h: summary.duration_days * 8, tempo: 'LOW', description: 'Initial phase' },
+        { name: 'Phase II', offset_h: summary.duration_days * 8, duration_h: summary.duration_days * 8, tempo: 'MEDIUM', description: 'Main phase' },
+        { name: 'Phase III', offset_h: summary.duration_days * 16, duration_h: summary.duration_days * 8, tempo: 'HIGH', description: 'Final phase' },
+      ],
+      units: Array.from({ length: summary.unit_count }, (_, i) => ({
+        name: `Unit ${i + 1}`,
+        type: i === 0 ? 'BN' : 'CO',
+        callsign: `UNIT-${i + 1}`,
+      })),
+    };
+  }
+  const response = await apiClient.get<ScenarioDetail>(`/simulator/scenarios/${name}`);
+  return response.data;
+}
+
+export async function getSimulatorStatus(): Promise<SimulatorStatus> {
+  if (isDemoMode) {
+    await mockDelay(50);
+    if (_demoStatus.status === 'running' && _demoStartTime) {
+      const elapsed = (Date.now() - _demoStartTime) / 1000;
+      _demoStatus.events_processed = Math.floor(elapsed * 2);
+    }
+    return { ..._demoStatus };
+  }
+  const response = await apiClient.get<SimulatorStatus>('/simulator/status');
+  return response.data;
+}
+
+export async function startSimulation(scenarioName: string, speed: number): Promise<void> {
+  if (isDemoMode) {
+    await mockDelay();
+    _demoStartTime = Date.now();
+    _demoStatus = {
+      status: 'running',
+      scenario_name: scenarioName,
+      speed,
+      started_at: new Date().toISOString(),
+      events_processed: 0,
+    };
+    return;
+  }
+  await apiClient.post('/simulator/start', { scenario_name: scenarioName, speed });
+}
+
+export async function stopSimulation(): Promise<void> {
+  if (isDemoMode) {
+    await mockDelay();
+    _demoStatus = { status: 'stopped', scenario_name: _demoStatus.scenario_name };
+    _demoStartTime = null;
+    return;
+  }
+  await apiClient.post('/simulator/stop');
+}
+
+export async function pauseSimulation(): Promise<void> {
+  if (isDemoMode) {
+    await mockDelay();
+    _demoStatus = { ..._demoStatus, status: 'paused' };
+    return;
+  }
+  await apiClient.post('/simulator/pause');
+}
+
+export async function resumeSimulation(): Promise<void> {
+  if (isDemoMode) {
+    await mockDelay();
+    _demoStatus = { ..._demoStatus, status: 'running' };
+    return;
+  }
+  await apiClient.post('/simulator/resume');
+}
+
+export async function setSimulationSpeed(speed: number): Promise<void> {
+  if (isDemoMode) {
+    await mockDelay();
+    _demoStatus = { ..._demoStatus, speed };
+    return;
+  }
+  await apiClient.post('/simulator/speed', { speed });
+}

--- a/frontend/src/components/admin/ScenarioManager.tsx
+++ b/frontend/src/components/admin/ScenarioManager.tsx
@@ -1,0 +1,1030 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Play,
+  Square,
+  Pause,
+  RotateCcw,
+  ChevronDown,
+  ChevronRight,
+  Zap,
+  Clock,
+  Users as UsersIcon,
+  MapPin,
+  Activity,
+} from 'lucide-react';
+import Card from '@/components/ui/Card';
+import {
+  getScenarios,
+  getScenarioDetail,
+  getSimulatorStatus,
+  startSimulation,
+  stopSimulation,
+  pauseSimulation,
+  resumeSimulation,
+  setSimulationSpeed,
+} from '@/api/simulator';
+import type {
+  ScenarioSummary,
+  ScenarioDetail,
+  SimulatorStatus,
+} from '@/api/simulator';
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const monoFont: React.CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+};
+
+const controlBtnStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  padding: '5px 12px',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius)',
+  backgroundColor: 'transparent',
+  color: 'var(--color-text-muted)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10,
+  fontWeight: 600,
+  letterSpacing: '0.5px',
+  cursor: 'pointer',
+};
+
+const speedBtnStyle = (isActive: boolean): React.CSSProperties => ({
+  padding: '3px 8px',
+  border: `1px solid ${isActive ? 'var(--color-accent)' : 'var(--color-border)'}`,
+  borderRadius: 'var(--radius)',
+  backgroundColor: isActive ? 'rgba(77, 171, 247, 0.15)' : 'transparent',
+  color: isActive ? 'var(--color-accent)' : 'var(--color-text-muted)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 9,
+  fontWeight: isActive ? 700 : 400,
+  cursor: 'pointer',
+});
+
+const categoryHeaderStyle: React.CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10,
+  fontWeight: 700,
+  letterSpacing: '1.5px',
+  textTransform: 'uppercase',
+  color: 'var(--color-text-muted)',
+  padding: '12px 0 6px 0',
+  borderBottom: '1px solid var(--color-border)',
+  marginBottom: 8,
+};
+
+const cardStyle: React.CSSProperties = {
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius)',
+  backgroundColor: 'var(--color-bg-elevated)',
+  padding: 12,
+  cursor: 'pointer',
+  transition: 'border-color var(--transition), background-color var(--transition)',
+};
+
+const cardHoverStyle: React.CSSProperties = {
+  ...cardStyle,
+  borderColor: 'var(--color-accent)',
+  backgroundColor: 'rgba(77, 171, 247, 0.04)',
+};
+
+const badgeStyle = (color: string): React.CSSProperties => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 3,
+  padding: '1px 6px',
+  borderRadius: 2,
+  fontSize: 9,
+  fontWeight: 600,
+  fontFamily: 'var(--font-mono)',
+  letterSpacing: '0.5px',
+  border: `1px solid ${color}`,
+  color,
+});
+
+const tempoColor = (tempo: string): string => {
+  switch (tempo) {
+    case 'LOW':
+      return '#40c057';
+    case 'MEDIUM':
+      return '#fab005';
+    case 'HIGH':
+      return '#ff6b6b';
+    default:
+      return 'var(--color-text-muted)';
+  }
+};
+
+const statusDotStyle = (status: string): React.CSSProperties => {
+  let color: string;
+  switch (status) {
+    case 'running':
+      color = '#40c057';
+      break;
+    case 'paused':
+      color = '#fab005';
+      break;
+    case 'stopped':
+      color = '#ff6b6b';
+      break;
+    default:
+      color = '#666';
+  }
+  return {
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    backgroundColor: color,
+    boxShadow: status === 'running' ? `0 0 6px ${color}` : 'none',
+    animation: status === 'running' ? 'pulse 2s ease-in-out infinite' : 'none',
+    flexShrink: 0,
+  };
+};
+
+const SPEED_OPTIONS = [
+  { label: '1x', value: 1 },
+  { label: '10x', value: 10 },
+  { label: '60x', value: 60 },
+  { label: '360x', value: 360 },
+  { label: '3600x', value: 3600 },
+];
+
+const CATEGORY_ORDER = [
+  'Pre-Deployment Training (CONUS)',
+  'Indo-Pacific',
+  'Europe / Africa / Middle East',
+  'Americas / Maritime',
+  'Crisis Response',
+  'Reserve Component',
+  'Deployment / Garrison',
+];
+
+// ---------------------------------------------------------------------------
+// Confirm Dialog sub-component
+// ---------------------------------------------------------------------------
+
+function ConfirmDialog({
+  message,
+  onConfirm,
+  onCancel,
+}: {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 3000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        backdropFilter: 'blur(2px)',
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div
+        style={{
+          width: 380,
+          backgroundColor: 'var(--color-bg-elevated)',
+          border: '1px solid var(--color-border-strong)',
+          borderRadius: 'var(--radius)',
+          boxShadow: '0 16px 48px rgba(0, 0, 0, 0.6)',
+          padding: 20,
+          fontFamily: 'var(--font-mono)',
+        }}
+      >
+        <p
+          style={{
+            fontSize: 12,
+            color: 'var(--color-text)',
+            margin: '0 0 16px 0',
+          }}
+        >
+          {message}
+        </p>
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button
+            onClick={onCancel}
+            style={{
+              ...controlBtnStyle,
+              padding: '5px 16px',
+            }}
+          >
+            CANCEL
+          </button>
+          <button
+            onClick={onConfirm}
+            style={{
+              ...controlBtnStyle,
+              borderColor: 'var(--color-danger)',
+              color: 'var(--color-danger)',
+              backgroundColor: 'rgba(255, 107, 107, 0.1)',
+              padding: '5px 16px',
+            }}
+          >
+            STOP SIMULATION
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ScenarioCard sub-component
+// ---------------------------------------------------------------------------
+
+function ScenarioCard({
+  scenario,
+  isExpanded,
+  detail,
+  isLoadingDetail,
+  onToggle,
+  onStart,
+  isSimRunning,
+}: {
+  scenario: ScenarioSummary;
+  isExpanded: boolean;
+  detail: ScenarioDetail | null;
+  isLoadingDetail: boolean;
+  onToggle: () => void;
+  onStart: (name: string) => void;
+  isSimRunning: boolean;
+}) {
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <div
+      style={hovered || isExpanded ? cardHoverStyle : cardStyle}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {/* Card Header */}
+      <div
+        onClick={onToggle}
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 8,
+        }}
+      >
+        <button
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 16,
+            height: 16,
+            flexShrink: 0,
+            marginTop: 2,
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            cursor: 'pointer',
+            color: 'var(--color-text-muted)',
+          }}
+        >
+          {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        </button>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              ...monoFont,
+              fontSize: 12,
+              fontWeight: 700,
+              color: 'var(--color-text-bright)',
+              marginBottom: 4,
+            }}
+          >
+            {scenario.display_name}
+          </div>
+          <div
+            style={{
+              ...monoFont,
+              fontSize: 10,
+              color: 'var(--color-text-muted)',
+              lineHeight: '1.4',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {scenario.description}
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              marginTop: 8,
+              flexWrap: 'wrap',
+            }}
+          >
+            <span style={badgeStyle('var(--color-accent)')}>
+              <Clock size={8} />
+              {scenario.duration_days} DAYS
+            </span>
+            <span style={badgeStyle('var(--color-text-muted)')}>
+              <Zap size={8} />
+              {scenario.phase_count} PHASES
+            </span>
+            <span style={badgeStyle('var(--color-text-muted)')}>
+              <UsersIcon size={8} />
+              {scenario.unit_count} UNITS
+            </span>
+          </div>
+        </div>
+
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onStart(scenario.name);
+          }}
+          disabled={isSimRunning}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+            padding: '4px 10px',
+            border: `1px solid ${isSimRunning ? 'var(--color-border)' : '#40c057'}`,
+            borderRadius: 'var(--radius)',
+            backgroundColor: isSimRunning ? 'transparent' : 'rgba(64, 192, 87, 0.1)',
+            color: isSimRunning ? 'var(--color-text-muted)' : '#40c057',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 9,
+            fontWeight: 700,
+            letterSpacing: '0.5px',
+            cursor: isSimRunning ? 'not-allowed' : 'pointer',
+            opacity: isSimRunning ? 0.5 : 1,
+            flexShrink: 0,
+          }}
+        >
+          <Play size={9} />
+          START
+        </button>
+      </div>
+
+      {/* Expanded Detail */}
+      {isExpanded && (
+        <div
+          style={{
+            marginTop: 12,
+            paddingTop: 12,
+            borderTop: '1px solid var(--color-border)',
+          }}
+        >
+          {isLoadingDetail ? (
+            <div
+              style={{
+                ...monoFont,
+                fontSize: 10,
+                color: 'var(--color-text-muted)',
+                padding: 8,
+              }}
+            >
+              Loading details...
+            </div>
+          ) : detail ? (
+            <>
+              {/* Phase Timeline */}
+              <div style={{ marginBottom: 12 }}>
+                <div
+                  style={{
+                    ...monoFont,
+                    fontSize: 9,
+                    fontWeight: 700,
+                    letterSpacing: '1px',
+                    color: 'var(--color-text-muted)',
+                    marginBottom: 8,
+                  }}
+                >
+                  PHASE TIMELINE
+                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    width: '100%',
+                    height: 28,
+                    borderRadius: 'var(--radius)',
+                    overflow: 'hidden',
+                    border: '1px solid var(--color-border)',
+                  }}
+                >
+                  {detail.phases.map((phase, i) => {
+                    const totalH = detail.phases.reduce(
+                      (acc, p) => acc + p.duration_h,
+                      0,
+                    );
+                    const widthPct =
+                      totalH > 0 ? (phase.duration_h / totalH) * 100 : 0;
+                    const tc = tempoColor(phase.tempo);
+                    return (
+                      <div
+                        key={i}
+                        title={`${phase.name}\n${phase.duration_h}h - ${phase.tempo} tempo\n${phase.description}`}
+                        style={{
+                          width: `${widthPct}%`,
+                          minWidth: widthPct > 3 ? undefined : 4,
+                          backgroundColor: `${tc}22`,
+                          borderRight:
+                            i < detail.phases.length - 1
+                              ? '1px solid var(--color-border)'
+                              : 'none',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          overflow: 'hidden',
+                          position: 'relative',
+                        }}
+                      >
+                        <div
+                          style={{
+                            position: 'absolute',
+                            bottom: 0,
+                            left: 0,
+                            right: 0,
+                            height: 3,
+                            backgroundColor: tc,
+                          }}
+                        />
+                        {widthPct > 12 && (
+                          <span
+                            style={{
+                              ...monoFont,
+                              fontSize: 8,
+                              color: 'var(--color-text)',
+                              whiteSpace: 'nowrap',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              padding: '0 4px',
+                            }}
+                          >
+                            {phase.name.replace(/^Phase \w+ -- /, '')}
+                          </span>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+                {/* Phase legend */}
+                <div
+                  style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 6,
+                    marginTop: 6,
+                  }}
+                >
+                  {detail.phases.map((phase, i) => (
+                    <div
+                      key={i}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 4,
+                        ...monoFont,
+                        fontSize: 9,
+                        color: 'var(--color-text-muted)',
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: 6,
+                          height: 6,
+                          borderRadius: 1,
+                          backgroundColor: tempoColor(phase.tempo),
+                        }}
+                      />
+                      <span>{phase.name}</span>
+                      <span style={{ opacity: 0.6 }}>
+                        ({phase.duration_h}h)
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Units List */}
+              <div style={{ marginBottom: 12 }}>
+                <div
+                  style={{
+                    ...monoFont,
+                    fontSize: 9,
+                    fontWeight: 700,
+                    letterSpacing: '1px',
+                    color: 'var(--color-text-muted)',
+                    marginBottom: 6,
+                  }}
+                >
+                  UNITS ({detail.units.length})
+                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 4,
+                  }}
+                >
+                  {detail.units.map((unit, i) => (
+                    <span
+                      key={i}
+                      style={{
+                        ...monoFont,
+                        fontSize: 9,
+                        padding: '2px 6px',
+                        border: '1px solid var(--color-border)',
+                        borderRadius: 2,
+                        color: 'var(--color-text)',
+                        backgroundColor: 'var(--color-bg)',
+                      }}
+                      title={`${unit.name} (${unit.type}) - ${unit.callsign}`}
+                    >
+                      {unit.callsign}
+                      <span
+                        style={{
+                          color: 'var(--color-text-muted)',
+                          marginLeft: 4,
+                          fontSize: 8,
+                        }}
+                      >
+                        {unit.type}
+                      </span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              {/* AO Info */}
+              {detail.area_of_operation && (
+                <div>
+                  <div
+                    style={{
+                      ...monoFont,
+                      fontSize: 9,
+                      fontWeight: 700,
+                      letterSpacing: '1px',
+                      color: 'var(--color-text-muted)',
+                      marginBottom: 4,
+                    }}
+                  >
+                    AREA OF OPERATIONS
+                  </div>
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      ...monoFont,
+                      fontSize: 10,
+                      color: 'var(--color-text)',
+                    }}
+                  >
+                    <MapPin size={10} style={{ color: 'var(--color-accent)' }} />
+                    {detail.area_of_operation.name}
+                    <span style={{ color: 'var(--color-text-muted)', fontSize: 9 }}>
+                      ({detail.area_of_operation.center[0].toFixed(2)},{' '}
+                      {detail.area_of_operation.center[1].toFixed(2)}) r=
+                      {detail.area_of_operation.radius_km}km
+                    </span>
+                  </div>
+                </div>
+              )}
+            </>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ScenarioManager (main component)
+// ---------------------------------------------------------------------------
+
+export default function ScenarioManager() {
+  const [scenarios, setScenarios] = useState<ScenarioSummary[]>([]);
+  const [status, setStatus] = useState<SimulatorStatus>({ status: 'idle' });
+  const [expandedScenario, setExpandedScenario] = useState<string | null>(null);
+  const [scenarioDetails, setScenarioDetails] = useState<
+    Record<string, ScenarioDetail>
+  >({});
+  const [loadingDetail, setLoadingDetail] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmStop, setConfirmStop] = useState(false);
+  const [actionLoading, setActionLoading] = useState(false);
+
+  // Load scenarios on mount
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await getScenarios();
+        if (!cancelled) {
+          setScenarios(data);
+          setLoading(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError('Failed to load scenarios');
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Poll status every 2 seconds when running
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const s = await getSimulatorStatus();
+        if (!cancelled) setStatus(s);
+      } catch {
+        // ignore polling errors
+      }
+    };
+
+    poll(); // initial fetch
+    const interval = setInterval(poll, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  // Toggle expanded scenario and load detail
+  const handleToggle = useCallback(
+    async (name: string) => {
+      if (expandedScenario === name) {
+        setExpandedScenario(null);
+        return;
+      }
+      setExpandedScenario(name);
+
+      if (!scenarioDetails[name]) {
+        setLoadingDetail(name);
+        try {
+          const detail = await getScenarioDetail(name);
+          setScenarioDetails((prev) => ({ ...prev, [name]: detail }));
+        } catch {
+          // ignore detail load errors
+        } finally {
+          setLoadingDetail(null);
+        }
+      }
+    },
+    [expandedScenario, scenarioDetails],
+  );
+
+  const handleStart = useCallback(
+    async (scenarioName: string, speed = 60) => {
+      setActionLoading(true);
+      try {
+        await startSimulation(scenarioName, speed);
+        setStatus({
+          status: 'running',
+          scenario_name: scenarioName,
+          speed,
+          started_at: new Date().toISOString(),
+          events_processed: 0,
+        });
+      } catch (err: unknown) {
+        const msg =
+          err instanceof Error ? err.message : 'Failed to start simulation';
+        setError(msg);
+      } finally {
+        setActionLoading(false);
+      }
+    },
+    [],
+  );
+
+  const handleStop = useCallback(async () => {
+    setConfirmStop(false);
+    setActionLoading(true);
+    try {
+      await stopSimulation();
+      setStatus({ status: 'stopped' });
+    } catch {
+      setError('Failed to stop simulation');
+    } finally {
+      setActionLoading(false);
+    }
+  }, []);
+
+  const handlePauseResume = useCallback(async () => {
+    setActionLoading(true);
+    try {
+      if (status.status === 'paused') {
+        await resumeSimulation();
+        setStatus((prev) => ({ ...prev, status: 'running' }));
+      } else {
+        await pauseSimulation();
+        setStatus((prev) => ({ ...prev, status: 'paused' }));
+      }
+    } catch {
+      setError('Failed to pause/resume');
+    } finally {
+      setActionLoading(false);
+    }
+  }, [status.status]);
+
+  const handleSpeedChange = useCallback(async (speed: number) => {
+    try {
+      await setSimulationSpeed(speed);
+      setStatus((prev) => ({ ...prev, speed }));
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  // Group scenarios by category
+  const grouped: Record<string, ScenarioSummary[]> = {};
+  for (const s of scenarios) {
+    const cat = s.category || 'Other';
+    if (!grouped[cat]) grouped[cat] = [];
+    grouped[cat].push(s);
+  }
+
+  const sortedCategories = CATEGORY_ORDER.filter((c) => grouped[c]);
+  // Add any categories not in the predefined order
+  for (const cat of Object.keys(grouped)) {
+    if (!sortedCategories.includes(cat)) sortedCategories.push(cat);
+  }
+
+  const isSimActive = status.status === 'running' || status.status === 'paused';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {/* Inject keyframe animation for pulse */}
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+
+      {/* Error banner */}
+      {error && (
+        <div
+          style={{
+            ...monoFont,
+            fontSize: 11,
+            color: 'var(--color-danger)',
+            padding: '8px 12px',
+            border: '1px solid var(--color-danger)',
+            borderRadius: 'var(--radius)',
+            backgroundColor: 'rgba(255, 107, 107, 0.08)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <span>{error}</span>
+          <button
+            onClick={() => setError(null)}
+            style={{
+              background: 'none',
+              border: 'none',
+              color: 'var(--color-danger)',
+              cursor: 'pointer',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+            }}
+          >
+            DISMISS
+          </button>
+        </div>
+      )}
+
+      {/* Section 1: Simulation Control Bar */}
+      <Card title="SIMULATION CONTROL">
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 16,
+            padding: 12,
+            flexWrap: 'wrap',
+          }}
+        >
+          {/* Status indicator */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
+            <div style={statusDotStyle(status.status)} />
+            <span
+              style={{
+                ...monoFont,
+                fontSize: 11,
+                fontWeight: 700,
+                color: 'var(--color-text-bright)',
+                letterSpacing: '0.5px',
+              }}
+            >
+              {status.status.toUpperCase()}
+            </span>
+          </div>
+
+          {/* Current scenario name */}
+          {status.scenario_name && (
+            <div
+              style={{
+                ...monoFont,
+                fontSize: 10,
+                color: 'var(--color-text)',
+                padding: '2px 8px',
+                border: '1px solid var(--color-border)',
+                borderRadius: 'var(--radius)',
+              }}
+            >
+              {status.scenario_name.replace(/_/g, ' ').toUpperCase()}
+            </div>
+          )}
+
+          {/* Speed display + controls */}
+          {isSimActive && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+              }}
+            >
+              <span
+                style={{
+                  ...monoFont,
+                  fontSize: 9,
+                  color: 'var(--color-text-muted)',
+                  marginRight: 4,
+                }}
+              >
+                SPEED:
+              </span>
+              {SPEED_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => handleSpeedChange(opt.value)}
+                  style={speedBtnStyle(status.speed === opt.value)}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Events processed */}
+          {isSimActive && status.events_processed != null && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+                ...monoFont,
+                fontSize: 10,
+                color: 'var(--color-text-muted)',
+              }}
+            >
+              <Activity size={10} />
+              {status.events_processed.toLocaleString()} events
+            </div>
+          )}
+
+          {/* Spacer */}
+          <div style={{ flex: 1 }} />
+
+          {/* Action buttons */}
+          <div style={{ display: 'flex', gap: 6 }}>
+            {isSimActive && (
+              <button
+                onClick={handlePauseResume}
+                disabled={actionLoading}
+                style={{
+                  ...controlBtnStyle,
+                  borderColor: status.status === 'paused' ? '#40c057' : '#fab005',
+                  color: status.status === 'paused' ? '#40c057' : '#fab005',
+                }}
+              >
+                {status.status === 'paused' ? (
+                  <>
+                    <RotateCcw size={10} /> RESUME
+                  </>
+                ) : (
+                  <>
+                    <Pause size={10} /> PAUSE
+                  </>
+                )}
+              </button>
+            )}
+
+            {isSimActive && (
+              <button
+                onClick={() => setConfirmStop(true)}
+                disabled={actionLoading}
+                style={{
+                  ...controlBtnStyle,
+                  borderColor: 'var(--color-danger)',
+                  color: 'var(--color-danger)',
+                }}
+              >
+                <Square size={10} /> STOP
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Started at / sim time row */}
+        {status.started_at && (
+          <div
+            style={{
+              display: 'flex',
+              gap: 16,
+              padding: '0 12px 12px 12px',
+              ...monoFont,
+              fontSize: 9,
+              color: 'var(--color-text-muted)',
+            }}
+          >
+            <span>
+              Started: {new Date(status.started_at).toLocaleString()}
+            </span>
+            {status.sim_time && <span>Sim Time: {status.sim_time}</span>}
+          </div>
+        )}
+      </Card>
+
+      {/* Section 2: Scenario Catalog */}
+      <Card title="SCENARIO CATALOG">
+        {loading ? (
+          <div
+            style={{
+              ...monoFont,
+              fontSize: 11,
+              color: 'var(--color-text-muted)',
+              padding: 24,
+              textAlign: 'center',
+            }}
+          >
+            Loading scenarios...
+          </div>
+        ) : (
+          <div style={{ padding: 12 }}>
+            {sortedCategories.map((category) => (
+              <div key={category} style={{ marginBottom: 16 }}>
+                <div style={categoryHeaderStyle}>{category}</div>
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))',
+                    gap: 8,
+                  }}
+                >
+                  {grouped[category].map((scenario) => (
+                    <ScenarioCard
+                      key={scenario.name}
+                      scenario={scenario}
+                      isExpanded={expandedScenario === scenario.name}
+                      detail={scenarioDetails[scenario.name] || null}
+                      isLoadingDetail={loadingDetail === scenario.name}
+                      onToggle={() => handleToggle(scenario.name)}
+                      onStart={handleStart}
+                      isSimRunning={isSimActive}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+
+      {/* Stop confirmation dialog */}
+      {confirmStop && (
+        <ConfirmDialog
+          message="Are you sure you want to stop the current simulation? This cannot be undone."
+          onConfirm={handleStop}
+          onCancel={() => setConfirmStop(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/CommanderView.tsx
+++ b/frontend/src/components/dashboard/CommanderView.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useDashboard } from '@/hooks/useDashboard';
 import { useAlerts } from '@/hooks/useAlerts';
 import SupplyStatusCard from './SupplyStatusCard';
@@ -28,36 +29,54 @@ const demoSupplyData: SupplyClassSummary[] = [
   { supplyClass: SupplyClass.II, name: 'Clothing & Equip', percentage: 88, dos: 10, status: SupplyStatus.GREEN, trend: 'UP', onHand: 8800, authorized: 10000 },
 ];
 
-const demoReadinessData = [
-  { type: 'HMMWV', percent: 87 },
-  { type: 'MTVR', percent: 74 },
-  { type: 'LAV-25', percent: 92 },
-  { type: 'AAV', percent: 68 },
-  { type: 'M777', percent: 95 },
-  { type: 'JLTV', percent: 81 },
-];
-
 const demoAlerts: Alert[] = [
   { id: '1', type: 'SUPPLY_CRITICAL' as never, severity: AlertSeverity.CRITICAL, unitId: '1-1', unitName: '1/1 BN', title: 'CL V CRITICAL', message: 'Ammunition below 50% - 2 DOS remaining', acknowledged: false, createdAt: new Date(Date.now() - 1800000).toISOString() },
   { id: '2', type: 'SUPPLY_LOW' as never, severity: AlertSeverity.WARNING, unitId: '2-1', unitName: '2/1 BN', title: 'CL III LOW', message: 'POL at 62% authorized level - consumption rate increasing', acknowledged: false, createdAt: new Date(Date.now() - 3600000).toISOString() },
   { id: '3', type: 'EQUIPMENT_DOWN' as never, severity: AlertSeverity.WARNING, unitId: '1-1', unitName: '1/1 BN', title: 'AAV READINESS DROP', message: '3x AAV NMC - parts on order, ETA 48hrs', acknowledged: false, createdAt: new Date(Date.now() - 7200000).toISOString() },
 ];
 
-const demoStatusTiles = [
-  { label: 'SUPPLY', status: SupplyStatus.AMBER, value: 74, detail: '6/10 classes green' },
-  { label: 'MAINTENANCE', status: SupplyStatus.GREEN, value: 84, detail: '312/371 MC' },
-  { label: 'TRANSPORTATION', status: SupplyStatus.GREEN, value: 91, detail: '3 active convoys' },
-  { label: 'ENGINEERING', status: SupplyStatus.GREEN, value: 95, detail: 'All projects on track' },
-  { label: 'HEALTH SVCS', status: SupplyStatus.GREEN, value: 92, detail: 'CL VIII adequate' },
-  { label: 'SERVICES', status: SupplyStatus.AMBER, value: 78, detail: '2 facilities degraded' },
-];
-
 export default function CommanderView() {
-  const { summary, supplyOverview, sustainability, isLoading } = useDashboard();
+  const { summary, supplyOverview, readiness, sustainability, isLoading } = useDashboard();
   const { alerts, acknowledgeAlert } = useAlerts();
 
   const supplyData = supplyOverview || demoSupplyData;
   const displayAlerts = alerts.length > 0 ? alerts : demoAlerts;
+
+  // Derive readiness data from API or use summary-based data
+  const readinessData = useMemo(() => {
+    if (readiness?.byType && readiness.byType.length > 0) {
+      return readiness.byType.map((r) => ({
+        type: r.type,
+        percent: r.readinessPercent,
+      }));
+    }
+    return [];
+  }, [readiness]);
+
+  // Compute status tiles from API data when available
+  const statusTiles = useMemo(() => {
+    const supplyPct = supplyOverview
+      ? Math.round(supplyOverview.reduce((s, c) => s + c.percentage, 0) / supplyOverview.length)
+      : 74;
+    const supplyGreenCount = supplyOverview
+      ? supplyOverview.filter((c) => c.status === SupplyStatus.GREEN).length
+      : 6;
+    const supplyTotal = supplyOverview ? supplyOverview.length : 10;
+
+    const maintenancePct = readiness?.overall ?? 84;
+    const maintenanceStatus = maintenancePct >= 90 ? SupplyStatus.GREEN : maintenancePct >= 75 ? SupplyStatus.AMBER : SupplyStatus.RED;
+
+    const movementCount = summary?.activeMovements ?? 3;
+
+    return [
+      { label: 'SUPPLY', status: supplyPct >= 80 ? SupplyStatus.GREEN : supplyPct >= 60 ? SupplyStatus.AMBER : SupplyStatus.RED, value: supplyPct, detail: `${supplyGreenCount}/${supplyTotal} classes green` },
+      { label: 'MAINTENANCE', status: maintenanceStatus, value: Math.round(maintenancePct), detail: readiness ? `${readiness.byType.reduce((s, r) => s + r.missionCapable, 0)}/${readiness.byType.reduce((s, r) => s + r.authorized, 0)} MC` : '312/371 MC' },
+      { label: 'TRANSPORTATION', status: SupplyStatus.GREEN, value: 91, detail: `${movementCount} active convoys` },
+      { label: 'ENGINEERING', status: SupplyStatus.GREEN, value: 95, detail: 'All projects on track' },
+      { label: 'HEALTH SVCS', status: SupplyStatus.GREEN, value: 92, detail: 'CL VIII adequate' },
+      { label: 'SERVICES', status: SupplyStatus.AMBER, value: 78, detail: '2 facilities degraded' },
+    ];
+  }, [supplyOverview, readiness, summary]);
 
   if (isLoading) {
     return (
@@ -75,7 +94,7 @@ export default function CommanderView() {
     <div className="animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
       {/* Top Row: Status Tiles */}
       <div className="grid-responsive-6col">
-        {demoStatusTiles.map((tile) => {
+        {statusTiles.map((tile) => {
           const color = getStatusColor(tile.status);
           return (
             <div
@@ -153,7 +172,7 @@ export default function CommanderView() {
               justifyItems: 'center',
             }}
           >
-            {demoReadinessData.map((eq) => (
+            {readinessData.map((eq) => (
               <ReadinessGauge key={eq.type} percent={eq.percent} label={eq.type} size={72} />
             ))}
           </div>

--- a/frontend/src/components/dashboard/S3View.tsx
+++ b/frontend/src/components/dashboard/S3View.tsx
@@ -1,8 +1,11 @@
+import { useMemo } from 'react';
 import Card from '@/components/ui/Card';
 import StatusBadge from '@/components/ui/StatusBadge';
 import StatusDot from '@/components/ui/StatusDot';
 import { SupplyStatus } from '@/lib/types';
 import { getStatusColor } from '@/lib/utils';
+import { useDashboardStore } from '@/stores/dashboardStore';
+import { DEMO_UNITS } from '@/api/mockData';
 
 // Demo unit sustainability data
 const unitCards = [
@@ -62,7 +65,41 @@ const movementFeasibility = [
   { name: 'ASR CHARLIE', status: 'RED', detail: 'Closed - IED threat' },
 ];
 
+// Map S3View card IDs to DEMO_UNITS abbreviations for filtering
+const cardUnitMapping: Record<string, string[]> = {
+  '1-1': ['1/1'],
+  '2-1': ['2/1'],
+  '3-1': ['3/1'],
+};
+
+function getDescendantUnitIds(unitId: string): string[] {
+  const ids = new Set<string>([unitId]);
+  let added = true;
+  while (added) {
+    added = false;
+    for (const u of DEMO_UNITS) {
+      if (u.parentId && ids.has(u.parentId) && !ids.has(u.id)) {
+        ids.add(u.id);
+        added = true;
+      }
+    }
+  }
+  return Array.from(ids);
+}
+
 export default function S3View() {
+  const selectedUnitId = useDashboardStore((s) => s.selectedUnitId);
+
+  const filteredUnitCards = useMemo(() => {
+    if (!selectedUnitId) return unitCards;
+    const validIds = getDescendantUnitIds(selectedUnitId);
+    const validAbbrevs = DEMO_UNITS.filter((u) => validIds.includes(u.id)).map((u) => u.abbreviation);
+    return unitCards.filter((card) => {
+      const mappedAbbrevs = cardUnitMapping[card.id] || [card.name];
+      return mappedAbbrevs.some((a) => validAbbrevs.some((v) => v.includes(a) || a.includes(v)));
+    });
+  }, [selectedUnitId]);
+
   return (
     <div className="animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
       {/* Unit Sustainability Cards */}
@@ -71,7 +108,7 @@ export default function S3View() {
           UNIT SUSTAINABILITY OVERLAY
         </div>
         <div className="grid-responsive-3col">
-          {unitCards.map((unit) => {
+          {filteredUnitCards.map((unit) => {
             const color = getStatusColor(unit.overallStatus);
             return (
               <div

--- a/frontend/src/components/dashboard/S4View.tsx
+++ b/frontend/src/components/dashboard/S4View.tsx
@@ -1,30 +1,12 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Card from '@/components/ui/Card';
 import StatusBadge from '@/components/ui/StatusBadge';
 import { SupplyStatus, SupplyClass, type SupplyRecord, type EquipmentRecord, type Movement, MovementStatus } from '@/lib/types';
 import { formatDateShort, getStatusColor } from '@/lib/utils';
 import { SUPPLY_CLASS_SHORT } from '@/lib/constants';
 import { Filter } from 'lucide-react';
-
-// Demo data
-const demoSupply: SupplyRecord[] = [
-  { id: '1', unitId: '1-1', unitName: '1/1 BN', supplyClass: SupplyClass.I, item: 'MRE Case A', onHand: 2400, authorized: 3000, required: 3000, dueIn: 0, consumptionRate: 300, dos: 8, status: SupplyStatus.GREEN, lastUpdated: '2026-03-03T08:00:00Z' },
-  { id: '2', unitId: '1-1', unitName: '1/1 BN', supplyClass: SupplyClass.III, item: 'JP-8', onHand: 12000, authorized: 20000, required: 20000, dueIn: 5000, consumptionRate: 3000, dos: 4, status: SupplyStatus.AMBER, lastUpdated: '2026-03-03T07:30:00Z' },
-  { id: '3', unitId: '2-1', unitName: '2/1 BN', supplyClass: SupplyClass.V, item: '5.56mm Ball', onHand: 45000, authorized: 100000, required: 100000, dueIn: 0, consumptionRate: 22500, dos: 2, status: SupplyStatus.RED, lastUpdated: '2026-03-03T06:00:00Z' },
-  { id: '4', unitId: '1-1', unitName: '1/1 BN', supplyClass: SupplyClass.VIII, item: 'Blood Type O+', onHand: 180, authorized: 200, required: 200, dueIn: 20, consumptionRate: 10, dos: 18, status: SupplyStatus.GREEN, lastUpdated: '2026-03-03T08:15:00Z' },
-  { id: '5', unitId: '2-1', unitName: '2/1 BN', supplyClass: SupplyClass.IX, item: 'HMMWV Parts Kit', onHand: 42, authorized: 60, required: 60, dueIn: 12, consumptionRate: 6, dos: 7, status: SupplyStatus.AMBER, lastUpdated: '2026-03-03T05:00:00Z' },
-];
-
-const demoEquipment: EquipmentRecord[] = [
-  { id: '1', unitId: '1-1', unitName: '1/1 BN', type: 'HMMWV', tamcn: 'D1092', authorized: 48, onHand: 46, missionCapable: 40, notMissionCapable: 6, readinessPercent: 87, status: SupplyStatus.GREEN, lastUpdated: '2026-03-03T08:00:00Z' },
-  { id: '2', unitId: '2-1', unitName: '2/1 BN', type: 'MTVR', tamcn: 'D0095', authorized: 24, onHand: 24, missionCapable: 18, notMissionCapable: 6, readinessPercent: 75, status: SupplyStatus.AMBER, lastUpdated: '2026-03-03T07:00:00Z' },
-  { id: '3', unitId: '1-1', unitName: '1/1 BN', type: 'AAV', tamcn: 'E0846', authorized: 12, onHand: 12, missionCapable: 8, notMissionCapable: 4, readinessPercent: 67, status: SupplyStatus.RED, lastUpdated: '2026-03-03T06:30:00Z' },
-];
-
-const demoMovements: Movement[] = [
-  { id: '1', name: 'CONVOY ALPHA', originUnit: 'CLB-1', destinationUnit: '1/1 BN', status: MovementStatus.EN_ROUTE, cargo: 'CL III, CL V', priority: 'ROUTINE', eta: '2026-03-03T16:00:00Z', vehicles: 8, personnel: 16, lastUpdated: '2026-03-03T08:00:00Z' },
-  { id: '2', name: 'CONVOY BRAVO', originUnit: 'CLB-1', destinationUnit: '2/1 BN', status: MovementStatus.PLANNED, cargo: 'CL IX', priority: 'PRIORITY', departureTime: '2026-03-04T06:00:00Z', vehicles: 4, personnel: 8, lastUpdated: '2026-03-03T07:00:00Z' },
-];
+import { useDashboardStore } from '@/stores/dashboardStore';
+import { mockApi } from '@/api/mockClient';
 
 const tableHeaderStyle: React.CSSProperties = {
   fontFamily: 'var(--font-mono)',
@@ -49,11 +31,21 @@ const tableCellStyle: React.CSSProperties = {
 
 export default function S4View() {
   const [supplyFilter, setSupplyFilter] = useState<string>('ALL');
+  const selectedUnitId = useDashboardStore((s) => s.selectedUnitId);
+  const [supplyData, setSupplyData] = useState<SupplyRecord[]>([]);
+  const [equipmentData, setEquipmentData] = useState<EquipmentRecord[]>([]);
+  const [movementData, setMovementData] = useState<Movement[]>([]);
+
+  useEffect(() => {
+    mockApi.getSupplyRecords({ unitId: selectedUnitId ?? undefined }).then((r) => setSupplyData(r.data));
+    mockApi.getEquipmentRecords({ unitId: selectedUnitId ?? undefined }).then((r) => setEquipmentData(r.data));
+    mockApi.getMovements({ unitId: selectedUnitId ?? undefined }).then(setMovementData);
+  }, [selectedUnitId]);
 
   const filteredSupply =
     supplyFilter === 'ALL'
-      ? demoSupply
-      : demoSupply.filter((s) => s.supplyClass === supplyFilter);
+      ? supplyData
+      : supplyData.filter((s) => s.supplyClass === supplyFilter);
 
   return (
     <div className="animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -168,7 +160,7 @@ export default function S4View() {
                 </tr>
               </thead>
               <tbody>
-                {demoEquipment.map((eq) => (
+                {equipmentData.map((eq) => (
                   <tr
                     key={eq.id}
                     style={{ transition: 'background-color var(--transition)' }}
@@ -212,7 +204,7 @@ export default function S4View() {
         {/* Active Movements */}
         <Card title="ACTIVE MOVEMENTS">
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {demoMovements.map((mov) => {
+            {movementData.map((mov) => {
               const movColor =
                 mov.status === MovementStatus.EN_ROUTE
                   ? 'var(--color-accent)'

--- a/frontend/src/components/equipment/MaintenanceQueue.tsx
+++ b/frontend/src/components/equipment/MaintenanceQueue.tsx
@@ -6,6 +6,7 @@ import { formatRelativeTime } from '@/lib/utils';
 import type { MaintenanceWorkOrder } from '@/lib/types';
 import { WorkOrderStatus } from '@/lib/types';
 import { getWorkOrders } from '@/api/maintenance';
+import { useDashboardStore } from '@/stores/dashboardStore';
 import WorkOrderDetailModal from './WorkOrderDetailModal';
 import CreateWorkOrderModal from './CreateWorkOrderModal';
 
@@ -40,10 +41,11 @@ export default function MaintenanceQueue() {
   const [workOrders, setWorkOrders] = useState<MaintenanceWorkOrder[]>([]);
   const [selectedWO, setSelectedWO] = useState<MaintenanceWorkOrder | null>(null);
   const [showCreate, setShowCreate] = useState(false);
+  const selectedUnitId = useDashboardStore((s) => s.selectedUnitId);
 
   const loadWorkOrders = useCallback(async () => {
     try {
-      const result = await getWorkOrders({});
+      const result = await getWorkOrders({ unitId: selectedUnitId ?? undefined });
       // Show only non-complete work orders in the queue
       const openOrders = result.data.filter(
         (wo) => wo.status !== WorkOrderStatus.COMPLETE,
@@ -52,7 +54,7 @@ export default function MaintenanceQueue() {
     } catch (err) {
       console.error('Failed to load work orders:', err);
     }
-  }, []);
+  }, [selectedUnitId]);
 
   useEffect(() => {
     loadWorkOrders();

--- a/frontend/src/components/equipment/ReadinessTable.tsx
+++ b/frontend/src/components/equipment/ReadinessTable.tsx
@@ -8,27 +8,27 @@ import {
   createColumnHelper,
   type SortingState,
 } from '@tanstack/react-table';
+import { useQuery } from '@tanstack/react-query';
 import { ArrowUpDown, ArrowUp, ArrowDown, ChevronRight } from 'lucide-react';
-import { SupplyStatus, type EquipmentRecord } from '@/lib/types';
+import { type EquipmentRecord } from '@/lib/types';
 import { getStatusColor } from '@/lib/utils';
 import StatusBadge from '@/components/ui/StatusBadge';
-
-const demoData: EquipmentRecord[] = [
-  { id: '1', unitId: '1-1', unitName: '1/1 BN', type: 'HMMWV', tamcn: 'D1092', authorized: 48, onHand: 46, missionCapable: 40, notMissionCapable: 6, readinessPercent: 87, status: SupplyStatus.GREEN, lastUpdated: '2026-03-03T08:00:00Z' },
-  { id: '2', unitId: '2-1', unitName: '2/1 BN', type: 'HMMWV', tamcn: 'D1092', authorized: 48, onHand: 48, missionCapable: 44, notMissionCapable: 4, readinessPercent: 92, status: SupplyStatus.GREEN, lastUpdated: '2026-03-03T07:00:00Z' },
-  { id: '3', unitId: '1-1', unitName: '1/1 BN', type: 'MTVR', tamcn: 'D0095', authorized: 24, onHand: 24, missionCapable: 18, notMissionCapable: 6, readinessPercent: 75, status: SupplyStatus.AMBER, lastUpdated: '2026-03-03T07:00:00Z' },
-  { id: '4', unitId: '2-1', unitName: '2/1 BN', type: 'MTVR', tamcn: 'D0095', authorized: 24, onHand: 22, missionCapable: 20, notMissionCapable: 2, readinessPercent: 91, status: SupplyStatus.GREEN, lastUpdated: '2026-03-03T06:00:00Z' },
-  { id: '5', unitId: '1-1', unitName: '1/1 BN', type: 'LAV-25', tamcn: 'E0846', authorized: 16, onHand: 16, missionCapable: 15, notMissionCapable: 1, readinessPercent: 94, status: SupplyStatus.GREEN, lastUpdated: '2026-03-03T08:00:00Z' },
-  { id: '6', unitId: '1-1', unitName: '1/1 BN', type: 'AAV', tamcn: 'E0902', authorized: 12, onHand: 12, missionCapable: 8, notMissionCapable: 4, readinessPercent: 67, status: SupplyStatus.RED, lastUpdated: '2026-03-03T06:30:00Z' },
-  { id: '7', unitId: '2-1', unitName: '2/1 BN', type: 'M777', tamcn: 'D1168', authorized: 6, onHand: 6, missionCapable: 6, notMissionCapable: 0, readinessPercent: 100, status: SupplyStatus.GREEN, lastUpdated: '2026-03-03T08:00:00Z' },
-  { id: '8', unitId: '1-1', unitName: '1/1 BN', type: 'JLTV', tamcn: 'D1200', authorized: 36, onHand: 34, missionCapable: 28, notMissionCapable: 6, readinessPercent: 82, status: SupplyStatus.AMBER, lastUpdated: '2026-03-03T07:00:00Z' },
-];
+import { getEquipmentRecords } from '@/api/equipment';
+import { useDashboardStore } from '@/stores/dashboardStore';
 
 const columnHelper = createColumnHelper<EquipmentRecord>();
 
 export default function ReadinessTable() {
   const [sorting, setSorting] = useState<SortingState>([]);
   const navigate = useNavigate();
+  const selectedUnitId = useDashboardStore((s) => s.selectedUnitId);
+
+  const { data: apiData } = useQuery({
+    queryKey: ['equipment', 'readiness-table', selectedUnitId],
+    queryFn: () => getEquipmentRecords({ unitId: selectedUnitId ?? undefined }),
+  });
+
+  const tableData = useMemo(() => apiData?.data || [], [apiData]);
 
   const columns = useMemo(
     () => [
@@ -75,7 +75,7 @@ export default function ReadinessTable() {
   );
 
   const table = useReactTable({
-    data: demoData,
+    data: tableData,
     columns,
     state: { sorting },
     onSortingChange: setSorting,

--- a/frontend/src/components/reports/ExportDestinations.tsx
+++ b/frontend/src/components/reports/ExportDestinations.tsx
@@ -1,0 +1,297 @@
+import { useEffect, useState } from 'react';
+import { Plus, Trash2, Edit2, Check, X, Globe, Loader } from 'lucide-react';
+import Card from '@/components/ui/Card';
+import type { ExportDestination, ExportDestinationCreate } from '@/lib/types';
+import {
+  getExportDestinations,
+  createExportDestination,
+  updateExportDestination,
+  deleteExportDestination,
+} from '@/api/reports';
+
+const AUTH_TYPES = [
+  { value: 'none', label: 'None' },
+  { value: 'bearer', label: 'Bearer Token' },
+  { value: 'api_key', label: 'API Key' },
+  { value: 'basic', label: 'Basic Auth' },
+] as const;
+
+export default function ExportDestinations() {
+  const [destinations, setDestinations] = useState<ExportDestination[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  // Form state
+  const [formName, setFormName] = useState('');
+  const [formUrl, setFormUrl] = useState('');
+  const [formAuthType, setFormAuthType] = useState<'none' | 'bearer' | 'api_key' | 'basic'>('none');
+  const [formAuthValue, setFormAuthValue] = useState('');
+  const [formActive, setFormActive] = useState(true);
+
+  useEffect(() => {
+    loadDestinations();
+  }, []);
+
+  const loadDestinations = async () => {
+    try {
+      const dests = await getExportDestinations();
+      setDestinations(dests);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const resetForm = () => {
+    setFormName('');
+    setFormUrl('');
+    setFormAuthType('none');
+    setFormAuthValue('');
+    setFormActive(true);
+    setEditingId(null);
+    setShowForm(false);
+  };
+
+  const startEdit = (dest: ExportDestination) => {
+    setFormName(dest.name);
+    setFormUrl(dest.url);
+    setFormAuthType(dest.auth_type);
+    setFormAuthValue(dest.auth_value || '');
+    setFormActive(dest.is_active);
+    setEditingId(dest.id);
+    setShowForm(true);
+  };
+
+  const handleSave = async () => {
+    if (!formName || !formUrl) return;
+    setSaving(true);
+    try {
+      if (editingId) {
+        const updated = await updateExportDestination(editingId, {
+          name: formName,
+          url: formUrl,
+          auth_type: formAuthType,
+          auth_value: formAuthValue || undefined,
+          is_active: formActive,
+        });
+        setDestinations((prev) => prev.map((d) => (d.id === editingId ? updated : d)));
+      } else {
+        const data: ExportDestinationCreate = {
+          name: formName,
+          url: formUrl,
+          auth_type: formAuthType,
+          auth_value: formAuthValue || undefined,
+          is_active: formActive,
+        };
+        const created = await createExportDestination(data);
+        setDestinations((prev) => [...prev, created]);
+      }
+      resetForm();
+    } catch {
+      // ignore
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteExportDestination(id);
+      setDestinations((prev) => prev.filter((d) => d.id !== id));
+    } catch {
+      // ignore
+    }
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '6px 8px',
+    backgroundColor: 'var(--color-bg)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 'var(--radius)',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 11,
+    color: 'var(--color-text)',
+    boxSizing: 'border-box',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontFamily: 'var(--font-mono)',
+    fontSize: 8,
+    textTransform: 'uppercase',
+    letterSpacing: '1.5px',
+    color: 'var(--color-text-muted)',
+    display: 'block',
+    marginBottom: 3,
+  };
+
+  const smallBtnStyle: React.CSSProperties = {
+    display: 'flex', alignItems: 'center', gap: 3, padding: '3px 6px',
+    backgroundColor: 'transparent', border: '1px solid var(--color-border)',
+    borderRadius: 'var(--radius)', cursor: 'pointer',
+    fontFamily: 'var(--font-mono)', fontSize: 8, color: 'var(--color-text-muted)',
+    letterSpacing: '0.5px',
+  };
+
+  return (
+    <Card
+      title="EXPORT DESTINATIONS"
+      headerRight={
+        !showForm ? (
+          <button
+            onClick={() => { resetForm(); setShowForm(true); }}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 4, padding: '4px 10px',
+              backgroundColor: 'var(--color-accent)', border: 'none',
+              borderRadius: 'var(--radius)', color: 'var(--color-bg)',
+              fontFamily: 'var(--font-mono)', fontSize: 9, fontWeight: 600, letterSpacing: '1px', cursor: 'pointer',
+            }}
+          >
+            <Plus size={10} /> ADD
+          </button>
+        ) : undefined
+      }
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {/* Add/Edit Form */}
+        {showForm && (
+          <div style={{
+            padding: 12, backgroundColor: 'var(--color-bg)',
+            border: '1px solid var(--color-accent)', borderRadius: 'var(--radius)',
+            display: 'flex', flexDirection: 'column', gap: 10,
+          }}>
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 600, color: 'var(--color-accent)', letterSpacing: '1px' }}>
+              {editingId ? 'EDIT DESTINATION' : 'NEW DESTINATION'}
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+              <div>
+                <label style={labelStyle}>NAME</label>
+                <input value={formName} onChange={(e) => setFormName(e.target.value)} placeholder="GCSS-MC API" style={inputStyle} />
+              </div>
+              <div>
+                <label style={labelStyle}>AUTH TYPE</label>
+                <select value={formAuthType} onChange={(e) => setFormAuthType(e.target.value as typeof formAuthType)} style={inputStyle}>
+                  {AUTH_TYPES.map((a) => <option key={a.value} value={a.value}>{a.label}</option>)}
+                </select>
+              </div>
+            </div>
+
+            <div>
+              <label style={labelStyle}>URL</label>
+              <input value={formUrl} onChange={(e) => setFormUrl(e.target.value)} placeholder="https://api.example.mil/reports" style={inputStyle} />
+            </div>
+
+            {formAuthType !== 'none' && (
+              <div>
+                <label style={labelStyle}>AUTH VALUE ({formAuthType === 'bearer' ? 'Token' : formAuthType === 'api_key' ? 'API Key' : 'Credentials'})</label>
+                <input
+                  type="password"
+                  value={formAuthValue}
+                  onChange={(e) => setFormAuthValue(e.target.value)}
+                  style={inputStyle}
+                />
+              </div>
+            )}
+
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <input
+                type="checkbox"
+                checked={formActive}
+                onChange={(e) => setFormActive(e.target.checked)}
+                style={{ accentColor: 'var(--color-accent)' }}
+              />
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--color-text)' }}>Active</span>
+            </div>
+
+            <div style={{ display: 'flex', gap: 6 }}>
+              <button
+                onClick={handleSave}
+                disabled={saving || !formName || !formUrl}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 4, padding: '6px 14px',
+                  backgroundColor: (!formName || !formUrl || saving) ? 'var(--color-bg-surface)' : 'var(--color-accent)',
+                  border: (!formName || !formUrl || saving) ? '1px solid var(--color-border)' : 'none',
+                  borderRadius: 'var(--radius)',
+                  color: (!formName || !formUrl || saving) ? 'var(--color-text-muted)' : 'var(--color-bg)',
+                  fontFamily: 'var(--font-mono)', fontSize: 9, fontWeight: 600, letterSpacing: '1px',
+                  cursor: (!formName || !formUrl || saving) ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {saving ? <Loader size={10} className="animate-spin" /> : <Check size={10} />}
+                {saving ? 'SAVING...' : 'SAVE'}
+              </button>
+              <button onClick={resetForm} style={{
+                display: 'flex', alignItems: 'center', gap: 4, padding: '6px 14px',
+                backgroundColor: 'transparent', border: '1px solid var(--color-border)',
+                borderRadius: 'var(--radius)', color: 'var(--color-text-muted)',
+                fontFamily: 'var(--font-mono)', fontSize: 9, letterSpacing: '1px', cursor: 'pointer',
+              }}>
+                <X size={10} /> CANCEL
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Destination List */}
+        {loading ? (
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-text-muted)', padding: 16, textAlign: 'center' }}>
+            Loading destinations...
+          </div>
+        ) : destinations.length === 0 ? (
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-text-muted)', padding: 16, textAlign: 'center' }}>
+            No export destinations configured yet.
+          </div>
+        ) : (
+          destinations.map((d) => (
+            <div key={d.id} style={{
+              display: 'flex', alignItems: 'center', gap: 10,
+              padding: '8px 10px', backgroundColor: 'var(--color-bg-surface)',
+              border: '1px solid var(--color-border)', borderRadius: 'var(--radius)',
+            }}>
+              <Globe size={14} style={{ color: d.is_active ? 'var(--color-green, #22c55e)' : 'var(--color-text-muted)', flexShrink: 0 }} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-text-bright)', fontWeight: 600 }}>
+                    {d.name}
+                  </span>
+                  <span style={{
+                    fontFamily: 'var(--font-mono)', fontSize: 8, padding: '1px 5px',
+                    borderRadius: 'var(--radius)', backgroundColor: d.is_active ? 'rgba(34,197,94,0.1)' : 'rgba(255,255,255,0.05)',
+                    border: d.is_active ? '1px solid rgba(34,197,94,0.3)' : '1px solid var(--color-border)',
+                    color: d.is_active ? 'var(--color-green, #22c55e)' : 'var(--color-text-muted)',
+                    textTransform: 'uppercase', letterSpacing: '0.5px',
+                  }}>
+                    {d.is_active ? 'ACTIVE' : 'INACTIVE'}
+                  </span>
+                  <span style={{
+                    fontFamily: 'var(--font-mono)', fontSize: 8, padding: '1px 5px',
+                    borderRadius: 'var(--radius)', backgroundColor: 'var(--color-bg)',
+                    border: '1px solid var(--color-border)', color: 'var(--color-text-muted)',
+                    textTransform: 'uppercase', letterSpacing: '0.5px',
+                  }}>
+                    {d.auth_type}
+                  </span>
+                </div>
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--color-text-muted)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {d.url}
+                </div>
+              </div>
+              <div style={{ display: 'flex', gap: 4 }}>
+                <button onClick={() => startEdit(d)} style={smallBtnStyle}>
+                  <Edit2 size={9} /> EDIT
+                </button>
+                <button onClick={() => handleDelete(d.id)} style={{ ...smallBtnStyle, borderColor: 'rgba(239,68,68,0.3)', color: 'var(--color-red, #ef4444)' }}>
+                  <Trash2 size={9} /> DEL
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/reports/ReportViewer.tsx
+++ b/frontend/src/components/reports/ReportViewer.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
-import { FileText, Check, Download, Clock, User } from 'lucide-react';
+import { FileText, Check, Download, Clock, User, FileDown, Send, X, Loader } from 'lucide-react';
 import Card from '@/components/ui/Card';
 import StatusBadge from '@/components/ui/StatusBadge';
 import { ReportStatus, ReportType } from '@/lib/types';
-import type { Report, ReportContent } from '@/lib/types';
+import type { Report, ReportContent, ExportDestination, ApiExportResultItem } from '@/lib/types';
 import { formatDate } from '@/lib/utils';
-import { getReports, finalizeReport as apiFinalizeReport } from '@/api/reports';
+import { getReports, finalizeReport as apiFinalizeReport, exportReportPdf, getExportDestinations, exportReportToApi } from '@/api/reports';
 import { useReportStore } from '@/stores/reportStore';
 
 function getReportStatusColor(status: ReportStatus | string) {
@@ -36,6 +36,8 @@ function statusColor(s: string): string {
 export default function ReportViewer() {
   const { selectedReport, generatedReports, setSelectedReport, setReports, updateReport } = useReportStore();
   const [loading, setLoading] = useState(true);
+  const [pdfLoading, setPdfLoading] = useState(false);
+  const [showApiExportModal, setShowApiExportModal] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -85,6 +87,35 @@ export default function ReportViewer() {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
+  };
+
+  const handleExportPdf = async () => {
+    if (!selectedReport) return;
+    setPdfLoading(true);
+    try {
+      const blob = await exportReportPdf(selectedReport.id);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${selectedReport.title.replace(/[^a-zA-Z0-9-_ ]/g, '') || 'report'}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      // Silently fail in demo
+    } finally {
+      setPdfLoading(false);
+    }
+  };
+
+  const exportBtnStyle: React.CSSProperties = {
+    display: 'flex', alignItems: 'center', gap: 4, padding: '4px 10px',
+    backgroundColor: 'transparent',
+    border: '1px solid var(--color-border-strong)',
+    borderRadius: 'var(--radius)',
+    color: 'var(--color-text-muted)',
+    fontFamily: 'var(--font-mono)', fontSize: 9, letterSpacing: '1px', cursor: 'pointer',
   };
 
   return (
@@ -162,18 +193,15 @@ export default function ReportViewer() {
                   <Check size={10} /> FINALIZE
                 </button>
               )}
-              <button
-                onClick={handleExport}
-                style={{
-                  display: 'flex', alignItems: 'center', gap: 4, padding: '4px 10px',
-                  backgroundColor: 'transparent',
-                  border: '1px solid var(--color-border-strong)',
-                  borderRadius: 'var(--radius)',
-                  color: 'var(--color-text-muted)',
-                  fontFamily: 'var(--font-mono)', fontSize: 9, letterSpacing: '1px', cursor: 'pointer',
-                }}
-              >
-                <Download size={10} /> EXPORT
+              <button onClick={handleExportPdf} disabled={pdfLoading} style={exportBtnStyle}>
+                {pdfLoading ? <Loader size={10} className="animate-spin" /> : <FileDown size={10} />}
+                {pdfLoading ? 'GENERATING...' : 'EXPORT PDF'}
+              </button>
+              <button onClick={() => setShowApiExportModal(true)} style={exportBtnStyle}>
+                <Send size={10} /> EXPORT TO API
+              </button>
+              <button onClick={handleExport} style={exportBtnStyle}>
+                <Download size={10} /> EXPORT TXT
               </button>
             </div>
           }
@@ -199,6 +227,188 @@ export default function ReportViewer() {
           }
         </Card>
       )}
+
+      {/* API Export Modal */}
+      {showApiExportModal && selectedReport && (
+        <ApiExportModal
+          reportId={selectedReport.id}
+          onClose={() => setShowApiExportModal(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// API Export Modal
+// ---------------------------------------------------------------------------
+
+function ApiExportModal({ reportId, onClose }: { reportId: string; onClose: () => void }) {
+  const [destinations, setDestinations] = useState<ExportDestination[]>([]);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [results, setResults] = useState<ApiExportResultItem[] | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const dests = await getExportDestinations();
+        setDestinations(dests.filter((d) => d.is_active));
+      } catch {
+        // ignore
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const toggleDest = (id: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleSend = async () => {
+    if (selected.size === 0) return;
+    setSending(true);
+    try {
+      const resp = await exportReportToApi(reportId, Array.from(selected));
+      setResults(resp.results);
+    } catch {
+      setResults([]);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const overlayStyle: React.CSSProperties = {
+    position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.6)', display: 'flex',
+    alignItems: 'center', justifyContent: 'center', zIndex: 9999,
+  };
+
+  const modalStyle: React.CSSProperties = {
+    backgroundColor: 'var(--color-bg-surface)', border: '1px solid var(--color-border)',
+    borderRadius: 'var(--radius)', padding: 20, minWidth: 400, maxWidth: 500,
+    maxHeight: '80vh', overflow: 'auto',
+  };
+
+  const checkboxRowStyle: React.CSSProperties = {
+    display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px',
+    backgroundColor: 'var(--color-bg)', borderRadius: 'var(--radius)',
+    border: '1px solid var(--color-border)', cursor: 'pointer',
+  };
+
+  return (
+    <div style={overlayStyle} onClick={onClose}>
+      <div style={modalStyle} onClick={(e) => e.stopPropagation()}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 12, fontWeight: 700, letterSpacing: '1.5px', color: 'var(--color-text-bright)' }}>
+            EXPORT TO API
+          </div>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-muted)' }}>
+            <X size={16} />
+          </button>
+        </div>
+
+        {loading ? (
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-text-muted)', textAlign: 'center', padding: 20 }}>
+            Loading destinations...
+          </div>
+        ) : destinations.length === 0 ? (
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-text-muted)', textAlign: 'center', padding: 20 }}>
+            No active export destinations configured.
+          </div>
+        ) : results ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 600, color: 'var(--color-text-muted)', textTransform: 'uppercase', letterSpacing: '1px', marginBottom: 4 }}>
+              EXPORT RESULTS
+            </div>
+            {results.map((r) => (
+              <div key={r.destination_id} style={{
+                ...checkboxRowStyle,
+                borderColor: r.success ? 'var(--color-green, #22c55e)' : 'var(--color-red, #ef4444)',
+                cursor: 'default',
+              }}>
+                <div style={{
+                  width: 8, height: 8, borderRadius: '50%',
+                  backgroundColor: r.success ? 'var(--color-green, #22c55e)' : 'var(--color-red, #ef4444)',
+                }} />
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-text-bright)', fontWeight: 600 }}>
+                    {r.destination_name}
+                  </div>
+                  <div style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--color-text-muted)' }}>
+                    {r.success ? `Success (${r.status_code})` : `Failed: ${r.error || 'Unknown error'}`}
+                  </div>
+                </div>
+              </div>
+            ))}
+            <button
+              onClick={onClose}
+              style={{
+                marginTop: 8, padding: '8px 16px', backgroundColor: 'var(--color-accent)',
+                border: 'none', borderRadius: 'var(--radius)', color: 'var(--color-bg)',
+                fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 600, letterSpacing: '1px', cursor: 'pointer',
+              }}
+            >
+              CLOSE
+            </button>
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 600, color: 'var(--color-text-muted)', textTransform: 'uppercase', letterSpacing: '1px', marginBottom: 4 }}>
+              SELECT DESTINATIONS
+            </div>
+            {destinations.map((d) => (
+              <div key={d.id} style={checkboxRowStyle} onClick={() => toggleDest(d.id)}>
+                <input
+                  type="checkbox"
+                  checked={selected.has(d.id)}
+                  onChange={() => toggleDest(d.id)}
+                  style={{ accentColor: 'var(--color-accent)' }}
+                />
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-text-bright)', fontWeight: 600 }}>
+                    {d.name}
+                  </div>
+                  <div style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--color-text-muted)' }}>
+                    {d.url}
+                  </div>
+                </div>
+                <div style={{
+                  fontFamily: 'var(--font-mono)', fontSize: 8, padding: '2px 6px',
+                  borderRadius: 'var(--radius)', backgroundColor: 'var(--color-bg-surface)',
+                  border: '1px solid var(--color-border)', color: 'var(--color-text-muted)',
+                  textTransform: 'uppercase', letterSpacing: '0.5px',
+                }}>
+                  {d.auth_type}
+                </div>
+              </div>
+            ))}
+            <button
+              onClick={handleSend}
+              disabled={selected.size === 0 || sending}
+              style={{
+                marginTop: 8, padding: '8px 16px',
+                backgroundColor: selected.size === 0 || sending ? 'var(--color-bg-surface)' : 'var(--color-accent)',
+                border: selected.size === 0 || sending ? '1px solid var(--color-border)' : 'none',
+                borderRadius: 'var(--radius)',
+                color: selected.size === 0 || sending ? 'var(--color-text-muted)' : 'var(--color-bg)',
+                fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 600, letterSpacing: '1px',
+                cursor: selected.size === 0 || sending ? 'not-allowed' : 'pointer',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+              }}
+            >
+              {sending ? <><Loader size={12} className="animate-spin" /> SENDING...</> : <><Send size={12} /> SEND TO {selected.size} DESTINATION{selected.size !== 1 ? 'S' : ''}</>}
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -483,6 +483,50 @@ export interface GenerateReportParams {
   title?: string;
 }
 
+// Export Destinations
+
+export interface ExportDestination {
+  id: number;
+  name: string;
+  url: string;
+  auth_type: 'none' | 'bearer' | 'api_key' | 'basic';
+  auth_value?: string | null;
+  headers?: Record<string, string> | null;
+  is_active: boolean;
+  created_at: string;
+}
+
+export interface ExportDestinationCreate {
+  name: string;
+  url: string;
+  auth_type: 'none' | 'bearer' | 'api_key' | 'basic';
+  auth_value?: string;
+  headers?: Record<string, string>;
+  is_active?: boolean;
+}
+
+export interface ExportDestinationUpdate {
+  name?: string;
+  url?: string;
+  auth_type?: 'none' | 'bearer' | 'api_key' | 'basic';
+  auth_value?: string;
+  headers?: Record<string, string>;
+  is_active?: boolean;
+}
+
+export interface ApiExportResultItem {
+  destination_id: number;
+  destination_name: string;
+  success: boolean;
+  status_code?: number | null;
+  error?: string | null;
+}
+
+export interface ApiExportResponse {
+  report_id: number;
+  results: ApiExportResultItem[];
+}
+
 // Personnel tracking enums
 
 export enum PersonnelStatus {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
-import { Users, Settings, Shield, Layers, Plus, Edit3, Save, Check, X, Trash2 } from 'lucide-react';
+import { Users, Settings, Shield, Layers, Plus, Edit3, Save, Check, X, Trash2, Crosshair } from 'lucide-react';
 import Card from '@/components/ui/Card';
 import StatusBadge from '@/components/ui/StatusBadge';
 import StatusDot from '@/components/ui/StatusDot';
 import UnitTreeView from '@/components/admin/UnitTreeView';
 import TileLayerSettings from '@/components/admin/TileLayerSettings';
+import ScenarioManager from '@/components/admin/ScenarioManager';
 import { Role, Echelon, type User, type Unit } from '@/lib/types';
 import { ECHELON_ORDER, ECHELON_ALLOWED_CHILDREN } from '@/lib/constants';
 import { mockApi } from '@/api/mockClient';
@@ -179,7 +180,7 @@ const addButtonStyle: React.CSSProperties = {
 // ---------------------------------------------------------------------------
 
 export default function AdminPage() {
-  const [activeTab, setActiveTab] = useState<'users' | 'units' | 'classification' | 'tiles'>('users');
+  const [activeTab, setActiveTab] = useState<'users' | 'units' | 'classification' | 'tiles' | 'scenarios'>('users');
   const { classification, updateClassification } = useClassificationStore();
 
   // ── User management state ──
@@ -379,6 +380,7 @@ export default function AdminPage() {
           { key: 'units' as const, label: 'UNIT CONFIGURATION', icon: Settings },
           { key: 'classification' as const, label: 'CLASSIFICATION', icon: Shield },
           { key: 'tiles' as const, label: 'MAP TILES', icon: Layers },
+          { key: 'scenarios' as const, label: 'SCENARIOS', icon: Crosshair },
         ].map((tab) => (
           <button
             key={tab.key}
@@ -749,6 +751,9 @@ export default function AdminPage() {
 
       {/* ── Map Tiles Tab ── */}
       {activeTab === 'tiles' && <TileLayerSettings />}
+
+      {/* ── Scenarios Tab ── */}
+      {activeTab === 'scenarios' && <ScenarioManager />}
 
       {/* ── User Add/Edit Modal ── */}
       {userModalOpen && (

--- a/frontend/src/pages/AlertsPage.tsx
+++ b/frontend/src/pages/AlertsPage.tsx
@@ -1,19 +1,12 @@
 import { useState } from 'react';
 import { AlertTriangle, AlertCircle, Info, Check, Filter } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
 import Card from '@/components/ui/Card';
 import StatusDot from '@/components/ui/StatusDot';
 import { AlertSeverity, type Alert } from '@/lib/types';
 import { formatDate, formatRelativeTime } from '@/lib/utils';
-
-const demoAlerts: Alert[] = [
-  { id: '1', type: 'SUPPLY_CRITICAL' as never, severity: AlertSeverity.CRITICAL, unitId: '2-1', unitName: '2/1 BN', title: 'CL V AMMUNITION CRITICAL', message: '5.56mm Ball at 45% authorized level. 2 DOS remaining at current consumption rate. Emergency resupply requested.', acknowledged: false, createdAt: '2026-03-03T06:00:00Z' },
-  { id: '2', type: 'SUPPLY_LOW' as never, severity: AlertSeverity.WARNING, unitId: '1-1', unitName: '1/1 BN', title: 'CL III POL LOW', message: 'JP-8 at 62% authorized. Consumption rate exceeding projections. 4 DOS remaining.', acknowledged: false, createdAt: '2026-03-03T07:30:00Z' },
-  { id: '3', type: 'EQUIPMENT_DOWN' as never, severity: AlertSeverity.WARNING, unitId: '1-1', unitName: '1/1 BN', title: 'AAV READINESS BELOW THRESHOLD', message: '4x AAV NMC (33%). Water pump failure on AAV-12, transmission leak on AAV-08. Parts on backorder, ETA 48hrs.', acknowledged: false, createdAt: '2026-03-03T06:30:00Z' },
-  { id: '4', type: 'MOVEMENT_DELAYED' as never, severity: AlertSeverity.WARNING, unitId: 'clb-1', unitName: 'CLB-1', title: 'CONVOY CHARLIE DELAYED', message: 'Delayed due to MSR BRAVO bridge restriction. Rerouting via ASR DELTA. New ETA +4hrs.', acknowledged: false, createdAt: '2026-03-03T08:00:00Z' },
-  { id: '5', type: 'READINESS_DROP' as never, severity: AlertSeverity.CRITICAL, unitId: '3-1', unitName: '3/1 BN', title: 'UNIT READINESS CRITICAL', message: '3/1 BN overall readiness dropped to 68%. Multiple supply classes AMBER/RED. Sustainability at 3 DOS.', acknowledged: false, createdAt: '2026-03-03T05:00:00Z' },
-  { id: '6', type: 'SUPPLY_LOW' as never, severity: AlertSeverity.WARNING, unitId: '2-1', unitName: '2/1 BN', title: 'CL IX PARTS SHORTAGE', message: 'HMMWV repair parts at 70%. Multiple items on backorder. Expected impact on vehicle readiness.', acknowledged: true, acknowledgedBy: 'sgt.jones', acknowledgedAt: '2026-03-03T07:00:00Z', createdAt: '2026-03-03T04:00:00Z' },
-  { id: '7', type: 'INGESTION_ERROR' as never, severity: AlertSeverity.INFO, unitId: '', unitName: 'SYSTEM', title: 'INGESTION PARSE ERROR', message: 'File bad_format.txt could not be parsed. Unrecognized format.', acknowledged: true, acknowledgedBy: 'cpl.smith', acknowledgedAt: '2026-03-03T09:00:00Z', createdAt: '2026-03-03T08:30:00Z' },
-];
+import { getAlerts } from '@/api/alerts';
+import { useDashboardStore } from '@/stores/dashboardStore';
 
 function getSeverityIcon(severity: AlertSeverity) {
   switch (severity) {
@@ -42,25 +35,33 @@ function getSeverityDot(severity: AlertSeverity) {
 export default function AlertsPage() {
   const [severityFilter, setSeverityFilter] = useState<string>('ALL');
   const [showAcknowledged, setShowAcknowledged] = useState(false);
+  const selectedUnitId = useDashboardStore((s) => s.selectedUnitId);
 
-  const filtered = demoAlerts.filter((a) => {
+  const { data: apiAlerts } = useQuery({
+    queryKey: ['alerts', 'page', selectedUnitId],
+    queryFn: () => getAlerts({ unitId: selectedUnitId ?? undefined }),
+  });
+
+  const allAlerts: Alert[] = apiAlerts || [];
+
+  const filtered = allAlerts.filter((a) => {
     if (severityFilter !== 'ALL' && a.severity !== severityFilter) return false;
     if (!showAcknowledged && a.acknowledged) return false;
     return true;
   });
 
-  const criticalCount = demoAlerts.filter((a) => a.severity === AlertSeverity.CRITICAL && !a.acknowledged).length;
-  const warningCount = demoAlerts.filter((a) => a.severity === AlertSeverity.WARNING && !a.acknowledged).length;
+  const criticalCount = allAlerts.filter((a) => a.severity === AlertSeverity.CRITICAL && !a.acknowledged).length;
+  const warningCount = allAlerts.filter((a) => a.severity === AlertSeverity.WARNING && !a.acknowledged).length;
 
   return (
     <div className="animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
       {/* Summary */}
       <div className="grid-responsive-4col">
         {[
-          { label: 'TOTAL ACTIVE', value: demoAlerts.filter((a) => !a.acknowledged).length, color: 'var(--color-text-bright)' },
+          { label: 'TOTAL ACTIVE', value: allAlerts.filter((a) => !a.acknowledged).length, color: 'var(--color-text-bright)' },
           { label: 'CRITICAL', value: criticalCount, color: 'var(--color-danger)' },
           { label: 'WARNING', value: warningCount, color: 'var(--color-warning)' },
-          { label: 'ACKNOWLEDGED', value: demoAlerts.filter((a) => a.acknowledged).length, color: 'var(--color-text-muted)' },
+          { label: 'ACKNOWLEDGED', value: allAlerts.filter((a) => a.acknowledged).length, color: 'var(--color-text-muted)' },
         ].map((stat) => (
           <div
             key={stat.label}

--- a/frontend/src/pages/DocsPage.tsx
+++ b/frontend/src/pages/DocsPage.tsx
@@ -9,6 +9,9 @@ import {
   HelpCircle,
   ExternalLink,
   ChevronRight,
+  Shield,
+  Wrench,
+  Settings,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
@@ -16,9 +19,13 @@ type Section =
   | 'getting-started'
   | 'architecture'
   | 'features'
+  | 'equipment'
+  | 'reports'
+  | 'admin'
   | 'deployment'
   | 'api-reference'
   | 'simulator'
+  | 'security'
   | 'troubleshooting';
 
 interface NavItem {
@@ -31,9 +38,13 @@ const navItems: NavItem[] = [
   { id: 'getting-started', label: 'Getting Started', icon: Rocket },
   { id: 'architecture', label: 'Architecture', icon: Layers },
   { id: 'features', label: 'Features', icon: Activity },
+  { id: 'equipment', label: 'Equipment & Maint.', icon: Wrench },
+  { id: 'reports', label: 'Reports', icon: Activity },
+  { id: 'admin', label: 'Administration', icon: Settings },
   { id: 'deployment', label: 'Deployment', icon: Server },
   { id: 'api-reference', label: 'API Reference', icon: Code },
   { id: 'simulator', label: 'Simulator', icon: Activity },
+  { id: 'security', label: 'Security', icon: Shield },
   { id: 'troubleshooting', label: 'Troubleshooting', icon: HelpCircle },
 ];
 
@@ -166,6 +177,44 @@ function InfoBox({
   );
 }
 
+function WarningBox({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        backgroundColor: 'rgba(245, 158, 11, 0.06)',
+        border: '1px solid rgba(245, 158, 11, 0.2)',
+        borderLeft: '3px solid var(--color-warning)',
+        borderRadius: 'var(--radius)',
+        padding: 16,
+        marginBottom: 16,
+      }}
+    >
+      <div
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 11,
+          fontWeight: 600,
+          color: 'var(--color-warning)',
+          textTransform: 'uppercase',
+          letterSpacing: '1px',
+          marginBottom: 8,
+        }}
+      >
+        {title}
+      </div>
+      <div style={{ fontSize: 13, lineHeight: 1.6, color: 'var(--color-text)' }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
 function FeatureCard({
   title,
   description,
@@ -244,16 +293,22 @@ function BulletList({ items }: { items: string[] }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// SECTION: Getting Started
+// ---------------------------------------------------------------------------
+
 function GettingStartedSection() {
   return (
     <div>
       <SectionHeading>Getting Started</SectionHeading>
 
       <Paragraph>
-        KEYSTONE is a USMC logistics intelligence application that provides
-        automated ingestion, analysis, and reporting of supply, equipment, and
-        transportation data. It gives commanders and staff a real-time Common
-        Operating Picture (COP) of their logistics posture.
+        KEYSTONE is a USMC logistics intelligence application built as a
+        component of Project Dynamis (USMC CJADC2). It provides automated
+        ingestion, analysis, and reporting of supply, equipment, and
+        transportation data, giving commanders and staff a real-time Common
+        Operating Picture (COP) of their logistics posture across all echelons
+        from company to MEF.
       </Paragraph>
 
       <InfoBox title="Quick Start">
@@ -266,18 +321,75 @@ function GettingStartedSection() {
 git clone https://github.com/morbidsteve/keystone.git
 cd keystone
 
-# Start all services
-docker compose up -d
+# Start all services (backend, frontend, database, Redis, Celery)
+docker compose up --build -d
 
-# Verify everything is healthy
+# Verify everything is healthy (~30 seconds)
 docker compose ps`}</CodeBlock>
 
       <SubHeading>2. Access the Application</SubHeading>
       <Paragraph>
         Once all services are healthy, open your browser to{' '}
-        <InlineCode>https://localhost</InlineCode>. In development mode,
-        seed users are created automatically.
+        <InlineCode>https://localhost</InlineCode> (self-signed certificate).
+        In development mode, seed users are created automatically.
       </Paragraph>
+
+      <SubHeading>Default Credentials (Development Only)</SubHeading>
+      <div
+        style={{
+          backgroundColor: 'var(--color-bg)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius)',
+          overflow: 'hidden',
+          marginBottom: 16,
+        }}
+      >
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+          }}
+        >
+          <thead>
+            <tr
+              style={{
+                borderBottom: '1px solid var(--color-border)',
+                backgroundColor: 'var(--color-bg-elevated)',
+              }}
+            >
+              <th style={thStyle}>Username</th>
+              <th style={thStyle}>Password</th>
+              <th style={thStyle}>Role</th>
+              <th style={thStyle}>Unit</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[
+              ['admin', 'admin123', 'Admin', 'I MEF'],
+              ['commander', 'cmd123', 'Commander', '1st MarDiv'],
+              ['s4officer', 's4pass123', 'S-4', '1st Marines'],
+              ['s3officer', 's3pass123', 'S-3', '1st Marines'],
+              ['operator', 'op123', 'Operator', '1/1'],
+              ['viewer', 'view123', 'Viewer', 'A Co 1/1'],
+            ].map(([user, pass, role, unit]) => (
+              <tr key={user} style={trStyle}>
+                <td style={tdStyle}>{user}</td>
+                <td style={tdStyle}>{pass}</td>
+                <td style={tdStyle}>{role}</td>
+                <td style={tdStyle}>{unit}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <WarningBox title="Security Note">
+        These seed accounts are only created when ENV_MODE=development (the
+        default). They are blocked from creation in production environments.
+        Always change SECRET_KEY in production.
+      </WarningBox>
 
       <SubHeading>3. Run the Simulator (Optional)</SubHeading>
       <Paragraph>
@@ -288,7 +400,7 @@ docker compose ps`}</CodeBlock>
       <Paragraph>
         The simulator runs the Steel Guardian scenario at 60x speed, feeding
         supply, equipment, and transportation events into the system
-        continuously.
+        continuously. See the Simulator section for all 20 available scenarios.
       </Paragraph>
 
       <SubHeading>Default Ports</SubHeading>
@@ -325,29 +437,63 @@ docker compose ps`}</CodeBlock>
             <tr style={trStyle}>
               <td style={tdStyle}>Frontend</td>
               <td style={tdStyle}>https://localhost</td>
-              <td style={tdStyle}>Main application</td>
+              <td style={tdStyle}>Main application (self-signed TLS)</td>
             </tr>
             <tr style={trStyle}>
               <td style={tdStyle}>API Docs</td>
               <td style={tdStyle}>https://localhost/api/docs</td>
-              <td style={tdStyle}>Swagger UI</td>
+              <td style={tdStyle}>Swagger UI (via nginx proxy)</td>
             </tr>
             <tr style={trStyle}>
               <td style={tdStyle}>Backend API</td>
               <td style={tdStyle}>http://localhost:8000</td>
-              <td style={tdStyle}>Direct access (dev)</td>
+              <td style={tdStyle}>Direct access (development)</td>
             </tr>
             <tr style={trStyle}>
               <td style={tdStyle}>PostgreSQL</td>
               <td style={tdStyle}>localhost:5432</td>
-              <td style={tdStyle}>Database (dev)</td>
+              <td style={tdStyle}>Database (development)</td>
+            </tr>
+            <tr style={trStyle}>
+              <td style={tdStyle}>Redis</td>
+              <td style={tdStyle}>localhost:6379</td>
+              <td style={tdStyle}>Cache and task queue</td>
             </tr>
           </tbody>
         </table>
       </div>
+
+      <SubHeading>Navigation</SubHeading>
+      <Paragraph>
+        KEYSTONE uses a sidebar navigation with the following pages:
+      </Paragraph>
+      <BulletList
+        items={[
+          'DASHBOARD -- Commander, S-4, and S-3 readiness views',
+          'MAP -- Interactive COP with military symbology and tile layers',
+          'SUPPLY -- All 10 NATO supply classes with status tracking',
+          'EQUIPMENT -- Fleet readiness aggregates and individual asset tracking',
+          'TRANSPORTATION -- Convoy management, route planning, movement tracking',
+          'INGESTION -- Upload mIRC logs, Excel, route files (GeoJSON/GPX/KML/KMZ)',
+          'DATA SOURCES -- Configure and monitor external data feeds',
+          'REPORTS -- Generate and export 7 report types',
+          'ALERTS -- View and acknowledge system alerts by severity',
+          'ADMIN -- User management, units, classification, map tile configuration',
+          'DOCS -- This documentation page',
+        ]}
+      />
+
+      <Paragraph>
+        The unit selector in the sidebar scopes all data to your selected unit
+        and its subordinates in the organizational hierarchy.
+      </Paragraph>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// SECTION: Architecture
+// ---------------------------------------------------------------------------
 
 function ArchitectureSection() {
   return (
@@ -356,7 +502,8 @@ function ArchitectureSection() {
 
       <Paragraph>
         KEYSTONE follows a modern full-stack architecture with a Python backend,
-        React frontend, and supporting infrastructure services.
+        React frontend, and supporting infrastructure services. All containers
+        are hardened per the DoD Container Hardening Guide.
       </Paragraph>
 
       <SubHeading>Technology Stack</SubHeading>
@@ -370,33 +517,32 @@ function ArchitectureSection() {
       >
         <FeatureCard
           title="Backend"
-          description="Python 3.11, FastAPI, SQLAlchemy 2.0 (async), Pydantic, Celery"
+          description="Python 3.11, FastAPI, SQLAlchemy 2.0 (async), Pydantic 2, Uvicorn, spaCy NLP"
         />
         <FeatureCard
           title="Frontend"
-          description="React 18, TypeScript, Vite, Zustand, TanStack Query/Table, Tailwind CSS"
+          description="React 18, TypeScript 5.3, Vite 5, Zustand, TanStack Query/Table, Tailwind CSS, Recharts"
         />
         <FeatureCard
           title="Database"
-          description="PostgreSQL 15 with PostGIS for geospatial data"
+          description="PostgreSQL 15 with PostGIS 3.4 for geospatial queries and MGRS support"
         />
         <FeatureCard
           title="Cache / Queue"
-          description="Redis 7 for Celery task queue and caching"
+          description="Redis 7 for Celery task queue and session caching"
         />
         <FeatureCard
           title="Maps"
-          description="react-leaflet with milsymbol for NATO MIL-STD-2525D symbols"
+          description="react-leaflet with milsymbol for APP-6D (MIL-STD-2525D) 15-character SIDCs"
         />
         <FeatureCard
           title="Infrastructure"
-          description="Docker, nginx (TLS + tile proxy), GitHub Actions CI/CD"
+          description="Docker, nginx-unprivileged (TLS + tile proxy), Alembic migrations, GitHub Actions CI/CD"
         />
       </div>
 
       <SubHeading>System Components</SubHeading>
-      <CodeBlock>{`
-  Browser (React SPA)
+      <CodeBlock>{`  Browser (React SPA)
       |
       | HTTPS (443)
       v
@@ -414,40 +560,54 @@ function ArchitectureSection() {
       |
       v
   PostgreSQL (db container, port 5432)
-  Redis (redis container, port 6379)`}</CodeBlock>
+  Redis (redis container, port 6379)
+  Simulator (demo profile, posts to backend API)`}</CodeBlock>
 
       <SubHeading>Data Flow</SubHeading>
       <BulletList
         items={[
-          'Logistics reports (CSV, XML, JSON) are uploaded via the Ingestion page',
+          'Logistics data enters via file upload (mIRC, Excel, route files), TAK integration, manual entry, or simulator',
           'Schema mapping normalizes external fields to KEYSTONE canonical format',
           'Celery workers process ingested data asynchronously',
           'Dashboard aggregates readiness metrics per unit echelon',
           'Map overlay displays unit positions with NATO military symbols',
-          'Alerts fire when readiness drops below configurable thresholds',
-          'Reports generate formatted LOGSTAT and other standard reports',
+          'Alerts fire when supply or readiness drops below configurable thresholds',
+          'Reports aggregate data into structured LOGSTAT and other standard formats',
         ]}
       />
 
       <SubHeading>Security Architecture</SubHeading>
       <BulletList
         items={[
-          'JWT bearer token authentication on all API endpoints',
-          'Role-based access control (COMMANDER, S4_STAFF, S3_STAFF, ANALYST, ADMIN)',
-          'nginx enforces HSTS, CSP, X-Frame-Options, and other security headers',
-          'Containers run as non-root with no-new-privileges and minimal capabilities',
-          'All tile requests proxy through nginx to avoid CSP violations and data leakage',
-          'Classification banner system for UNCLASSIFIED through TS//SCI',
+          'JWT bearer token authentication (HS256) on all API endpoints with configurable 8-hour expiry',
+          'Role-based access control with 6 roles: ADMIN, COMMANDER, S4, S3, OPERATOR, VIEWER',
+          'Unit hierarchy scoping -- users see only their unit and its subordinates',
+          'nginx enforces HSTS, CSP, X-Frame-Options, X-Content-Type-Options headers',
+          'Containers run as non-root (UID 1001) with read-only filesystems, no-new-privileges, minimal capabilities',
+          'All external tile requests proxy through nginx to prevent CSP violations and data leakage',
+          'Pydantic 2 input validation on all API inputs; parameterized SQL via SQLAlchemy',
+          'Classification banner system for UNCLASSIFIED through TS//SCI per IC/DoD standards',
+          'Cosign keyless image signing with SBOM attestation in CI pipeline',
         ]}
       />
     </div>
   );
 }
 
+// ---------------------------------------------------------------------------
+// SECTION: Features Overview
+// ---------------------------------------------------------------------------
+
 function FeaturesSection() {
   return (
     <div>
       <SectionHeading>Features</SectionHeading>
+
+      <Paragraph>
+        KEYSTONE provides a comprehensive logistics Common Operating Picture
+        with the following capabilities. Each feature card below corresponds to
+        a module accessible from the sidebar navigation.
+      </Paragraph>
 
       <div
         style={{
@@ -459,56 +619,377 @@ function FeaturesSection() {
       >
         <FeatureCard
           title="Commander Dashboard"
-          description="High-level readiness overview showing supply, equipment, and personnel status across all subordinate units with trend indicators."
+          description="High-level readiness overview showing supply, equipment, and personnel status across all subordinate units with 30-second readiness assessment and trend indicators."
         />
         <FeatureCard
           title="S-4 (Logistics) View"
-          description="Detailed supply class breakdowns, shortfall analysis, and readiness percentages by supply category (I through X)."
+          description="Detailed supply class breakdowns (I-X), shortfall analysis, consumption rate tracking, days-of-supply calculations, and reorder point management."
         />
         <FeatureCard
           title="S-3 (Operations) View"
-          description="Operational readiness metrics, equipment availability rates, and maintenance status for mission planning."
+          description="Operational readiness metrics, equipment availability rates, fleet MC/NMC breakdown, and maintenance status for mission planning."
         />
         <FeatureCard
           title="Interactive COP Map"
-          description="Full-screen map with NATO MIL-STD-2525D military symbols, unit positions, routes, and multiple tile layers (OSM, satellite, topo)."
+          description="Full-screen Leaflet map with APP-6D military symbols (15-char SIDCs), unit positions, supply points, route overlays, convoy tracking, MGRS/lat-lon coordinates, three tile layers (OSM, satellite, topo), and distance measurement."
         />
         <FeatureCard
           title="Equipment Tracking"
-          description="Individual serial-number-level equipment tracking with maintenance history, readiness status, and TAMCN aggregation."
+          description="Fleet-level readiness aggregates by TAMCN. Individual asset detail pages with 5 tabs: Overview, Maintenance History, Faults, Drivers, and Convoy assignments."
         />
         <FeatureCard
-          title="Transportation Management"
-          description="Convoy manifest creation, vehicle load planning, route tracking, and movement request management."
+          title="Maintenance Work Orders"
+          description="Full CRUD lifecycle: create work orders, transition status (OPEN > IN_PROGRESS > AWAITING_PARTS > COMPLETE), manage parts with sourcing, track labor by type, assign priority and category."
+        />
+        <FeatureCard
+          title="Supply Management"
+          description="All 10 NATO supply classes with on-hand vs. required quantities, days-of-supply, traffic-light status (GREEN/AMBER/RED), consumption trend charts, class breakdown, and DOS calculator."
+        />
+        <FeatureCard
+          title="Transportation & Convoys"
+          description="Convoy map with route overlays, movement tracker (PLANNED > EN_ROUTE > COMPLETE), route planner modal, throughput charts, and vehicle/personnel allocation."
         />
         <FeatureCard
           title="Data Ingestion"
-          description="Upload CSV, XML, or JSON logistics reports with automatic schema mapping to canonical KEYSTONE format."
+          description="Upload mIRC chat logs (NLP extraction), Excel LOGSTAT templates, route files (GeoJSON/GPX/KML/KMZ). Schema mapping wizard for new formats."
         />
         <FeatureCard
-          title="Alerts System"
-          description="Configurable readiness threshold alerts with severity levels. Get notified when supply or equipment readiness drops."
+          title="Report Generation"
+          description="7 report types: LOGSTAT, Readiness, Supply Status, Equipment Status, Maintenance Summary, Movement Summary, Personnel Strength. Draft/Final workflow with export."
         />
         <FeatureCard
-          title="Reports"
-          description="Generate formatted logistics reports (LOGSTAT, equipment status, etc.) with export capabilities."
+          title="Alert System"
+          description="Automatic alerts for low supply, low readiness, delayed convoys, and anomaly detection. Three severity levels (CRITICAL, WARNING, INFO) with acknowledgement tracking."
         />
         <FeatureCard
           title="Unit Hierarchy"
-          description="Full echelon tree from MEF down to squad level. Filter all data by selected unit scope."
+          description="Complete active-duty USMC organizational structure (~403 units). All three MEFs, MARFORRES, MARSOC, Supporting Establishment. Echelons from HQMC to company level."
         />
         <FeatureCard
           title="TAK Integration"
-          description="Push and pull Cursor-on-Target (CoT) events to/from TAK Server for interoperability with ATAK/WinTAK."
+          description="Push and pull Cursor-on-Target (CoT) events to/from TAK Server for interoperability with ATAK/WinTAK field devices."
         />
         <FeatureCard
           title="Classification Banners"
-          description="Configurable classification level from UNCLASSIFIED through TS//SCI with color-coded banners on every page."
+          description="Admin-configurable classification level from UNCLASSIFIED through TS//SCI with color-coded banners at top and bottom of every page per IC/DoD standards."
+        />
+        <FeatureCard
+          title="Responsive Design"
+          description="Optimized layouts for desktop, tablet, and mobile. Collapsible sidebar, responsive grid systems, scrollable tables, and full-screen map mode."
+        />
+        <FeatureCard
+          title="Demo Mode"
+          description="Full static site deployment with mock data and no backend dependency. Auto-deployed to GitHub Pages. Toggle with VITE_DEMO_MODE=true."
         />
       </div>
+
+      <InfoBox title="Future Capability">
+        GCSS-MC (Global Combat Support System -- Marine Corps) integration is
+        planned as a future capability for automated supply and equipment
+        synchronization from authoritative Marine Corps logistics systems.
+      </InfoBox>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// SECTION: Equipment & Maintenance
+// ---------------------------------------------------------------------------
+
+function EquipmentSection() {
+  return (
+    <div>
+      <SectionHeading>Equipment & Maintenance</SectionHeading>
+
+      <Paragraph>
+        The Equipment module provides fleet-level readiness aggregates and
+        individual asset tracking with a comprehensive maintenance workflow.
+      </Paragraph>
+
+      <SubHeading>Equipment List (Fleet View)</SubHeading>
+      <Paragraph>
+        The main Equipment page displays a readiness table showing all equipment
+        types aggregated by TAMCN (Table of Authorized Materiel Control Number).
+        Each row shows:
+      </Paragraph>
+      <BulletList
+        items={[
+          'Equipment type/nomenclature and TAMCN',
+          'Total possessed, mission capable (MC), and not mission capable (NMC) counts',
+          'NMC breakdown: NMC-M (maintenance) vs NMC-S (supply)',
+          'Readiness percentage with color-coded status',
+        ]}
+      />
+      <Paragraph>
+        Below the readiness table, you will find the Maintenance Queue (showing
+        current open work orders) and a Readiness Trend chart.
+      </Paragraph>
+
+      <SubHeading>Individual Equipment Detail</SubHeading>
+      <Paragraph>
+        Click any equipment item to open its detail page. The detail page shows
+        the bumper number, equipment type, serial number, unit, TAMCN, and
+        current status (FMC, NMC_M, NMC_S, DEADLINED, ADMIN). Five tabs provide
+        detailed information:
+      </Paragraph>
+      <BulletList
+        items={[
+          'OVERVIEW -- Equipment specifications, current status, mileage, assigned driver, and key dates',
+          'MAINTENANCE -- Full work order history with ability to create new work orders and manage existing ones',
+          'FAULTS -- Report new faults (SAFETY, MAJOR, MINOR, COSMETIC severity), resolve existing faults, link faults to work orders',
+          'DRIVERS -- Assign/release drivers (Primary or A-Driver), view assignment history with dates',
+          'CONVOYS -- View convoy and movement assignment history for this equipment',
+        ]}
+      />
+
+      <SubHeading>Maintenance Work Order Workflow</SubHeading>
+      <Paragraph>
+        Work orders track maintenance from request through completion with full
+        lifecycle management:
+      </Paragraph>
+
+      <InfoBox title="Work Order Status Flow">
+        OPEN &rarr; IN_PROGRESS &rarr; AWAITING_PARTS (optional) &rarr; COMPLETE
+      </InfoBox>
+
+      <Paragraph>
+        <strong>Creating a Work Order:</strong> Click the "CREATE WORK ORDER"
+        button from the Maintenance tab. Fill in:
+      </Paragraph>
+      <BulletList
+        items={[
+          'Work Order Number (auto-generated as WO-YYYY-NNNN)',
+          'Priority: URGENT (1), PRIORITY (2), or ROUTINE (3)',
+          'Category: CORRECTIVE, PREVENTIVE, MODIFICATION, or INSPECTION',
+          'Description of the maintenance requirement',
+          'Equipment ID, Unit ID, Assigned mechanic, Location, Estimated completion date',
+        ]}
+      />
+
+      <Paragraph>
+        <strong>Managing a Work Order:</strong> Click any work order to open the
+        detail modal. From there you can:
+      </Paragraph>
+      <BulletList
+        items={[
+          'Transition status forward (OPEN > IN_PROGRESS > AWAITING_PARTS > COMPLETE) or revert to previous status',
+          'Edit work order details: description, priority, category, assigned mechanic, location, estimated completion',
+          'Add Parts: specify NSN/part number, description, quantity, source (ON_HAND, ORDERED, CANNIBALIZED), and status (NEEDED, ON_ORDER, RECEIVED, INSTALLED)',
+          'Edit or delete individual parts as they are received or installed',
+          'Add Labor entries: type (INSPECTION, REPAIR, PMCS, MODIFICATION), personnel name, hours worked, and date',
+          'Edit or delete labor entries',
+          'Delete the entire work order if created in error',
+        ]}
+      />
+
+      <SubHeading>Fault Tracking</SubHeading>
+      <Paragraph>
+        The Faults tab on the equipment detail page tracks all reported faults
+        for an individual asset:
+      </Paragraph>
+      <BulletList
+        items={[
+          'Report a new fault with severity (SAFETY, MAJOR, MINOR, COSMETIC), description, and reporter name',
+          'Safety and Major faults are displayed with red/amber indicators for immediate visibility',
+          'Resolve faults by clicking the RESOLVE button, which records the resolution timestamp',
+          'Faults linked to work orders display the work order ID for cross-reference',
+        ]}
+      />
+
+      <SubHeading>Driver Assignment</SubHeading>
+      <Paragraph>
+        The Drivers tab manages personnel assignments to individual equipment:
+      </Paragraph>
+      <BulletList
+        items={[
+          'Assign a driver by Personnel ID with optional name and Primary/A-Driver designation',
+          'Current (active) assignments are highlighted; released assignments show historical dates',
+          'Release a driver by clicking the RELEASE button, which records the release date',
+        ]}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SECTION: Reports
+// ---------------------------------------------------------------------------
+
+function ReportsSection() {
+  return (
+    <div>
+      <SectionHeading>Reports</SectionHeading>
+
+      <Paragraph>
+        The Reports page provides automated report generation, a structured
+        report viewer, and export capabilities for standard USMC logistics
+        reports.
+      </Paragraph>
+
+      <SubHeading>Report Types</SubHeading>
+      <div
+        style={{
+          backgroundColor: 'var(--color-bg)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius)',
+          overflow: 'hidden',
+          marginBottom: 16,
+        }}
+      >
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+          }}
+        >
+          <thead>
+            <tr
+              style={{
+                borderBottom: '1px solid var(--color-border)',
+                backgroundColor: 'var(--color-bg-elevated)',
+              }}
+            >
+              <th style={thStyle}>Type</th>
+              <th style={thStyle}>Contents</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[
+              ['LOGSTAT', 'Supply status, equipment readiness, open WOs, active movements, personnel strength'],
+              ['READINESS', 'MC/NMC rates by equipment type, individual status breakdown, deadlined items'],
+              ['SUPPLY STATUS', 'All 10 supply classes with on-hand, required, fill rate, avg DOS, critical items'],
+              ['EQUIPMENT STATUS', 'Fleet readiness by type, NMC-M vs NMC-S, individual breakdown, top deadlined items'],
+              ['MAINTENANCE', 'WO counts by status, avg completion time, total labor hours, parts on order, top issues'],
+              ['MOVEMENTS', 'Active/planned/completed counts, vehicles and personnel in transit, recent completions'],
+              ['PERSONNEL', 'Total assigned vs active, status breakdown (present/deployed/leave/TAD/medical), by rank and MOS'],
+            ].map(([type, desc]) => (
+              <tr key={type} style={trStyle}>
+                <td style={{ ...tdStyle, fontWeight: 600, whiteSpace: 'nowrap' }}>{type}</td>
+                <td style={tdStyle}>{desc}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <SubHeading>Generating a Report</SubHeading>
+      <BulletList
+        items={[
+          'Select the report type from the dropdown on the left panel',
+          'Choose the unit scope (I MEF, 1st MarDiv, 1st Marines, or specific battalions)',
+          'Optionally set a date range (defaults to last 7 days)',
+          'Click GENERATE REPORT -- the system aggregates current data and produces a structured report',
+        ]}
+      />
+
+      <SubHeading>Viewing and Managing Reports</SubHeading>
+      <Paragraph>
+        Generated reports appear in the right panel with a structured viewer
+        that includes type-specific sections:
+      </Paragraph>
+      <BulletList
+        items={[
+          'Report header with type, unit, and generation timestamp',
+          'Summary statistics with large metric cards (readiness %, totals, etc.)',
+          'Tabular breakdowns by supply class, equipment type, status, rank, or MOS',
+          'Color-coded status indicators (GREEN/AMBER/RED) matching the traffic-light system',
+          'Critical items highlighted in red for immediate attention',
+        ]}
+      />
+
+      <SubHeading>Report Workflow</SubHeading>
+      <BulletList
+        items={[
+          'Reports are generated in READY status',
+          'Click FINALIZE to mark a report as official (status changes to FINALIZED)',
+          'Click EXPORT to download the report as a text/JSON file for offline distribution or submission to higher HQ',
+          'Report history is maintained with author and timestamp for each report',
+        ]}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SECTION: Administration
+// ---------------------------------------------------------------------------
+
+function AdminSection() {
+  return (
+    <div>
+      <SectionHeading>Administration</SectionHeading>
+
+      <Paragraph>
+        The Admin page (accessible to ADMIN role users) provides system
+        configuration through four tabs: Users, Units, Classification, and Map
+        Tiles.
+      </Paragraph>
+
+      <SubHeading>User Management</SubHeading>
+      <BulletList
+        items={[
+          'View all system users with username, name, role, unit assignment, and active status',
+          'Create new users with username, full name, email, password, role, and unit assignment',
+          'Edit existing users to change role, unit assignment, or account details',
+          'Activate or deactivate user accounts (deactivated users cannot log in)',
+          '6 available roles: ADMIN, COMMANDER, S4, S3, OPERATOR, VIEWER',
+        ]}
+      />
+
+      <SubHeading>Unit Management</SubHeading>
+      <BulletList
+        items={[
+          'Interactive tree view of the complete USMC organizational hierarchy (~403 units)',
+          'All three MEFs (I, II, III), MARFORRES, MARSOC, and Supporting Establishment',
+          'Echelons from HQMC down to company level with UICs and geographic coordinates',
+          'Create new subordinate units with proper echelon validation (e.g., battalions under regiments)',
+          'Edit unit properties: name, abbreviation, UIC, echelon, coordinates, MGRS',
+        ]}
+      />
+
+      <SubHeading>Classification Settings</SubHeading>
+      <Paragraph>
+        Configure the classification level displayed on the banners at the top
+        and bottom of every page:
+      </Paragraph>
+      <BulletList
+        items={[
+          'UNCLASSIFIED (green banner)',
+          'CUI -- Controlled Unclassified Information (amber banner)',
+          'CONFIDENTIAL (blue banner)',
+          'SECRET (red banner)',
+          'TOP SECRET (orange banner)',
+          'TOP SECRET//SCI (yellow text on red banner)',
+        ]}
+      />
+      <Paragraph>
+        The classification setting is stored server-side and applies to all
+        users. A live preview shows exactly how the banner will appear before
+        saving.
+      </Paragraph>
+
+      <SubHeading>Map Tile Settings</SubHeading>
+      <Paragraph>
+        Configure tile layer sources for the three map layers:
+      </Paragraph>
+      <BulletList
+        items={[
+          'OpenStreetMap -- default general-purpose street map',
+          'Satellite -- aerial/satellite imagery layer',
+          'Topographic -- contour and terrain map',
+          'Each layer can point to online tile servers or local tile servers for air-gapped deployments',
+          'Tile URL templates use standard {z}/{x}/{y} placeholders',
+        ]}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SECTION: Deployment
+// ---------------------------------------------------------------------------
 
 function DeploymentSection() {
   return (
@@ -517,9 +998,9 @@ function DeploymentSection() {
 
       <Paragraph>
         KEYSTONE supports multiple deployment models, from local development to
-        air-gapped classified networks. Comprehensive deployment guides are
-        available in the repository under{' '}
-        <InlineCode>docs/deployment/</InlineCode>.
+        air-gapped classified networks. All containers are hardened per the DoD
+        Container Hardening Guide with non-root users, read-only filesystems,
+        and minimal capabilities.
       </Paragraph>
 
       <SubHeading>Deployment Options</SubHeading>
@@ -533,31 +1014,88 @@ function DeploymentSection() {
         }}
       >
         <DeploymentOption
-          title="Docker Compose"
-          description="The simplest deployment method. Suitable for development, demos, and single-server production."
-          guide="docs/deployment/docker-compose.md"
-        />
-        <DeploymentOption
-          title="On-Premises / Bare Metal"
-          description="Direct installation on physical or virtual servers with systemd services and nginx reverse proxy."
-          guide="docs/deployment/on-premises.md"
-        />
-        <DeploymentOption
-          title="Cloud (AWS / Azure / GCP)"
-          description="Managed container services, databases, and caching. Auto-scaling and CDN for static assets."
-          guide="docs/deployment/cloud.md"
+          title="Docker Compose (Recommended)"
+          description="Single command brings up the full stack: PostgreSQL, Redis, Backend, Celery, Frontend. Suitable for development, demos, and single-server production."
+          guide="docker-compose.yml"
         />
         <DeploymentOption
           title="Air-Gapped / SIPR / Classified"
-          description="Fully offline deployment with local tile server, internal PKI, and classification banner support."
-          guide="docs/deployment/air-gapped.md"
+          description="Fully offline deployment with pre-downloaded tile cache, internal PKI for TLS, and classification banner support. No external network required."
+          guide="scripts/download-tiles.py"
         />
         <DeploymentOption
-          title="Kubernetes / Helm"
-          description="Helm chart deployment with HPA, PVCs, ingress, secrets management, and monitoring."
-          guide="docs/deployment/kubernetes.md"
+          title="Demo Mode (Static Site)"
+          description="Build frontend with VITE_DEMO_MODE=true for a fully functional static site with mock data. No backend required. Auto-deployed to GitHub Pages."
+          guide="deploy-pages.yml"
         />
       </div>
+
+      <SubHeading>Docker Compose Services</SubHeading>
+      <div
+        style={{
+          backgroundColor: 'var(--color-bg)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius)',
+          overflow: 'hidden',
+          marginBottom: 16,
+        }}
+      >
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+          }}
+        >
+          <thead>
+            <tr
+              style={{
+                borderBottom: '1px solid var(--color-border)',
+                backgroundColor: 'var(--color-bg-elevated)',
+              }}
+            >
+              <th style={thStyle}>Service</th>
+              <th style={thStyle}>Image</th>
+              <th style={thStyle}>Port</th>
+              <th style={thStyle}>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[
+              ['db', 'postgis/postgis:15-3.4', '5432', 'PostgreSQL + PostGIS'],
+              ['redis', 'redis:7-alpine', '6379', 'Cache and task queue'],
+              ['backend', 'keystone-backend', '8000', 'FastAPI (Uvicorn)'],
+              ['celery_worker', 'keystone-backend', '--', 'Background tasks'],
+              ['frontend', 'keystone-frontend', '80/443', 'nginx + React SPA'],
+              ['simulator', 'keystone-backend', '--', 'Demo profile only'],
+            ].map(([name, img, port, notes]) => (
+              <tr key={name} style={trStyle}>
+                <td style={{ ...tdStyle, fontWeight: 600 }}>{name}</td>
+                <td style={tdStyle}>{img}</td>
+                <td style={tdStyle}>{port}</td>
+                <td style={tdStyle}>{notes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <SubHeading>Air-Gapped Tile Cache</SubHeading>
+      <Paragraph>
+        Pre-download map tiles for your area of operations using the included
+        script:
+      </Paragraph>
+      <CodeBlock>{`python scripts/download-tiles.py \\
+  --bbox 33.0,-117.6,33.5,-117.0 \\
+  --zoom 8-14 \\
+  --output ./tiles \\
+  --source osm`}</CodeBlock>
+      <Paragraph>
+        Both nginx and the Vite dev server proxy tile requests through{' '}
+        <InlineCode>/tiles/&#123;osm,satellite,topo&#125;</InlineCode>,
+        allowing seamless use of cached tiles in disconnected environments.
+      </Paragraph>
 
       <SubHeading>Environment Variables</SubHeading>
       <div
@@ -590,36 +1128,41 @@ function DeploymentSection() {
             </tr>
           </thead>
           <tbody>
-            <tr style={trStyle}>
-              <td style={tdStyle}>DATABASE_URL</td>
-              <td style={tdStyle}>Yes</td>
-              <td style={tdStyle}>Async PostgreSQL connection string</td>
-            </tr>
-            <tr style={trStyle}>
-              <td style={tdStyle}>REDIS_URL</td>
-              <td style={tdStyle}>Yes</td>
-              <td style={tdStyle}>Redis connection string</td>
-            </tr>
-            <tr style={trStyle}>
-              <td style={tdStyle}>SECRET_KEY</td>
-              <td style={tdStyle}>Yes (prod)</td>
-              <td style={tdStyle}>JWT signing key (must be random in production)</td>
-            </tr>
-            <tr style={trStyle}>
-              <td style={tdStyle}>ENV_MODE</td>
-              <td style={tdStyle}>No</td>
-              <td style={tdStyle}>
-                &quot;development&quot; (default) or &quot;production&quot;
-              </td>
-            </tr>
-            <tr style={trStyle}>
-              <td style={tdStyle}>CORS_ORIGINS</td>
-              <td style={tdStyle}>No</td>
-              <td style={tdStyle}>JSON array of allowed origins</td>
-            </tr>
+            {[
+              ['DATABASE_URL', 'Yes', 'Async PostgreSQL connection (postgresql+asyncpg://...)'],
+              ['DATABASE_URL_SYNC', 'Yes', 'Sync PostgreSQL connection for Celery workers'],
+              ['REDIS_URL', 'Yes', 'Redis connection string'],
+              ['SECRET_KEY', 'Yes (prod)', 'JWT signing key (MUST be random in production)'],
+              ['ENV_MODE', 'No', '"development" (default) or "production"'],
+              ['CORS_ORIGINS', 'No', 'JSON array of allowed CORS origins'],
+              ['ACCESS_TOKEN_EXPIRE_MINUTES', 'No', 'JWT expiry in minutes (default: 480 = 8 hours)'],
+              ['ALLOW_PRIVATE_TAK_HOSTS', 'No', 'Allow TAK connections to RFC1918 addresses (default: true)'],
+              ['VITE_DEMO_MODE', 'No', 'Build frontend as static demo site (default: false)'],
+              ['VITE_BASE_PATH', 'No', 'Base URL path for GitHub Pages (default: /)'],
+            ].map(([name, req, desc]) => (
+              <tr key={name} style={trStyle}>
+                <td style={{ ...tdStyle, fontWeight: 600 }}>{name}</td>
+                <td style={tdStyle}>{req}</td>
+                <td style={tdStyle}>{desc}</td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>
+
+      <SubHeading>CI/CD Pipeline</SubHeading>
+      <Paragraph>
+        KEYSTONE uses a 5-phase DevSecOps pipeline via GitHub Actions:
+      </Paragraph>
+      <BulletList
+        items={[
+          'Phase 1 -- Lint: Backend (ruff + mypy), Frontend (tsc -b)',
+          'Phase 2 -- Build + Scan: Docker image builds, Grype/Trivy CVE scans, Semgrep SAST, CodeQL',
+          'Phase 3 -- Test + DAST: Backend pytest, Frontend vitest, ZAP dynamic security testing',
+          'Phase 4 -- Sign + Attest: Cosign keyless image signing, SBOM generation',
+          'Phase 5 -- Compliance Gate: Final gate aggregating all prior results',
+        ]}
+      />
     </div>
   );
 }
@@ -682,6 +1225,10 @@ function DeploymentOption({
   );
 }
 
+// ---------------------------------------------------------------------------
+// SECTION: API Reference
+// ---------------------------------------------------------------------------
+
 function ApiReferenceSection() {
   return (
     <div>
@@ -690,7 +1237,7 @@ function ApiReferenceSection() {
       <Paragraph>
         KEYSTONE exposes a RESTful API under{' '}
         <InlineCode>/api/v1/</InlineCode>. Full interactive documentation
-        is available via Swagger UI.
+        is available via Swagger UI when the backend is running.
       </Paragraph>
 
       <InfoBox title="Interactive API Docs">
@@ -711,7 +1258,8 @@ function ApiReferenceSection() {
           <ExternalLink size={14} />
         </a>
         {' '}&mdash; Try out API endpoints directly in your browser with
-        authentication support.
+        authentication support. Also available at{' '}
+        <InlineCode>/api/redoc</InlineCode> for a read-only view.
       </InfoBox>
 
       <SubHeading>API Groups</SubHeading>
@@ -745,26 +1293,26 @@ function ApiReferenceSection() {
           </thead>
           <tbody>
             {[
-              ['/api/v1/auth', 'Login, token management'],
-              ['/api/v1/dashboard', 'Readiness aggregation'],
-              ['/api/v1/supply', 'Supply status CRUD'],
-              ['/api/v1/equipment', 'Equipment readiness'],
-              ['/api/v1/equipment/individual', 'Serial-level tracking'],
-              ['/api/v1/transportation', 'Movement & convoys'],
-              ['/api/v1/ingestion', 'File upload & parsing'],
-              ['/api/v1/reports', 'Report generation'],
-              ['/api/v1/alerts', 'Alert management'],
-              ['/api/v1/units', 'Unit hierarchy'],
-              ['/api/v1/map', 'Geospatial data'],
-              ['/api/v1/personnel', 'Personnel strength'],
-              ['/api/v1/tak', 'TAK Server integration'],
-              ['/api/v1/settings', 'System configuration'],
-              ['/api/v1/schema-mapping', 'Field mapping'],
-              ['/api/v1/data-sources', 'External sources'],
-              ['/api/v1/maintenance', 'Maintenance tracking'],
+              ['/api/v1/auth', 'Login, token refresh, user CRUD'],
+              ['/api/v1/dashboard', 'Commander readiness, sustainability projections'],
+              ['/api/v1/supply', 'Supply status CRUD, class I-X tracking'],
+              ['/api/v1/equipment', 'Fleet readiness aggregates by TAMCN'],
+              ['/api/v1/equipment/individual', 'Serial-level tracking: faults, drivers, history'],
+              ['/api/v1/maintenance', 'Work orders, parts, labor tracking (full CRUD)'],
+              ['/api/v1/transportation', 'Movement lifecycle, convoy manifests'],
+              ['/api/v1/personnel', 'Personnel roster, weapons, ammo loads'],
+              ['/api/v1/map', 'Unit positions, supply points, routes, convoys'],
+              ['/api/v1/reports', 'Generate/list/finalize 7 report types'],
+              ['/api/v1/alerts', 'Alert management and acknowledgement'],
+              ['/api/v1/ingestion', 'File upload: mIRC, Excel, route files'],
+              ['/api/v1/data-sources', 'External source configuration and monitoring'],
+              ['/api/v1/schema-mapping', 'Canonical field mapping for ingestion'],
+              ['/api/v1/tak', 'TAK server connections and CoT data'],
+              ['/api/v1/settings', 'System settings (classification, etc.)'],
+              ['/api/v1/units', 'USMC unit hierarchy (read)'],
             ].map(([prefix, desc]) => (
               <tr key={prefix} style={trStyle}>
-                <td style={tdStyle}>{prefix}</td>
+                <td style={{ ...tdStyle, whiteSpace: 'nowrap' }}>{prefix}</td>
                 <td style={tdStyle}>{desc}</td>
               </tr>
             ))}
@@ -790,12 +1338,36 @@ Content-Type: application/json
   "token_type": "bearer"
 }`}</CodeBlock>
       <Paragraph>
-        Include the token in subsequent requests:
+        Include the token in subsequent requests via the Authorization header:
       </Paragraph>
       <CodeBlock>{`Authorization: Bearer eyJhbGciOiJIUzI1NiIs...`}</CodeBlock>
+      <Paragraph>
+        Tokens expire after 8 hours by default (configurable via{' '}
+        <InlineCode>ACCESS_TOKEN_EXPIRE_MINUTES</InlineCode>). All endpoints
+        except <InlineCode>/health</InlineCode> and{' '}
+        <InlineCode>/api/v1/auth/login</InlineCode> require authentication.
+      </Paragraph>
+
+      <SubHeading>Common Response Patterns</SubHeading>
+      <BulletList
+        items={[
+          '200 OK -- Successful GET/PUT/PATCH requests',
+          '201 Created -- Successful POST creation',
+          '204 No Content -- Successful DELETE',
+          '400 Bad Request -- Validation errors (Pydantic schema failures)',
+          '401 Unauthorized -- Missing or expired JWT token',
+          '403 Forbidden -- Insufficient role or unit scope',
+          '404 Not Found -- Resource does not exist',
+          '422 Unprocessable Entity -- Request body validation failed',
+        ]}
+      />
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// SECTION: Simulator
+// ---------------------------------------------------------------------------
 
 function SimulatorSection() {
   return (
@@ -803,10 +1375,11 @@ function SimulatorSection() {
       <SectionHeading>Simulator</SectionHeading>
 
       <Paragraph>
-        KEYSTONE includes a built-in simulator that generates realistic logistics
-        data for demonstrations, training, and testing. The simulator creates
-        supply status reports, equipment readiness updates, transportation
-        requests, and alert conditions.
+        KEYSTONE includes a built-in event-driven simulator that generates
+        realistic logistics data for demonstrations, training, and development
+        testing. The simulator posts data through the same API endpoints used
+        by real data sources, exercising all ingestion, validation, and
+        processing logic.
       </Paragraph>
 
       <SubHeading>Running the Simulator</SubHeading>
@@ -814,9 +1387,13 @@ function SimulatorSection() {
 docker compose --profile demo up -d
 
 # View simulator output
-docker compose logs -f simulator`}</CodeBlock>
+docker compose logs -f simulator
 
-      <SubHeading>Configuration</SubHeading>
+# Or run standalone against any KEYSTONE instance
+cd backend
+python -m simulator run --scenario=steel_guardian --speed=60`}</CodeBlock>
+
+      <SubHeading>Available Scenarios (20)</SubHeading>
       <div
         style={{
           backgroundColor: 'var(--color-bg)',
@@ -841,57 +1418,217 @@ docker compose logs -f simulator`}</CodeBlock>
                 backgroundColor: 'var(--color-bg-elevated)',
               }}
             >
-              <th style={thStyle}>Variable</th>
+              <th style={thStyle}>Category</th>
+              <th style={thStyle}>Scenarios</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[
+              ['Pre-Deployment (CONUS)', 'steel_guardian, itx, steel_knight, comptuex'],
+              ['Indo-Pacific', 'cobra_gold, balikatan, resolute_dragon, ssang_yong, kamandag, valiant_shield, rimpac, island_sentinel'],
+              ['Europe / Africa / ME', 'african_lion, cold_response, native_fury'],
+              ['Americas / Maritime', 'unitas'],
+              ['Crisis Response', 'trident_spear'],
+              ['Reserve Component', 'reserve_itx'],
+              ['Deployment / Garrison', 'pacific_fury, iron_forge'],
+            ].map(([cat, scenarios]) => (
+              <tr key={cat} style={trStyle}>
+                <td style={{ ...tdStyle, fontWeight: 600, whiteSpace: 'nowrap' }}>{cat}</td>
+                <td style={tdStyle}>{scenarios}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <SubHeading>CLI Options</SubHeading>
+      <div
+        style={{
+          backgroundColor: 'var(--color-bg)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius)',
+          overflow: 'hidden',
+          marginBottom: 16,
+        }}
+      >
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+          }}
+        >
+          <thead>
+            <tr
+              style={{
+                borderBottom: '1px solid var(--color-border)',
+                backgroundColor: 'var(--color-bg-elevated)',
+              }}
+            >
+              <th style={thStyle}>Flag / Env Var</th>
               <th style={thStyle}>Default</th>
               <th style={thStyle}>Description</th>
             </tr>
           </thead>
           <tbody>
-            <tr style={trStyle}>
-              <td style={tdStyle}>SIM_SPEED</td>
-              <td style={tdStyle}>60</td>
-              <td style={tdStyle}>
-                Time multiplier (60 = 1 hour of data per minute)
-              </td>
-            </tr>
-            <tr style={trStyle}>
-              <td style={tdStyle}>SIM_SCENARIO</td>
-              <td style={tdStyle}>steel_guardian</td>
-              <td style={tdStyle}>Scenario name</td>
-            </tr>
-            <tr style={trStyle}>
-              <td style={tdStyle}>KEYSTONE_URL</td>
-              <td style={tdStyle}>http://backend:8000</td>
-              <td style={tdStyle}>Backend API URL</td>
-            </tr>
+            {[
+              ['--scenario / SIM_SCENARIO', 'steel_guardian', 'Scenario name from the catalog above'],
+              ['--speed / SIM_SPEED', '60', 'Speed multiplier (60 = 1 sim-minute per real-second)'],
+              ['--url / KEYSTONE_URL', 'http://localhost:8000', 'KEYSTONE API base URL'],
+              ['--username', 'simulator', 'API username for authentication'],
+              ['--password / SIM_PASSWORD', '--', 'API password'],
+              ['--log-level', 'INFO', 'Logging level (DEBUG, INFO, WARNING, ERROR)'],
+              ['--max-events-per-tick', '50', 'Max events processed per simulation tick'],
+            ].map(([flag, def, desc]) => (
+              <tr key={flag} style={trStyle}>
+                <td style={{ ...tdStyle, whiteSpace: 'nowrap' }}>{flag}</td>
+                <td style={tdStyle}>{def}</td>
+                <td style={tdStyle}>{desc}</td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>
 
-      <SubHeading>Steel Guardian Scenario</SubHeading>
+      <SubHeading>Simulated Events</SubHeading>
       <Paragraph>
-        The default scenario simulates a Marine Expeditionary Brigade (MEB)
-        conducting a multi-phase exercise. It generates:
+        Each scenario consists of named phases with different operational tempos
+        (LOW, MEDIUM, HIGH). The simulator generates:
       </Paragraph>
       <BulletList
         items={[
-          'Supply status reports across all ten supply classes (I-X)',
-          'Equipment readiness fluctuations with maintenance events',
-          'Transportation movement requests and convoy manifests',
-          'Personnel strength changes and manning updates',
-          'Readiness alerts when thresholds are crossed',
+          'Supply consumption reports across all 10 NATO supply classes (I-X)',
+          'Equipment breakdowns with probability scaled to operational tempo (LOW 3%, MEDIUM 8%, HIGH 15% per unit/day)',
+          'Resupply convoys with manifests, vehicles, and personnel assignments',
+          'LOGSTAT and readiness report submissions',
+          'Phase transitions with tempo changes',
           'Map position updates for unit movements',
+          'Alert generation when thresholds are crossed',
         ]}
       />
 
+      <SubHeading>List Scenarios</SubHeading>
+      <CodeBlock>{`cd backend
+python -m simulator list
+
+# Output shows all 20 scenarios grouped by category:
+# Pre-Deployment Training (CONUS):
+#   steel_guardian       Exercise Steel Guardian, 29 Palms      [7d, 6u]
+#   itx                  Integrated Training Exercise            [21d, 8u]
+#   ...`}</CodeBlock>
+
       <InfoBox title="Note">
-        The simulator connects to the backend API and submits data through the
-        same endpoints used by real data sources. This means all ingestion,
-        validation, and processing logic is exercised during simulation.
+        The simulator submits data through the same API endpoints used by real
+        data sources. This means all ingestion, validation, RBAC, and processing
+        logic is fully exercised during simulation.
       </InfoBox>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// SECTION: Security
+// ---------------------------------------------------------------------------
+
+function SecuritySection() {
+  return (
+    <div>
+      <SectionHeading>Security</SectionHeading>
+
+      <Paragraph>
+        KEYSTONE is designed for deployment across classification domains with
+        defense-in-depth security. The platform follows DoD Container Hardening
+        Guide (CHG) requirements and implements STIG-aligned controls.
+      </Paragraph>
+
+      <SubHeading>Authentication and Authorization</SubHeading>
+      <BulletList
+        items={[
+          'JWT bearer token authentication (HS256) with configurable expiry (default 8 hours)',
+          'Role-based access control with 6 roles: ADMIN, COMMANDER, S4, S3, OPERATOR, VIEWER',
+          'Unit hierarchy scoping -- users can only access data for their assigned unit and its subordinates',
+          'Seed users are automatically blocked from creation when ENV_MODE is not "development"',
+          'SECRET_KEY must be changed from the default value in production deployments',
+        ]}
+      />
+
+      <SubHeading>Container Hardening (DoD CHG)</SubHeading>
+      <BulletList
+        items={[
+          'All containers run as non-root users (UID 1001)',
+          'Read-only root filesystems with targeted tmpfs mounts for /tmp',
+          'security_opt: no-new-privileges:true on all containers',
+          'cap_drop: ALL with only minimal capabilities added (CHOWN, DAC_OVERRIDE, FOWNER, SETGID, SETUID for database/Redis)',
+          'Multi-stage Docker builds to minimize image attack surface',
+          'nginx-unprivileged base image for the frontend container',
+          'Health checks on all services for orchestrator integration',
+        ]}
+      />
+
+      <SubHeading>Network Security</SubHeading>
+      <BulletList
+        items={[
+          'TLS termination at nginx with self-signed certificates (replace with org PKI in production)',
+          'Strict Transport Security (HSTS) header enforcement',
+          'Content Security Policy (CSP), X-Frame-Options, X-Content-Type-Options headers',
+          'All external tile requests proxied through nginx to prevent CSP violations and data leakage',
+          'CORS origin whitelist (configurable via CORS_ORIGINS environment variable)',
+        ]}
+      />
+
+      <SubHeading>Supply Chain Security</SubHeading>
+      <BulletList
+        items={[
+          'Cosign keyless image signing on all container images pushed to GHCR',
+          'SBOM (Software Bill of Materials) generation and attestation',
+          'Grype and Trivy vulnerability scanning on every CI build',
+          'Semgrep SAST and CodeQL static analysis',
+          'ZAP DAST (Dynamic Application Security Testing) on every pipeline run',
+          'Dependency review on all pull requests',
+        ]}
+      />
+
+      <SubHeading>Input Validation</SubHeading>
+      <BulletList
+        items={[
+          'Pydantic 2 schema validation on all API request bodies',
+          'Parameterized SQL via SQLAlchemy (no raw SQL string interpolation)',
+          'File upload validation with allowed directory restrictions (ALLOWED_DATA_DIRS)',
+          'TAK server connection restrictions with ALLOW_PRIVATE_TAK_HOSTS control',
+        ]}
+      />
+
+      <SubHeading>Classification System</SubHeading>
+      <Paragraph>
+        KEYSTONE supports configurable classification banners per IC/DoD
+        standards. The classification level is set by administrators via the
+        Admin page and applies globally to all users:
+      </Paragraph>
+      <BulletList
+        items={[
+          'UNCLASSIFIED -- Green banner',
+          'CUI (Controlled Unclassified Information) -- Amber banner',
+          'CONFIDENTIAL -- Blue banner',
+          'SECRET -- Red banner',
+          'TOP SECRET -- Orange banner',
+          'TOP SECRET//SCI -- Yellow text on red banner',
+        ]}
+      />
+
+      <WarningBox title="Production Checklist">
+        Before deploying to production: (1) Change SECRET_KEY to a random value,
+        (2) Set ENV_MODE=production to disable seed users, (3) Replace self-signed
+        TLS certificates with organizational PKI, (4) Review and restrict
+        CORS_ORIGINS, (5) Set appropriate classification level.
+      </WarningBox>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SECTION: Troubleshooting
+// ---------------------------------------------------------------------------
 
 function TroubleshootingSection() {
   return (
@@ -916,6 +1653,7 @@ docker compose logs db`}</CodeBlock>
           'Verify PostgreSQL is healthy: docker compose exec db pg_isready -U keystone',
           'Check that port 5432 is not already in use by a local PostgreSQL instance',
           'Ensure DATABASE_URL matches the db service credentials in docker-compose.yml',
+          'Wait for the db health check to pass before starting the backend (docker compose handles this via depends_on)',
         ]}
       />
 
@@ -926,16 +1664,17 @@ docker compose logs db`}</CodeBlock>
           'Check browser console (F12) for JavaScript errors',
           'Verify the backend is reachable: curl http://localhost:8000/health',
           'Check nginx logs: docker compose logs frontend',
+          'Ensure the backend health check has passed before the frontend starts',
         ]}
       />
 
       <SubHeading>Map tiles not loading</SubHeading>
       <BulletList
         items={[
-          'Tiles are proxied through nginx to avoid CSP issues',
-          'Check nginx logs for tile proxy errors',
-          'In air-gapped environments, ensure tileserver-gl is running with valid MBTiles',
-          'Admin > Tile Layers can switch between online and local tile sources',
+          'Tiles are proxied through nginx to avoid CSP issues -- check nginx logs',
+          'In air-gapped environments, ensure cached tiles are available at the configured path',
+          'Admin > Map Tiles can switch between online and local tile sources',
+          'Verify the tile URL template uses correct {z}/{x}/{y} placeholders',
         ]}
       />
 
@@ -945,6 +1684,27 @@ docker compose logs db`}</CodeBlock>
           'JWT tokens expire after 8 hours by default (ACCESS_TOKEN_EXPIRE_MINUTES=480)',
           'Log in again to obtain a fresh token',
           'Verify SECRET_KEY has not changed between token issuance and validation',
+          'Check that the user account is still active (not deactivated in Admin)',
+        ]}
+      />
+
+      <SubHeading>Reports fail to generate</SubHeading>
+      <BulletList
+        items={[
+          'Ensure there is data in the system for the selected unit and date range',
+          'Check backend logs for specific error messages: docker compose logs backend',
+          'Verify the Celery worker is running: docker compose logs celery_worker',
+          'Try generating with a broader date range or a higher-echelon unit',
+        ]}
+      />
+
+      <SubHeading>Simulator not producing data</SubHeading>
+      <BulletList
+        items={[
+          'Verify the simulator container is running: docker compose --profile demo ps',
+          'Check simulator logs: docker compose logs simulator',
+          'Ensure the backend is healthy before the simulator starts (it depends_on backend)',
+          'The simulator authenticates as the "simulator" user -- ensure this user exists or ENV_MODE=development',
         ]}
       />
 
@@ -959,7 +1719,7 @@ docker compose logs celery_worker
 docker compose exec redis redis-cli ping`}</CodeBlock>
 
       <SubHeading>Resetting to a clean state</SubHeading>
-      <CodeBlock>{`# Stop all services and remove volumes
+      <CodeBlock>{`# Stop all services and remove volumes (deletes all data)
 docker compose down -v
 
 # Rebuild and start fresh
@@ -968,11 +1728,16 @@ docker compose up -d --build`}</CodeBlock>
       <InfoBox title="Getting Help">
         If you encounter issues not covered here, check the backend logs for
         detailed error messages. Most errors include structured context that
-        points to the root cause.
+        points to the root cause. For CI/CD issues, review the GitHub Actions
+        workflow runs.
       </InfoBox>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Shared table styles
+// ---------------------------------------------------------------------------
 
 const thStyle: React.CSSProperties = {
   textAlign: 'left',
@@ -994,13 +1759,21 @@ const trStyle: React.CSSProperties = {
   borderBottom: '1px solid var(--color-border)',
 };
 
+// ---------------------------------------------------------------------------
+// Section registry and main component
+// ---------------------------------------------------------------------------
+
 const sectionComponents: Record<Section, () => JSX.Element> = {
   'getting-started': GettingStartedSection,
   architecture: ArchitectureSection,
   features: FeaturesSection,
+  equipment: EquipmentSection,
+  reports: ReportsSection,
+  admin: AdminSection,
   deployment: DeploymentSection,
   'api-reference': ApiReferenceSection,
   simulator: SimulatorSection,
+  security: SecuritySection,
   troubleshooting: TroubleshootingSection,
 };
 

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -1,11 +1,15 @@
 import ReportGenerator from '@/components/reports/ReportGenerator';
 import ReportViewer from '@/components/reports/ReportViewer';
+import ExportDestinations from '@/components/reports/ExportDestinations';
 
 export default function ReportsPage() {
   return (
     <div className="animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
       <div className="grid-responsive-sidebar-content">
-        <ReportGenerator />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <ReportGenerator />
+          <ExportDestinations />
+        </div>
         <ReportViewer />
       </div>
     </div>

--- a/frontend/src/pages/SupplyPage.tsx
+++ b/frontend/src/pages/SupplyPage.tsx
@@ -5,10 +5,12 @@ import SupplyTable from '@/components/supply/SupplyTable';
 import SupplyClassBreakdown from '@/components/supply/SupplyClassBreakdown';
 import DOSCalculator from '@/components/supply/DOSCalculator';
 import ConsumptionChart from '@/components/dashboard/ConsumptionChart';
+import { useDashboardStore } from '@/stores/dashboardStore';
 
 export default function SupplyPage() {
   const [classFilter, setClassFilter] = useState<SupplyClass | undefined>(undefined);
   const [statusFilter, setStatusFilter] = useState<SupplyStatus | undefined>(undefined);
+  const selectedUnitId = useDashboardStore((s) => s.selectedUnitId);
 
   return (
     <div className="animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -91,7 +93,7 @@ export default function SupplyPage() {
 
       {/* Table */}
       <div className="responsive-table-wrapper">
-        <SupplyTable classFilter={classFilter} statusFilter={statusFilter} />
+        <SupplyTable unitFilter={selectedUnitId ?? undefined} classFilter={classFilter} statusFilter={statusFilter} />
       </div>
 
       {/* Bottom Row: Breakdown + Charts + Calculator */}

--- a/frontend/src/pages/TransportationPage.tsx
+++ b/frontend/src/pages/TransportationPage.tsx
@@ -5,19 +5,21 @@ import ThroughputChart from '@/components/transportation/ThroughputChart';
 import RoutePlannerModal from '@/components/transportation/RoutePlannerModal';
 import { mockApi } from '@/api/mockClient';
 import type { Movement } from '@/lib/types';
+import { useDashboardStore } from '@/stores/dashboardStore';
 
 export default function TransportationPage() {
   const [movements, setMovements] = useState<Movement[]>([]);
   const [selectedConvoyId, setSelectedConvoyId] = useState<string | null>(null);
   const [routePlannerOpen, setRoutePlannerOpen] = useState(false);
+  const selectedUnitId = useDashboardStore((s) => s.selectedUnitId);
 
   useEffect(() => {
-    mockApi.getMovements().then(setMovements);
-  }, []);
+    mockApi.getMovements({ unitId: selectedUnitId ?? undefined }).then(setMovements);
+  }, [selectedUnitId]);
 
   const handleSaveRoute = async (data: Partial<Movement>) => {
     await mockApi.createMovement(data);
-    const updated = await mockApi.getMovements();
+    const updated = await mockApi.getMovements({ unitId: selectedUnitId ?? undefined });
     setMovements(updated);
     setRoutePlannerOpen(false);
   };


### PR DESCRIPTION
## Summary

- **Unit selector filtering**: Switching units now filters data across all pages — Dashboard, Equipment, Supply, Transportation, Alerts, Maintenance. Mock API does hierarchical filtering (selecting a parent unit shows all descendants). Replaced hardcoded demo data with live API-driven data.
- **Scenario management admin UI**: New SCENARIOS tab in Admin page with catalog of all 19 exercise scenarios grouped by category, phase timelines, and simulation controls (start/stop/pause/speed). Backend API (8 endpoints) wraps existing simulator engine.
- **Report PDF & API export**: PDF generation for all 7 report types, download button in viewer, configurable API export destinations (CRUD), export-to-API modal with per-destination results.
- **Documentation**: Comprehensive README update, expanded interactive DocsPage (11 sections), new frontend/README.md and backend/README.md.

## Test plan
- [ ] Switch units in sidebar → data changes on Dashboard, Equipment, Supply, Transportation, Alerts
- [ ] Select leaf unit (e.g., "Alpha Co") → only that unit's data shown
- [ ] Select top unit ("I MEF") → all data shown
- [ ] Admin > SCENARIOS tab → 19 scenarios displayed grouped by category
- [ ] Click scenario card → phase timeline expands
- [ ] Reports > generate report → EXPORT PDF button downloads PDF
- [ ] Reports > EXPORT TO API → modal shows destinations, sends report
- [ ] Admin > configure export destinations
- [ ] /docs page → 11 sections with comprehensive feature documentation
- [ ] `cd frontend && npx tsc -b` passes
- [ ] `cd frontend && npx vitest run` passes
- [ ] `cd backend && ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)