### PR TITLE
fix: map search button not responding to clicks

### DIFF
--- a/frontend/src/components/map/MapSearchBar.tsx
+++ b/frontend/src/components/map/MapSearchBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useMap } from 'react-leaflet';
+import L from 'leaflet';
 import { Search, X, MapPin, Loader2 } from 'lucide-react';
 import {
   mgrsToLatLon,
@@ -68,25 +69,14 @@ export default function MapSearchBar() {
   const containerRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Prevent Leaflet from receiving events on the search bar container
+  // Prevent Leaflet from receiving click/scroll events on the search bar
+  // Uses Leaflet's own helpers which stop propagation at mousedown level,
+  // allowing React 18's click event delegation to still work.
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
-
-    const stop = (e: Event) => e.stopPropagation();
-    // Stop scroll, click, dblclick, mousedown from reaching the map
-    const events = [
-      'click',
-      'dblclick',
-      'mousedown',
-      'mouseup',
-      'wheel',
-      'touchstart',
-    ] as const;
-    events.forEach((evt) => el.addEventListener(evt, stop));
-    return () => {
-      events.forEach((evt) => el.removeEventListener(evt, stop));
-    };
+    L.DomEvent.disableClickPropagation(el);
+    L.DomEvent.disableScrollPropagation(el);
   }, []);
 
   // Click-outside handler to close dropdown


### PR DESCRIPTION
## Summary
The map search button appeared but clicking it did nothing. Root cause: a native `stopPropagation` on `click` events blocked React 18's event delegation (which listens at `#root`). Replaced with Leaflet's `L.DomEvent.disableClickPropagation` which stops at `mousedown` level — blocks Leaflet map interaction while allowing React `onClick` handlers to fire.

## Test plan
- [ ] Click search icon on map → bar expands to 280px with text input
- [ ] Type a location → geocoding results appear
- [ ] Select a result → map flies to location
- [ ] Type lat/lon or MGRS → parses and flies to coordinates
- [ ] Press ESC or click X → search bar collapses
- [ ] `npx tsc -b` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)