### PR TITLE
fix: ESC key closes all modals

### DIFF
--- a/frontend/src/components/equipment/CreateWorkOrderModal.tsx
+++ b/frontend/src/components/equipment/CreateWorkOrderModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { X, AlertTriangle } from 'lucide-react';
 import type { MaintenanceWorkOrder, WorkOrderCategory } from '@/lib/types';
 import { WorkOrderPriority, WorkOrderCategory as WOCat } from '@/lib/types';
@@ -65,6 +65,13 @@ export default function CreateWorkOrderModal({
   const [estimatedCompletion, setEstimatedCompletion] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
 
   if (!isOpen) return null;
 

--- a/frontend/src/components/equipment/WorkOrderDetailModal.tsx
+++ b/frontend/src/components/equipment/WorkOrderDetailModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { X, Package, Clock, Wrench, User, MapPin, Calendar, Tag, Pencil, Trash2, Plus, Check, AlertTriangle, RotateCcw } from 'lucide-react';
 import type { MaintenanceWorkOrder, MaintenancePart, MaintenanceLabor, WorkOrderCategory } from '@/lib/types';
 import { WorkOrderStatus, WorkOrderCategory as WOCat, PartSource, PartStatus, LaborType } from '@/lib/types';
@@ -172,6 +172,14 @@ const inlineTdSelect: React.CSSProperties = {
 };
 
 export default function WorkOrderDetailModal({ workOrder, onClose, onUpdate }: WorkOrderDetailModalProps) {
+  // ----- ESC to close -----
+  useEffect(() => {
+    if (!workOrder) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [workOrder, onClose]);
+
   // ----- Local mutable WO state (so we can reflect mutations immediately) -----
   const [wo, setWo] = useState<MaintenanceWorkOrder | null>(null);
   const [statusLoading, setStatusLoading] = useState(false);

--- a/frontend/src/components/map/RouteImportModal.tsx
+++ b/frontend/src/components/map/RouteImportModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { X, Upload, FileUp, Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
 import { useMapStore } from '@/stores/mapStore';
 import { uploadRouteFile } from '@/api/map';
@@ -29,6 +29,13 @@ export default function RouteImportModal() {
     reset();
     closeRouteImport();
   }, [reset, closeRouteImport]);
+
+  useEffect(() => {
+    if (!routeImportOpen) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') handleClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [routeImportOpen, handleClose]);
 
   const handleFile = useCallback((f: File) => {
     setError('');

--- a/frontend/src/components/map/placement/PlaceEntityModal.tsx
+++ b/frontend/src/components/map/placement/PlaceEntityModal.tsx
@@ -157,6 +157,13 @@ export default function PlaceEntityModal() {
     queryClient,
   ]);
 
+  useEffect(() => {
+    if (!placement.active) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') clearPlacement(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [placement.active, clearPlacement]);
+
   if (!placement.active) return null;
 
   const labelStyle: React.CSSProperties = {

--- a/frontend/src/components/map/placement/RouteDrawModal.tsx
+++ b/frontend/src/components/map/placement/RouteDrawModal.tsx
@@ -163,6 +163,13 @@ export default function RouteDrawModal() {
     queryClient,
   ]);
 
+  useEffect(() => {
+    if (!routeDrawing.active) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') clearRouteDrawing(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [routeDrawing.active, clearRouteDrawing]);
+
   if (!routeDrawing.active) return null;
 
   // When adding a waypoint, collapse to a compact floating bar so the map is clickable

--- a/frontend/src/components/transportation/MovementDetailModal.tsx
+++ b/frontend/src/components/transportation/MovementDetailModal.tsx
@@ -175,6 +175,13 @@ const TILE_URL =
   '/tiles/osm/{z}/{x}/{y}.png';
 
 export default function MovementDetailModal({ movement, onClose }: MovementDetailModalProps) {
+  useEffect(() => {
+    if (!movement) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [movement, onClose]);
+
   if (!movement) return null;
 
   const mov = movement;

--- a/frontend/src/components/transportation/RoutePlannerModal.tsx
+++ b/frontend/src/components/transportation/RoutePlannerModal.tsx
@@ -405,6 +405,13 @@ export default function RoutePlannerModal({
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
   // ---------------------------------------------------------------------------
   // Computed values
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Added Escape key handler to all 7 modals that were missing it:
- MovementDetailModal, WorkOrderDetailModal, CreateWorkOrderModal
- RoutePlannerModal, RouteImportModal, RouteDrawModal, PlaceEntityModal

NearbyModal already had ESC handling — now all 8 modals are consistent.

## Test plan
- [ ] Open any modal → press ESC → modal closes
- [ ] `npx tsc -b` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)