### PR TITLE
feat: SITREP reporting engine with templates, schedules, and military report generation

### DIFF
--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 import httpx
@@ -15,7 +15,14 @@ from app.core.auth import get_current_user
 from app.core.exceptions import BadRequestError, NotFoundError
 from app.core.permissions import check_unit_access, get_accessible_units, require_role
 from app.database import get_db
-from app.models.report import Report, ReportExportDestination, ReportStatus, ReportType
+from app.models.report import (
+    Report,
+    ReportExportDestination,
+    ReportSchedule,
+    ReportStatus,
+    ReportTemplate,
+    ReportType,
+)
 from app.models.user import Role, User
 from app.schemas.report import (
     ApiExportRequest,
@@ -25,7 +32,15 @@ from app.schemas.report import (
     ExportDestinationResponse,
     ExportDestinationUpdate,
     ReportCreate,
+    ReportDetailResponse,
     ReportResponse,
+    ScheduleCreate,
+    ScheduleResponse,
+    ScheduleUpdate,
+    SpotrepCreate,
+    TemplateCreate,
+    TemplateResponse,
+    TemplateUpdate,
 )
 from app.services.pdf_generator import generate_report_pdf
 from app.services.report_generator import generate_and_save_report
@@ -131,11 +146,104 @@ async def generate_report(
     return report
 
 
+# ---------------------------------------------------------------------------
+# SITREP / PERSTAT / SPOTREP / Rollup / Template-based generation
+# ---------------------------------------------------------------------------
+
+
+@router.post("/generate/sitrep/{unit_id}", response_model=ReportDetailResponse, status_code=201)
+async def generate_sitrep(
+    unit_id: int,
+    period_hours: int = Query(24, ge=1, le=720),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Generate a SITREP for the specified unit."""
+    await check_unit_access(current_user, unit_id, db)
+    from app.services.sitrep_generator import SitrepGeneratorService
+
+    svc = SitrepGeneratorService(db)
+    now = datetime.now(timezone.utc)
+    report = await svc.generate_sitrep(
+        unit_id, current_user.id, now - timedelta(hours=period_hours), now
+    )
+    return report
+
+
+@router.post("/generate/perstat/{unit_id}", response_model=ReportDetailResponse, status_code=201)
+async def generate_perstat(
+    unit_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Generate a PERSTAT (Personnel Status) report for the specified unit."""
+    await check_unit_access(current_user, unit_id, db)
+    from app.services.sitrep_generator import SitrepGeneratorService
+
+    svc = SitrepGeneratorService(db)
+    report = await svc.generate_perstat(unit_id, current_user.id)
+    return report
+
+
+@router.post("/generate/spotrep/{unit_id}", response_model=ReportDetailResponse, status_code=201)
+async def generate_spotrep(
+    unit_id: int,
+    body: SpotrepCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Generate a SPOTREP (Spot Report) for the specified unit."""
+    await check_unit_access(current_user, unit_id, db)
+    from app.services.sitrep_generator import SitrepGeneratorService
+
+    svc = SitrepGeneratorService(db)
+    report = await svc.generate_spotrep(
+        unit_id,
+        current_user.id,
+        title=body.title,
+        situation_text=body.situation_text,
+        classification=body.classification,
+    )
+    return report
+
+
+@router.post("/generate/rollup/{unit_id}", response_model=ReportDetailResponse, status_code=201)
+async def generate_rollup(
+    unit_id: int,
+    report_type: ReportType = Query(ReportType.SITREP),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Generate a rollup report aggregating subordinate unit reports."""
+    await check_unit_access(current_user, unit_id, db)
+    from app.services.sitrep_generator import SitrepGeneratorService
+
+    svc = SitrepGeneratorService(db)
+    report = await svc.generate_rollup(unit_id, current_user.id, report_type)
+    return report
+
+
+@router.post("/generate/from-template", response_model=ReportDetailResponse, status_code=201)
+async def generate_from_template(
+    template_id: int = Query(...),
+    unit_id: int = Query(...),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Generate a report from a saved template."""
+    await check_unit_access(current_user, unit_id, db)
+    from app.services.sitrep_generator import SitrepGeneratorService
+
+    svc = SitrepGeneratorService(db)
+    report = await svc.render_from_template(template_id, unit_id, current_user.id)
+    return report
+
+
 @router.post("/", response_model=ReportResponse, status_code=201)
 async def create_report(
     data: ReportCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
 ):
     """Create a new report record (legacy endpoint, uses Celery for generation)."""
     await check_unit_access(current_user, data.unit_id, db)
@@ -207,10 +315,63 @@ async def finalize_report(
     if report.status == ReportStatus.FINAL:
         raise BadRequestError("Report is already finalized")
 
+    if report.status not in (ReportStatus.DRAFT, ReportStatus.READY):
+        raise BadRequestError(
+            f"Cannot finalize a report with status '{report.status.value}'. "
+            "Only DRAFT or READY reports can be finalized."
+        )
+
     report.status = ReportStatus.FINAL
+    report.finalized_at = datetime.now(timezone.utc)
+    report.finalized_by = current_user.id
     await db.flush()
     await db.refresh(report)
     return report
+
+
+@router.put("/{report_id}/archive", response_model=ReportResponse)
+async def archive_report(
+    report_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Mark a report as archived."""
+    result = await db.execute(select(Report).where(Report.id == report_id))
+    report = result.scalar_one_or_none()
+    if not report:
+        raise NotFoundError("Report", report_id)
+
+    await check_unit_access(current_user, report.unit_id, db)
+
+    if report.status == ReportStatus.ARCHIVED:
+        raise BadRequestError("Report is already archived")
+
+    if report.status != ReportStatus.FINAL:
+        raise BadRequestError(
+            f"Cannot archive a report with status '{report.status.value}'. "
+            "Only FINAL reports can be archived."
+        )
+
+    report.status = ReportStatus.ARCHIVED
+    await db.flush()
+    await db.refresh(report)
+    return report
+
+
+@router.post("/{report_id}/distribute")
+async def distribute_report(
+    report_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Distribute a report (placeholder)."""
+    result = await db.execute(select(Report).where(Report.id == report_id))
+    report = result.scalar_one_or_none()
+    if not report:
+        raise NotFoundError("Report", report_id)
+
+    await check_unit_access(current_user, report.unit_id, db)
+    return {"message": f"Report {report_id} distribution initiated", "report_id": report_id}
 
 
 # ---------------------------------------------------------------------------
@@ -267,7 +428,7 @@ async def export_report_pdf(
 @router.get("/export-destinations", response_model=List[ExportDestinationResponse])
 async def list_export_destinations(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role([Role.ADMIN])),
 ):
     """List all configured export destinations."""
     result = await db.execute(
@@ -445,3 +606,233 @@ async def export_report_to_api(
                 )
 
     return ApiExportResponse(report_id=report.id, results=results)
+
+
+# ---------------------------------------------------------------------------
+# Report Templates (CRUD)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/templates", response_model=List[TemplateResponse])
+async def list_templates(
+    report_type: Optional[str] = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List all report templates."""
+    query = select(ReportTemplate).order_by(ReportTemplate.name)
+    if report_type:
+        query = query.where(ReportTemplate.report_type == report_type)
+    result = await db.execute(query)
+    return result.scalars().all()
+
+
+@router.get("/templates/{template_id}", response_model=TemplateResponse)
+async def get_template(
+    template_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get a single report template."""
+    result = await db.execute(
+        select(ReportTemplate).where(ReportTemplate.id == template_id)
+    )
+    template = result.scalar_one_or_none()
+    if not template:
+        raise NotFoundError("ReportTemplate", template_id)
+    return template
+
+
+@router.post("/templates", response_model=TemplateResponse, status_code=201)
+async def create_template(
+    data: TemplateCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Create a new report template."""
+    template = ReportTemplate(
+        name=data.name,
+        report_type=data.report_type,
+        description=data.description,
+        template_body=data.template_body,
+        sections=data.sections,
+        classification_default=data.classification_default,
+        is_default=data.is_default,
+        created_by=current_user.id,
+    )
+    db.add(template)
+    await db.flush()
+    await db.refresh(template)
+    return template
+
+
+@router.put("/templates/{template_id}", response_model=TemplateResponse)
+async def update_template(
+    template_id: int,
+    data: TemplateUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Update a report template."""
+    result = await db.execute(
+        select(ReportTemplate).where(ReportTemplate.id == template_id)
+    )
+    template = result.scalar_one_or_none()
+    if not template:
+        raise NotFoundError("ReportTemplate", template_id)
+
+    # Only the template creator or an ADMIN can modify templates
+    if template.created_by != current_user.id and current_user.role != Role.ADMIN:
+        raise BadRequestError("Only the template creator or an ADMIN can modify this template")
+
+    update_data = data.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(template, field, value)
+
+    await db.flush()
+    await db.refresh(template)
+    return template
+
+
+@router.delete("/templates/{template_id}", status_code=204)
+async def delete_template(
+    template_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Delete a report template."""
+    result = await db.execute(
+        select(ReportTemplate).where(ReportTemplate.id == template_id)
+    )
+    template = result.scalar_one_or_none()
+    if not template:
+        raise NotFoundError("ReportTemplate", template_id)
+
+    # Only the template creator or an ADMIN can delete templates
+    if template.created_by != current_user.id and current_user.role != Role.ADMIN:
+        raise BadRequestError("Only the template creator or an ADMIN can delete this template")
+
+    await db.delete(template)
+    await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# Report Schedules (CRUD)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/schedules", response_model=List[ScheduleResponse])
+async def list_schedules(
+    unit_id: Optional[int] = Query(None),
+    is_active: Optional[bool] = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List report schedules, optionally filtered by unit or active status."""
+    accessible = await get_accessible_units(db, current_user)
+    query = select(ReportSchedule).where(ReportSchedule.unit_id.in_(accessible))
+
+    if unit_id and unit_id in accessible:
+        query = query.where(ReportSchedule.unit_id == unit_id)
+    if is_active is not None:
+        query = query.where(ReportSchedule.is_active == is_active)
+
+    query = query.order_by(ReportSchedule.id)
+    result = await db.execute(query)
+    return result.scalars().all()
+
+
+@router.get("/schedules/{schedule_id}", response_model=ScheduleResponse)
+async def get_schedule(
+    schedule_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get a single report schedule."""
+    result = await db.execute(
+        select(ReportSchedule).where(ReportSchedule.id == schedule_id)
+    )
+    schedule = result.scalar_one_or_none()
+    if not schedule:
+        raise NotFoundError("ReportSchedule", schedule_id)
+
+    await check_unit_access(current_user, schedule.unit_id, db)
+    return schedule
+
+
+@router.post("/schedules", response_model=ScheduleResponse, status_code=201)
+async def create_schedule(
+    data: ScheduleCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Create a new report schedule."""
+    await check_unit_access(current_user, data.unit_id, db)
+
+    # Verify template exists
+    tpl_result = await db.execute(
+        select(ReportTemplate).where(ReportTemplate.id == data.template_id)
+    )
+    if not tpl_result.scalar_one_or_none():
+        raise NotFoundError("ReportTemplate", data.template_id)
+
+    schedule = ReportSchedule(
+        template_id=data.template_id,
+        unit_id=data.unit_id,
+        frequency=data.frequency,
+        time_of_day=data.time_of_day,
+        day_of_week=data.day_of_week,
+        day_of_month=data.day_of_month,
+        auto_distribute=data.auto_distribute,
+        distribution_list=data.distribution_list,
+    )
+    db.add(schedule)
+    await db.flush()
+    await db.refresh(schedule)
+    return schedule
+
+
+@router.put("/schedules/{schedule_id}", response_model=ScheduleResponse)
+async def update_schedule(
+    schedule_id: int,
+    data: ScheduleUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Update a report schedule."""
+    result = await db.execute(
+        select(ReportSchedule).where(ReportSchedule.id == schedule_id)
+    )
+    schedule = result.scalar_one_or_none()
+    if not schedule:
+        raise NotFoundError("ReportSchedule", schedule_id)
+
+    await check_unit_access(current_user, schedule.unit_id, db)
+
+    update_data = data.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(schedule, field, value)
+
+    await db.flush()
+    await db.refresh(schedule)
+    return schedule
+
+
+@router.delete("/schedules/{schedule_id}", status_code=204)
+async def delete_schedule(
+    schedule_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(WRITE_ROLES)),
+):
+    """Delete a report schedule."""
+    result = await db.execute(
+        select(ReportSchedule).where(ReportSchedule.id == schedule_id)
+    )
+    schedule = result.scalar_one_or_none()
+    if not schedule:
+        raise NotFoundError("ReportSchedule", schedule_id)
+
+    await check_unit_access(current_user, schedule.unit_id, db)
+
+    await db.delete(schedule)
+    await db.flush()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -42,7 +42,19 @@ from app.models.maintenance_schedule import (
     DeadlineReason,
     EROStatus,
 )
-from app.models.report import Report, ReportType, ReportStatus, ReportExportDestination, AuthType
+from app.models.report import (
+    Report,
+    ReportType,
+    ReportStatus,
+    ReportExportDestination,
+    AuthType,
+    ReportFormat,
+    ReportClassification,
+    ScheduleFrequency,
+    ReportSection,
+    ReportTemplate,
+    ReportSchedule,
+)
 from app.models.raw_data import RawData, SourceType, ParseStatus
 from app.models.alert import Alert, AlertType, AlertSeverity
 from app.models.canonical_schema import CanonicalField
@@ -156,6 +168,12 @@ __all__ = [
     "ReportStatus",
     "ReportExportDestination",
     "AuthType",
+    "ReportFormat",
+    "ReportClassification",
+    "ScheduleFrequency",
+    "ReportSection",
+    "ReportTemplate",
+    "ReportSchedule",
     "RawData",
     "SourceType",
     "ParseStatus",

--- a/backend/app/models/report.py
+++ b/backend/app/models/report.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     Text,
 )
 from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from app.database import Base
@@ -27,12 +28,63 @@ class ReportType(str, enum.Enum):
     MOVEMENT_SUMMARY = "MOVEMENT_SUMMARY"
     PERSONNEL_STRENGTH = "PERSONNEL_STRENGTH"
     ROLLUP = "ROLLUP"
+    SITREP = "SITREP"
+    SPOTREP = "SPOTREP"
+    PERSTAT = "PERSTAT"
+    INTSUM = "INTSUM"
+    COMMAND_BRIEF = "COMMAND_BRIEF"
+    AAR = "AAR"
 
 
 class ReportStatus(str, enum.Enum):
     DRAFT = "DRAFT"
     READY = "READY"
     FINAL = "FINAL"
+    ARCHIVED = "ARCHIVED"
+
+
+class ReportFormat(str, enum.Enum):
+    TEXT = "TEXT"
+    HTML = "HTML"
+    PDF = "PDF"
+    JSON = "JSON"
+
+
+class ReportClassification(str, enum.Enum):
+    UNCLASS = "UNCLASS"
+    CUI = "CUI"
+    SECRET = "SECRET"
+    TS = "TS"
+    TS_SCI = "TS_SCI"
+
+
+class ScheduleFrequency(str, enum.Enum):
+    DAILY = "DAILY"
+    WEEKLY = "WEEKLY"
+    BIWEEKLY = "BIWEEKLY"
+    MONTHLY = "MONTHLY"
+
+
+class ReportSection(str, enum.Enum):
+    HEADER = "HEADER"
+    SITUATION = "SITUATION"
+    LOGISTICS_SUMMARY = "LOGISTICS_SUMMARY"
+    SUPPLY_CLASS_I = "SUPPLY_CLASS_I"
+    SUPPLY_CLASS_III = "SUPPLY_CLASS_III"
+    SUPPLY_CLASS_V = "SUPPLY_CLASS_V"
+    SUPPLY_CLASS_VIII = "SUPPLY_CLASS_VIII"
+    EQUIPMENT_STATUS = "EQUIPMENT_STATUS"
+    MAINTENANCE_STATUS = "MAINTENANCE_STATUS"
+    PERSONNEL_STRENGTH = "PERSONNEL_STRENGTH"
+    MOVEMENT_STATUS = "MOVEMENT_STATUS"
+    AMMUNITION_STATUS = "AMMUNITION_STATUS"
+    MEDICAL_STATUS = "MEDICAL_STATUS"
+    COMMUNICATIONS = "COMMUNICATIONS"
+    MORALE = "MORALE"
+    COMMANDER_ASSESSMENT = "COMMANDER_ASSESSMENT"
+    REQUESTS = "REQUESTS"
+    WEATHER = "WEATHER"
+    FOOTER = "FOOTER"
 
 
 class Report(Base):
@@ -48,6 +100,27 @@ class Report(Base):
     generated_by = Column(Integer, ForeignKey("users.id"), nullable=True)
     period_start = Column(DateTime(timezone=True), nullable=True)
     period_end = Column(DateTime(timezone=True), nullable=True)
+
+    # --- New columns for SITREP expansion ---
+    template_id = Column(Integer, ForeignKey("report_templates.id"), nullable=True)
+    format = Column(SQLEnum(ReportFormat), default=ReportFormat.TEXT)
+    classification = Column(SQLEnum(ReportClassification), default=ReportClassification.UNCLASS)
+    distribution_list = Column(JSON, nullable=True)
+    auto_generated = Column(Boolean, default=False)
+    schedule_id = Column(Integer, ForeignKey("report_schedules.id"), nullable=True)
+    parent_report_id = Column(Integer, ForeignKey("reports.id"), nullable=True)
+    finalized_at = Column(DateTime(timezone=True), nullable=True)
+    finalized_by = Column(Integer, ForeignKey("users.id"), nullable=True)
+
+    # --- Relationships ---
+    template = relationship("ReportTemplate", back_populates="reports", foreign_keys=[template_id])
+    schedule = relationship("ReportSchedule", back_populates="reports", foreign_keys=[schedule_id])
+    child_reports = relationship(
+        "Report",
+        backref="parent_report",
+        remote_side=[id],
+        foreign_keys=[parent_report_id],
+    )
 
 
 class AuthType(str, enum.Enum):
@@ -68,3 +141,44 @@ class ReportExportDestination(Base):
     headers = Column(JSON, nullable=True)
     is_active = Column(Boolean, default=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class ReportTemplate(Base):
+    __tablename__ = "report_templates"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False, unique=True, index=True)
+    report_type = Column(String(50), nullable=False)
+    description = Column(Text, nullable=True)
+    template_body = Column(Text, nullable=False)
+    sections = Column(JSON, nullable=False)
+    classification_default = Column(String(50), default="UNCLASS")
+    is_default = Column(Boolean, default=False)
+    created_by = Column(Integer, ForeignKey("users.id"), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    reports = relationship("Report", back_populates="template", foreign_keys="Report.template_id")
+
+
+class ReportSchedule(Base):
+    __tablename__ = "report_schedules"
+
+    id = Column(Integer, primary_key=True, index=True)
+    template_id = Column(Integer, ForeignKey("report_templates.id"), nullable=False)
+    unit_id = Column(Integer, ForeignKey("units.id"), nullable=False, index=True)
+    frequency = Column(SQLEnum(ScheduleFrequency), nullable=False)
+    time_of_day = Column(String(5), nullable=True)  # HH:MM format (avoid Time for SQLite compat)
+    day_of_week = Column(Integer, nullable=True)
+    day_of_month = Column(Integer, nullable=True)
+    is_active = Column(Boolean, default=True, index=True)
+    last_generated = Column(DateTime(timezone=True), nullable=True)
+    next_generation = Column(DateTime(timezone=True), nullable=True)
+    auto_distribute = Column(Boolean, default=False)
+    distribution_list = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    template = relationship("ReportTemplate")
+    unit = relationship("Unit")
+    reports = relationship("Report", back_populates="schedule", foreign_keys="Report.schedule_id")

--- a/backend/app/schemas/report.py
+++ b/backend/app/schemas/report.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from app.models.report import ReportStatus, ReportType
+from app.models.report import ReportClassification, ReportStatus, ReportType, ScheduleFrequency
 
 
 class ReportBase(BaseModel):
@@ -26,6 +26,11 @@ class ReportResponse(ReportBase):
     generated_at: datetime
     status: ReportStatus
     generated_by: Optional[int] = None
+    format: Optional[str] = None
+    classification: Optional[str] = None
+    auto_generated: bool = False
+    finalized_at: Optional[datetime] = None
+    finalized_by: Optional[int] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -55,9 +60,14 @@ class ExportDestinationUpdate(BaseModel):
     is_active: Optional[bool] = None
 
 
-class ExportDestinationResponse(ExportDestinationBase):
+class ExportDestinationResponse(BaseModel):
     id: int
+    name: str
+    url: str
+    auth_type: str
+    is_active: bool
     created_at: datetime
+    # NO auth_value or headers — sensitive data excluded from responses
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -77,3 +87,106 @@ class ApiExportResultItem(BaseModel):
 class ApiExportResponse(BaseModel):
     report_id: int
     results: List[ApiExportResultItem]
+
+
+# --- Template schemas ---
+
+
+class TemplateCreate(BaseModel):
+    name: str = Field(..., max_length=255)
+    report_type: str = Field(..., max_length=50)
+    description: Optional[str] = Field(None, max_length=2000)
+    template_body: str = Field(..., max_length=50000)
+    sections: List[str]
+    classification_default: str = Field("UNCLASS", max_length=50)
+    is_default: bool = False
+
+
+class TemplateUpdate(BaseModel):
+    name: Optional[str] = Field(None, max_length=255)
+    report_type: Optional[str] = Field(None, max_length=50)
+    description: Optional[str] = Field(None, max_length=2000)
+    template_body: Optional[str] = Field(None, max_length=50000)
+    sections: Optional[List[str]] = None
+    classification_default: Optional[str] = Field(None, max_length=50)
+    is_default: Optional[bool] = None
+
+
+class TemplateResponse(BaseModel):
+    id: int
+    name: str
+    report_type: str
+    description: Optional[str] = None
+    template_body: str
+    sections: List[str]
+    classification_default: str
+    is_default: bool
+    created_by: int
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# --- Schedule schemas ---
+
+
+class ScheduleCreate(BaseModel):
+    template_id: int
+    unit_id: int
+    frequency: ScheduleFrequency
+    time_of_day: Optional[str] = Field(None, max_length=5, pattern=r"^\d{2}:\d{2}$")
+    day_of_week: Optional[int] = Field(None, ge=0, le=6)
+    day_of_month: Optional[int] = Field(None, ge=1, le=31)
+    auto_distribute: bool = False
+    distribution_list: Optional[List[dict]] = None
+
+
+class ScheduleUpdate(BaseModel):
+    frequency: Optional[ScheduleFrequency] = None
+    time_of_day: Optional[str] = Field(None, max_length=5, pattern=r"^\d{2}:\d{2}$")
+    day_of_week: Optional[int] = Field(None, ge=0, le=6)
+    day_of_month: Optional[int] = Field(None, ge=1, le=31)
+    is_active: Optional[bool] = None
+    auto_distribute: Optional[bool] = None
+    distribution_list: Optional[List[dict]] = None
+
+
+class ScheduleResponse(BaseModel):
+    id: int
+    template_id: int
+    unit_id: int
+    frequency: ScheduleFrequency
+    time_of_day: Optional[str] = None
+    day_of_week: Optional[int] = None
+    day_of_month: Optional[int] = None
+    is_active: bool
+    last_generated: Optional[datetime] = None
+    next_generation: Optional[datetime] = None
+    auto_distribute: bool
+    distribution_list: Optional[List[dict]] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# --- SPOTREP generation ---
+
+
+class SpotrepCreate(BaseModel):
+    title: str = Field(..., max_length=255)
+    situation_text: str = Field(..., max_length=10000)
+    classification: ReportClassification = ReportClassification.CUI
+
+
+# --- Enhanced Report Response ---
+
+
+class ReportDetailResponse(ReportResponse):
+    """Extended report response with new fields."""
+
+    template_id: Optional[int] = None
+    distribution_list: Optional[List[dict]] = None
+    schedule_id: Optional[int] = None
+    parent_report_id: Optional[int] = None

--- a/backend/app/services/sitrep_generator.py
+++ b/backend/app/services/sitrep_generator.py
@@ -1,0 +1,435 @@
+"""SITREP and military report generation service."""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import NotFoundError
+from app.models.alert import Alert
+from app.models.equipment import EquipmentStatus
+from app.models.maintenance import MaintenanceWorkOrder, WorkOrderStatus
+from app.models.medical import CasualtyReport, CasualtyReportStatus
+from app.models.personnel import Personnel, PersonnelStatus
+from app.models.report import (
+    Report,
+    ReportClassification,
+    ReportFormat,
+    ReportStatus,
+    ReportTemplate,
+    ReportType,
+)
+from app.models.transportation import Movement, MovementStatus
+from app.models.unit import Unit
+
+logger = logging.getLogger(__name__)
+
+_CLASSIFICATION_ORDER = {
+    ReportClassification.UNCLASS: 0,
+    ReportClassification.CUI: 1,
+    ReportClassification.SECRET: 2,
+    ReportClassification.TS: 3,
+    ReportClassification.TS_SCI: 4,
+}
+
+
+class SitrepGeneratorService:
+    """Generates SITREP, PERSTAT, SPOTREP, and other military-format reports."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def _get_unit(self, unit_id: int) -> Unit:
+        result = await self.db.execute(select(Unit).where(Unit.id == unit_id))
+        unit = result.scalar_one_or_none()
+        if not unit:
+            raise NotFoundError("Unit", unit_id)
+        return unit
+
+    async def generate_sitrep(
+        self,
+        unit_id: int,
+        user_id: int,
+        period_start: Optional[datetime] = None,
+        period_end: Optional[datetime] = None,
+    ) -> Report:
+        """Generate comprehensive SITREP combining all operational data."""
+        now = datetime.now(timezone.utc)
+        period_start = period_start or (now - timedelta(hours=24))
+        period_end = period_end or now
+        unit = await self._get_unit(unit_id)
+        dtg = now.strftime("%d%H%MZ%b%y").upper()
+
+        # Personnel
+        pers_result = await self.db.execute(
+            select(Personnel).where(Personnel.unit_id == unit_id)
+        )
+        personnel = pers_result.scalars().all()
+        total_pers = len(personnel)
+        active_pers = sum(1 for p in personnel if p.status != PersonnelStatus.INACTIVE)
+
+        # Equipment
+        eq_result = await self.db.execute(
+            select(EquipmentStatus).where(EquipmentStatus.unit_id == unit_id)
+        )
+        equipment = eq_result.scalars().all()
+        total_poss = sum(r.total_possessed for r in equipment)
+        total_mc = sum(r.mission_capable for r in equipment)
+        mc_rate = round(total_mc / total_poss * 100, 1) if total_poss > 0 else 0.0
+
+        # Open work orders
+        wo_result = await self.db.execute(
+            select(func.count(MaintenanceWorkOrder.id)).where(
+                MaintenanceWorkOrder.unit_id == unit_id,
+                MaintenanceWorkOrder.status != WorkOrderStatus.COMPLETE,
+            )
+        )
+        open_wos = wo_result.scalar() or 0
+
+        # Active movements
+        mv_result = await self.db.execute(
+            select(func.count(Movement.id)).where(
+                Movement.unit_id == unit_id,
+                Movement.status.in_([MovementStatus.EN_ROUTE, MovementStatus.PLANNED]),
+            )
+        )
+        active_mvts = mv_result.scalar() or 0
+
+        # Active casualties
+        cas_result = await self.db.execute(
+            select(func.count(CasualtyReport.id)).where(
+                CasualtyReport.unit_id == unit_id,
+                CasualtyReport.status.in_(
+                    [CasualtyReportStatus.OPEN, CasualtyReportStatus.IN_PROGRESS]
+                ),
+            )
+        )
+        active_casualties = cas_result.scalar() or 0
+
+        # Alerts
+        alert_result = await self.db.execute(
+            select(Alert)
+            .where(Alert.unit_id == unit_id, Alert.created_at >= period_start)
+            .order_by(Alert.created_at.desc())
+            .limit(10)
+        )
+        alerts = alert_result.scalars().all()
+
+        pers_readiness = round(active_pers / total_pers * 100, 1) if total_pers > 0 else 0.0
+
+        content = (
+            f"SITUATION REPORT (SITREP)\n"
+            f"================================================\n"
+            f"UNIT: {unit.name} ({unit.abbreviation or ''})\n"
+            f"DTG: {dtg}\n"
+            f"CLASSIFICATION: CUI\n"
+            f"PERIOD: {period_start.strftime('%Y%m%d %H%M')}Z"
+            f" - {period_end.strftime('%Y%m%d %H%M')}Z\n"
+            f"\n"
+            f"1. SITUATION:\n"
+            f"   Unit Status: OPERATIONAL\n"
+            f"\n"
+            f"2. PERSONNEL:\n"
+            f"   Assigned: {total_pers}\n"
+            f"   Present/Active: {active_pers}\n"
+            f"   Readiness: {pers_readiness}%\n"
+            f"   Active Casualties: {active_casualties}\n"
+            f"\n"
+            f"3. LOGISTICS:\n"
+            f"   Equipment MC Rate: {mc_rate}%\n"
+            f"   Total Possessed: {total_poss}\n"
+            f"   Mission Capable: {total_mc}\n"
+            f"   Open Work Orders: {open_wos}\n"
+            f"\n"
+            f"4. MOVEMENTS:\n"
+            f"   Active/Planned: {active_mvts}\n"
+            f"\n"
+            f"5. ALERTS/EVENTS:\n"
+        )
+        for a in alerts:
+            sev = a.severity.value if hasattr(a, "severity") and a.severity else "INFO"
+            content += f"   [{sev}] {a.message}\n"
+        if not alerts:
+            content += "   No significant events during reporting period.\n"
+
+        content += (
+            f"\n"
+            f"6. COMMANDER'S ASSESSMENT:\n"
+            f"   Unit is operational and mission capable.\n"
+            f"\n"
+            f"================================================\n"
+            f"Report generated by KEYSTONE // {dtg}\n"
+        )
+
+        report = Report(
+            unit_id=unit_id,
+            report_type=ReportType.SITREP,
+            title=f"SITREP {unit.name} {now.strftime('%Y%m%d %H%M')}Z",
+            content=content,
+            format=ReportFormat.TEXT,
+            classification=ReportClassification.CUI,
+            status=ReportStatus.READY,
+            generated_by=user_id,
+            auto_generated=False,
+            period_start=period_start,
+            period_end=period_end,
+        )
+        self.db.add(report)
+        await self.db.flush()
+        await self.db.refresh(report)
+        return report
+
+    async def generate_perstat(
+        self,
+        unit_id: int,
+        user_id: int,
+    ) -> Report:
+        """Generate PERSTAT (Personnel Status) report."""
+        now = datetime.now(timezone.utc)
+        unit = await self._get_unit(unit_id)
+        dtg = now.strftime("%d%H%MZ%b%y").upper()
+
+        pers_result = await self.db.execute(
+            select(Personnel).where(Personnel.unit_id == unit_id)
+        )
+        personnel = pers_result.scalars().all()
+
+        status_counts: Dict[str, int] = {}
+        for p in personnel:
+            s = p.status.value if p.status else "ACTIVE"
+            status_counts[s] = status_counts.get(s, 0) + 1
+
+        total = len(personnel)
+        active = status_counts.get(PersonnelStatus.ACTIVE.value, 0)
+        pers_readiness = round(active / total * 100, 1) if total > 0 else 0.0
+
+        content = (
+            f"PERSONNEL STATUS REPORT (PERSTAT)\n"
+            f"================================================\n"
+            f"UNIT: {unit.name} ({unit.abbreviation or ''})\n"
+            f"DTG: {dtg}\n"
+            f"CLASSIFICATION: CUI\n"
+            f"\n"
+            f"STRENGTH SUMMARY:\n"
+            f"  Total Assigned: {total}\n"
+            f"  Present/Active: {active}\n"
+            f"  Readiness: {pers_readiness}%\n"
+            f"\n"
+            f"PERSONNEL BY STATUS:\n"
+        )
+        for status, count in sorted(status_counts.items()):
+            content += f"  {status}: {count}\n"
+
+        content += (
+            f"\n"
+            f"================================================\n"
+            f"Report generated by KEYSTONE // {dtg}\n"
+        )
+
+        report = Report(
+            unit_id=unit_id,
+            report_type=ReportType.PERSTAT,
+            title=f"PERSTAT {unit.name} {now.strftime('%Y%m%d')}",
+            content=content,
+            format=ReportFormat.TEXT,
+            classification=ReportClassification.CUI,
+            status=ReportStatus.READY,
+            generated_by=user_id,
+            auto_generated=False,
+            period_start=now.replace(hour=0, minute=0, second=0, microsecond=0),
+            period_end=now,
+        )
+        self.db.add(report)
+        await self.db.flush()
+        await self.db.refresh(report)
+        return report
+
+    async def generate_spotrep(
+        self,
+        unit_id: int,
+        user_id: int,
+        title: str,
+        situation_text: str,
+        classification: ReportClassification = ReportClassification.CUI,
+    ) -> Report:
+        """Generate SPOTREP (Spot Report) -- urgent, user-initiated."""
+        now = datetime.now(timezone.utc)
+        unit = await self._get_unit(unit_id)
+        dtg = now.strftime("%d%H%MZ%b%y").upper()
+
+        cls = classification
+
+        content = (
+            f"SPOT REPORT (SPOTREP)\n"
+            f"================================================\n"
+            f"UNIT: {unit.name} ({unit.abbreviation or ''})\n"
+            f"DTG: {dtg}\n"
+            f"CLASSIFICATION: {cls.value}\n"
+            f"\n"
+            f"SITUATION:\n"
+            f"{situation_text}\n"
+            f"\n"
+            f"================================================\n"
+            f"Report generated by KEYSTONE // {dtg}\n"
+        )
+
+        report = Report(
+            unit_id=unit_id,
+            report_type=ReportType.SPOTREP,
+            title=title,
+            content=content,
+            format=ReportFormat.TEXT,
+            classification=cls,
+            status=ReportStatus.READY,
+            generated_by=user_id,
+            auto_generated=False,
+        )
+        self.db.add(report)
+        await self.db.flush()
+        await self.db.refresh(report)
+        return report
+
+    async def generate_rollup(
+        self,
+        parent_unit_id: int,
+        user_id: int,
+        report_type: ReportType = ReportType.SITREP,
+    ) -> Report:
+        """Generate rollup report aggregating subordinate unit reports."""
+        now = datetime.now(timezone.utc)
+        unit = await self._get_unit(parent_unit_id)
+        dtg = now.strftime("%d%H%MZ%b%y").upper()
+
+        # Get subordinate units (Unit.parent_id is the FK column)
+        sub_result = await self.db.execute(
+            select(Unit).where(Unit.parent_id == parent_unit_id)
+        )
+        subordinates = sub_result.scalars().all()
+
+        # Get latest report from each subordinate
+        child_reports: List[Report] = []
+        for sub in subordinates:
+            rpt_result = await self.db.execute(
+                select(Report)
+                .where(
+                    Report.unit_id == sub.id,
+                    Report.report_type == report_type,
+                    Report.status.in_([ReportStatus.READY, ReportStatus.FINAL]),
+                )
+                .order_by(Report.generated_at.desc())
+                .limit(1)
+            )
+            rpt = rpt_result.scalar_one_or_none()
+            if rpt:
+                child_reports.append(rpt)
+
+        # Compute rollup classification as the MAX of all child classifications
+        max_cls = ReportClassification.UNCLASS
+        for cr in child_reports:
+            cr_cls = cr.classification or ReportClassification.UNCLASS
+            if _CLASSIFICATION_ORDER.get(cr_cls, 0) > _CLASSIFICATION_ORDER.get(max_cls, 0):
+                max_cls = cr_cls
+
+        content = (
+            f"ROLLUP REPORT -- {report_type.value}\n"
+            f"================================================\n"
+            f"PARENT UNIT: {unit.name} ({unit.abbreviation or ''})\n"
+            f"DTG: {dtg}\n"
+            f"CLASSIFICATION: {max_cls.value}\n"
+            f"SUBORDINATE REPORTS INCLUDED: {len(child_reports)}\n"
+            f"\n"
+        )
+        for cr in child_reports:
+            content += f"--- {cr.title} (Status: {cr.status.value}) ---\n"
+            snippet = (cr.content or "")[:500]
+            content += f"{snippet}\n\n"
+
+        content += (
+            f"================================================\n"
+            f"Report generated by KEYSTONE // {dtg}\n"
+        )
+
+        report = Report(
+            unit_id=parent_unit_id,
+            report_type=ReportType.ROLLUP,
+            title=f"ROLLUP {report_type.value} {unit.name} {dtg}",
+            content=content,
+            format=ReportFormat.TEXT,
+            classification=max_cls,
+            status=ReportStatus.READY,
+            generated_by=user_id,
+            auto_generated=True,
+        )
+        self.db.add(report)
+        await self.db.flush()
+        await self.db.refresh(report)
+
+        # Link child reports
+        for cr in child_reports:
+            cr.parent_report_id = report.id
+        await self.db.flush()
+
+        return report
+
+    async def render_from_template(
+        self,
+        template_id: int,
+        unit_id: int,
+        user_id: int,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> Report:
+        """Render a report using a Jinja2 template."""
+        from jinja2.sandbox import SandboxedEnvironment
+
+        tpl_result = await self.db.execute(
+            select(ReportTemplate).where(ReportTemplate.id == template_id)
+        )
+        template = tpl_result.scalar_one_or_none()
+        if not template:
+            raise NotFoundError("ReportTemplate", template_id)
+
+        unit = await self._get_unit(unit_id)
+        now = datetime.now(timezone.utc)
+
+        env = SandboxedEnvironment(autoescape=True)
+        jinja_tpl = env.from_string(template.template_body)
+
+        render_data = {
+            "unit": {"name": unit.name, "abbreviation": unit.abbreviation, "uic": unit.uic},
+            "dtg": now.strftime("%d%H%MZ%b%y").upper(),
+            "generated_at": now.isoformat(),
+            **(data or {}),
+        }
+
+        rendered = jinja_tpl.render(**render_data)
+
+        report_type = ReportType.SITREP
+        try:
+            report_type = ReportType(template.report_type)
+        except ValueError:
+            pass
+
+        cls = ReportClassification.UNCLASS
+        try:
+            cls = ReportClassification(template.classification_default)
+        except ValueError:
+            pass
+
+        report = Report(
+            unit_id=unit_id,
+            report_type=report_type,
+            title=f"{template.report_type} {unit.name} {now.strftime('%Y%m%d')}",
+            content=rendered,
+            template_id=template_id,
+            format=ReportFormat.TEXT,
+            classification=cls,
+            status=ReportStatus.READY,
+            generated_by=user_id,
+            auto_generated=False,
+        )
+        self.db.add(report)
+        await self.db.flush()
+        await self.db.refresh(report)
+        return report

--- a/frontend/src/api/mockClient.ts
+++ b/frontend/src/api/mockClient.ts
@@ -47,10 +47,13 @@ import type {
   ExportDestinationCreate,
   ExportDestinationUpdate,
   ApiExportResponse,
+  ReportTemplate,
+  ReportSchedule,
 } from '@/lib/types';
 
 import {
   ReportType,
+  ScheduleFrequency,
   WorkOrderStatus,
   SupplyStatus,
 } from '@/lib/types';
@@ -138,6 +141,18 @@ let demoWorkOrders = [...DEMO_WORK_ORDERS];
 let demoIndividualEquipment = [...DEMO_INDIVIDUAL_EQUIPMENT];
 let demoFaults = [...DEMO_EQUIPMENT_FAULTS];
 let demoDriverAssignments = [...DEMO_DRIVER_ASSIGNMENTS];
+
+let demoTemplates: ReportTemplate[] = [
+  { id: 1, name: 'Default LOGSTAT', report_type: 'LOGSTAT', description: 'Standard logistics status template', template_body: '...', sections: ['HEADER', 'LOGISTICS_SUMMARY', 'SUPPLY_CLASS_I', 'SUPPLY_CLASS_III', 'EQUIPMENT_STATUS', 'FOOTER'], classification_default: 'CUI', is_default: true, created_by: 1, created_at: '2026-01-15T00:00:00Z' },
+  { id: 2, name: 'Daily SITREP', report_type: 'SITREP', description: 'Daily situation report template', template_body: '...', sections: ['HEADER', 'SITUATION', 'PERSONNEL_STRENGTH', 'LOGISTICS_SUMMARY', 'EQUIPMENT_STATUS', 'MAINTENANCE_STATUS', 'COMMANDER_ASSESSMENT', 'FOOTER'], classification_default: 'CUI', is_default: true, created_by: 1, created_at: '2026-01-15T00:00:00Z' },
+  { id: 3, name: 'Weekly PERSTAT', report_type: 'PERSTAT', description: 'Weekly personnel status template', template_body: '...', sections: ['HEADER', 'PERSONNEL_STRENGTH', 'FOOTER'], classification_default: 'CUI', is_default: false, created_by: 1, created_at: '2026-01-20T00:00:00Z' },
+];
+
+let demoSchedules: ReportSchedule[] = [
+  { id: 1, template_id: 1, unit_id: 3, frequency: ScheduleFrequency.DAILY, time_of_day: '06:00', is_active: true, auto_distribute: true, last_generated: '2026-03-04T06:00:00Z', next_generation: '2026-03-05T06:00:00Z', created_at: '2026-02-01T00:00:00Z' },
+  { id: 2, template_id: 2, unit_id: 3, frequency: ScheduleFrequency.DAILY, time_of_day: '18:00', is_active: true, auto_distribute: false, last_generated: '2026-03-04T18:00:00Z', next_generation: '2026-03-05T18:00:00Z', created_at: '2026-02-01T00:00:00Z' },
+  { id: 3, template_id: 3, unit_id: 3, frequency: ScheduleFrequency.WEEKLY, time_of_day: '08:00', day_of_week: 0, is_active: true, auto_distribute: true, created_at: '2026-02-15T00:00:00Z' },
+];
 
 // ---------------------------------------------------------------------------
 // Helper: hierarchical unit filtering — walks the unit tree to find
@@ -761,6 +776,261 @@ export const mockApi = {
         };
       }),
     };
+  },
+
+  // -------------------------------------------------------------------------
+  // SITREP / PERSTAT / SPOTREP Quick Generation
+  // -------------------------------------------------------------------------
+
+  async generateSitrep(unitId: number, periodHours?: number): Promise<Report> {
+    await mockDelay(800);
+    const unit = DEMO_UNITS.find((u) => u.id === String(unitId));
+    const unitName = unit?.abbreviation || 'Unknown';
+    const now = new Date();
+    const period = periodHours || 24;
+    const periodStart = new Date(now.getTime() - period * 3600000);
+    const content = [
+      `SITREP`,
+      `DTG: ${now.toISOString()}`,
+      `FROM: ${unitName}`,
+      `PERIOD: ${periodStart.toISOString()} TO ${now.toISOString()}`,
+      ``,
+      `1. SITUATION: Unit continues operations in AO. No significant enemy activity.`,
+      ``,
+      `2. PERSONNEL STRENGTH:`,
+      `   AUTHORIZED: 847  ASSIGNED: 812  PRESENT: 789`,
+      `   CASUALTIES LAST ${period}H: 0`,
+      ``,
+      `3. LOGISTICS SUMMARY:`,
+      `   CLASS I: GREEN (7 DOS)`,
+      `   CLASS III: AMBER (4 DOS)`,
+      `   CLASS V: GREEN (8 DOS)`,
+      `   CLASS IX: AMBER (3 DOS)`,
+      ``,
+      `4. EQUIPMENT STATUS:`,
+      `   TOTAL POSSESSED: 156  MC: 136  NMC: 20`,
+      `   READINESS: 87%`,
+      ``,
+      `5. MAINTENANCE:`,
+      `   OPEN WORK ORDERS: 12  DEADLINED: 3`,
+      ``,
+      `6. COMMANDER'S ASSESSMENT:`,
+      `   Unit maintains combat readiness. Class III resupply requested.`,
+      `   No significant issues to report.`,
+    ].join('\n');
+
+    const report: Report = {
+      id: 'rpt-sitrep-' + Date.now(),
+      type: ReportType.SITREP,
+      title: `SITREP - ${unitName} - ${now.toLocaleDateString()}`,
+      unitId: String(unitId),
+      unitName,
+      dateRange: { start: periodStart.toISOString(), end: now.toISOString() },
+      status: 'READY' as ReportStatus,
+      content,
+      generatedBy: 'Demo User',
+      generatedAt: now.toISOString(),
+    };
+    demoReports = [report, ...demoReports];
+    return report;
+  },
+
+  async generatePerstat(unitId: number): Promise<Report> {
+    await mockDelay(800);
+    const unit = DEMO_UNITS.find((u) => u.id === String(unitId));
+    const unitName = unit?.abbreviation || 'Unknown';
+    const now = new Date();
+    const content = [
+      `PERSTAT`,
+      `DTG: ${now.toISOString()}`,
+      `FROM: ${unitName}`,
+      ``,
+      `1. STRENGTH:`,
+      `   AUTHORIZED OFFICERS: 42   ASSIGNED: 39`,
+      `   AUTHORIZED ENLISTED: 805  ASSIGNED: 773`,
+      `   TOTAL AUTHORIZED: 847     TOTAL ASSIGNED: 812`,
+      `   FILL RATE: 95.9%`,
+      ``,
+      `2. DUTY STATUS:`,
+      `   PRESENT FOR DUTY: 789`,
+      `   LEAVE: 8`,
+      `   TDY/TAD: 6`,
+      `   MEDICAL (LIMDU): 5`,
+      `   UA: 0`,
+      `   ATTACHED: 4`,
+      `   DETACHED: 0`,
+      ``,
+      `3. MOS SHORTFALLS:`,
+      `   0311 (RIFLEMAN): AUTH 180, ASGD 172, SHORT 8`,
+      `   0352 (ANTI-TANK): AUTH 24, ASGD 20, SHORT 4`,
+      `   0621 (RADIO OPER): AUTH 36, ASGD 33, SHORT 3`,
+      ``,
+      `4. REMARKS:`,
+      `   No significant personnel issues.`,
+    ].join('\n');
+
+    const report: Report = {
+      id: 'rpt-perstat-' + Date.now(),
+      type: ReportType.PERSTAT,
+      title: `PERSTAT - ${unitName} - ${now.toLocaleDateString()}`,
+      unitId: String(unitId),
+      unitName,
+      dateRange: { start: now.toISOString(), end: now.toISOString() },
+      status: 'READY' as ReportStatus,
+      content,
+      generatedBy: 'Demo User',
+      generatedAt: now.toISOString(),
+    };
+    demoReports = [report, ...demoReports];
+    return report;
+  },
+
+  async generateSpotrep(unitId: number, data: { title: string; situation_text: string; classification?: string }): Promise<Report> {
+    await mockDelay(800);
+    const unit = DEMO_UNITS.find((u) => u.id === String(unitId));
+    const unitName = unit?.abbreviation || 'Unknown';
+    const now = new Date();
+    const classification = data.classification || 'CUI';
+    const content = [
+      `CLASSIFICATION: ${classification}`,
+      `SPOTREP`,
+      `DTG: ${now.toISOString()}`,
+      `FROM: ${unitName}`,
+      ``,
+      `LINE 1 - DATE/TIME: ${now.toISOString()}`,
+      `LINE 2 - UNIT: ${unitName}`,
+      `LINE 3 - SIZE/ACTIVITY: SEE BELOW`,
+      `LINE 4 - LOCATION: AO ${unitName}`,
+      `LINE 5 - EQUIPMENT: N/A`,
+      `LINE 6 - NARRATIVE:`,
+      `   ${data.situation_text}`,
+      ``,
+      `TITLE: ${data.title}`,
+      ``,
+      `ASSESSMENT: Situation under observation. No immediate action required.`,
+    ].join('\n');
+
+    const report: Report = {
+      id: 'rpt-spotrep-' + Date.now(),
+      type: ReportType.SPOTREP,
+      title: data.title || `SPOTREP - ${unitName} - ${now.toLocaleDateString()}`,
+      unitId: String(unitId),
+      unitName,
+      dateRange: { start: now.toISOString(), end: now.toISOString() },
+      status: 'READY' as ReportStatus,
+      content,
+      generatedBy: 'Demo User',
+      generatedAt: now.toISOString(),
+    };
+    demoReports = [report, ...demoReports];
+    return report;
+  },
+
+  async generateRollup(unitId: number, reportType?: string): Promise<Report> {
+    await mockDelay(1000);
+    const unit = DEMO_UNITS.find((u) => u.id === String(unitId));
+    const unitName = unit?.abbreviation || 'Unknown';
+    const now = new Date();
+    const rType = reportType || 'SITREP';
+    const content = [
+      `${rType} ROLLUP`,
+      `DTG: ${now.toISOString()}`,
+      `FROM: ${unitName} (ROLLUP OF SUBORDINATE UNITS)`,
+      ``,
+      `1. SUBORDINATE REPORTS AGGREGATED: 3`,
+      `   - 1/1 BN: SUBMITTED`,
+      `   - 2/1 BN: SUBMITTED`,
+      `   - 3/1 BN: SUBMITTED`,
+      ``,
+      `2. COMBINED STRENGTH: 2,431 / 2,541 (95.7%)`,
+      ``,
+      `3. COMBINED LOGISTICS:`,
+      `   CLASS I: GREEN  CLASS III: AMBER  CLASS V: GREEN  CLASS IX: AMBER`,
+      ``,
+      `4. COMBINED EQUIPMENT: 468 POSS / 407 MC (87.0%)`,
+      ``,
+      `5. COMMANDER'S ASSESSMENT:`,
+      `   Regiment maintains combat readiness across all battalions.`,
+      `   Class III resupply priority for 1/1 and 3/1 BN.`,
+    ].join('\n');
+
+    const report: Report = {
+      id: 'rpt-rollup-' + Date.now(),
+      type: rType as ReportType,
+      title: `${rType} ROLLUP - ${unitName} - ${now.toLocaleDateString()}`,
+      unitId: String(unitId),
+      unitName,
+      dateRange: { start: now.toISOString(), end: now.toISOString() },
+      status: 'READY' as ReportStatus,
+      content,
+      generatedBy: 'Demo User',
+      generatedAt: now.toISOString(),
+    };
+    demoReports = [report, ...demoReports];
+    return report;
+  },
+
+  // -------------------------------------------------------------------------
+  // Templates
+  // -------------------------------------------------------------------------
+
+  async getTemplates(): Promise<ReportTemplate[]> {
+    await mockDelay();
+    return [...demoTemplates];
+  },
+
+  async createTemplate(data: Omit<ReportTemplate, 'id' | 'created_by' | 'created_at' | 'updated_at'>): Promise<ReportTemplate> {
+    await mockDelay();
+    const template: ReportTemplate = {
+      ...data,
+      id: Date.now(),
+      created_by: 1,
+      created_at: new Date().toISOString(),
+    };
+    demoTemplates.push(template);
+    return template;
+  },
+
+  async updateTemplate(id: number, data: Partial<ReportTemplate>): Promise<ReportTemplate> {
+    await mockDelay();
+    demoTemplates = demoTemplates.map((t) =>
+      t.id === id ? { ...t, ...data, updated_at: new Date().toISOString() } as ReportTemplate : t,
+    );
+    return demoTemplates.find((t) => t.id === id) || demoTemplates[0];
+  },
+
+  async deleteTemplate(id: number): Promise<void> {
+    await mockDelay();
+    demoTemplates = demoTemplates.filter((t) => t.id !== id);
+  },
+
+  // -------------------------------------------------------------------------
+  // Schedules
+  // -------------------------------------------------------------------------
+
+  async getSchedules(_unitId?: number): Promise<ReportSchedule[]> {
+    await mockDelay();
+    let schedules = [...demoSchedules];
+    if (_unitId) {
+      schedules = schedules.filter((s) => s.unit_id === _unitId);
+    }
+    return schedules;
+  },
+
+  async createSchedule(data: Omit<ReportSchedule, 'id' | 'last_generated' | 'next_generation' | 'created_at' | 'updated_at'>): Promise<ReportSchedule> {
+    await mockDelay();
+    const schedule: ReportSchedule = {
+      ...data,
+      id: Date.now(),
+      created_at: new Date().toISOString(),
+    };
+    demoSchedules.push(schedule);
+    return schedule;
+  },
+
+  async deleteSchedule(id: number): Promise<void> {
+    await mockDelay();
+    demoSchedules = demoSchedules.filter((s) => s.id !== id);
   },
 
   // -------------------------------------------------------------------------

--- a/frontend/src/api/reports.ts
+++ b/frontend/src/api/reports.ts
@@ -9,6 +9,8 @@ import type {
   ExportDestinationCreate,
   ExportDestinationUpdate,
   ApiExportResponse,
+  ReportTemplate,
+  ReportSchedule,
 } from '@/lib/types';
 
 export async function getReports(filters?: ReportFilters): Promise<PaginatedResponse<Report>> {
@@ -88,4 +90,80 @@ export async function exportReportToApi(reportId: string, destinationIds: number
     destination_ids: destinationIds,
   });
   return response.data;
+}
+
+// --- SITREP/PERSTAT/SPOTREP quick generation ---
+
+export async function generateSitrep(unitId: number, periodHours?: number): Promise<Report> {
+  if (isDemoMode) return mockApi.generateSitrep(unitId, periodHours);
+  const response = await apiClient.post<Report>(`/reports/generate/sitrep/${unitId}`, null, {
+    params: { period_hours: periodHours || 24 },
+  });
+  return response.data;
+}
+
+export async function generatePerstat(unitId: number): Promise<Report> {
+  if (isDemoMode) return mockApi.generatePerstat(unitId);
+  const response = await apiClient.post<Report>(`/reports/generate/perstat/${unitId}`);
+  return response.data;
+}
+
+export async function generateSpotrep(unitId: number, data: { title: string; situation_text: string; classification?: string }): Promise<Report> {
+  if (isDemoMode) return mockApi.generateSpotrep(unitId, data);
+  const response = await apiClient.post<Report>(`/reports/generate/spotrep/${unitId}`, data);
+  return response.data;
+}
+
+export async function generateRollup(unitId: number, reportType?: string): Promise<Report> {
+  if (isDemoMode) return mockApi.generateRollup(unitId, reportType);
+  const response = await apiClient.post<Report>(`/reports/generate/rollup/${unitId}`, null, {
+    params: { report_type: reportType || 'SITREP' },
+  });
+  return response.data;
+}
+
+// --- Templates ---
+
+export async function getTemplates(): Promise<ReportTemplate[]> {
+  if (isDemoMode) return mockApi.getTemplates();
+  const response = await apiClient.get<ReportTemplate[]>('/reports/templates');
+  return response.data;
+}
+
+export async function createTemplate(data: Omit<ReportTemplate, 'id' | 'created_by' | 'created_at' | 'updated_at'>): Promise<ReportTemplate> {
+  if (isDemoMode) return mockApi.createTemplate(data);
+  const response = await apiClient.post<ReportTemplate>('/reports/templates', data);
+  return response.data;
+}
+
+export async function updateTemplate(id: number, data: Partial<ReportTemplate>): Promise<ReportTemplate> {
+  if (isDemoMode) return mockApi.updateTemplate(id, data);
+  const response = await apiClient.put<ReportTemplate>(`/reports/templates/${id}`, data);
+  return response.data;
+}
+
+export async function deleteTemplate(id: number): Promise<void> {
+  if (isDemoMode) return mockApi.deleteTemplate(id);
+  await apiClient.delete(`/reports/templates/${id}`);
+}
+
+// --- Schedules ---
+
+export async function getSchedules(unitId?: number): Promise<ReportSchedule[]> {
+  if (isDemoMode) return mockApi.getSchedules(unitId);
+  const response = await apiClient.get<ReportSchedule[]>('/reports/schedules', {
+    params: unitId ? { unit_id: unitId } : undefined,
+  });
+  return response.data;
+}
+
+export async function createSchedule(data: Omit<ReportSchedule, 'id' | 'last_generated' | 'next_generation' | 'created_at' | 'updated_at'>): Promise<ReportSchedule> {
+  if (isDemoMode) return mockApi.createSchedule(data);
+  const response = await apiClient.post<ReportSchedule>('/reports/schedules', data);
+  return response.data;
+}
+
+export async function deleteSchedule(id: number): Promise<void> {
+  if (isDemoMode) return mockApi.deleteSchedule(id);
+  await apiClient.delete(`/reports/schedules/${id}`);
 }

--- a/frontend/src/components/reports/QuickGeneratePanel.tsx
+++ b/frontend/src/components/reports/QuickGeneratePanel.tsx
@@ -1,0 +1,385 @@
+import { useState, useCallback } from 'react';
+import { Zap, Loader, FileText } from 'lucide-react';
+import Card from '@/components/ui/Card';
+import { ReportType } from '@/lib/types';
+import type { Report, ReportContent, GenerateReportParams } from '@/lib/types';
+import {
+  generateReport,
+  generateSitrep,
+  generatePerstat,
+  generateSpotrep,
+  generateRollup,
+} from '@/api/reports';
+import { useReportStore } from '@/stores/reportStore';
+
+type QuickReportType =
+  | 'LOGSTAT'
+  | 'SITREP'
+  | 'PERSTAT'
+  | 'SPOTREP'
+  | 'EQUIPMENT'
+  | 'MAINTENANCE'
+  | 'ROLLUP';
+
+const QUICK_REPORT_TYPES: { type: QuickReportType; label: string; desc: string }[] = [
+  { type: 'LOGSTAT', label: 'LOGSTAT', desc: 'Supply, equipment, maintenance summary' },
+  { type: 'SITREP', label: 'SITREP', desc: 'Situation report with all sections' },
+  { type: 'PERSTAT', label: 'PERSTAT', desc: 'Personnel status and strength' },
+  { type: 'SPOTREP', label: 'SPOTREP', desc: 'Spot report for immediate events' },
+  { type: 'EQUIPMENT', label: 'EQUIPMENT', desc: 'Fleet readiness and NMC breakdown' },
+  { type: 'MAINTENANCE', label: 'MAINTENANCE', desc: 'Work orders, labor, parts status' },
+  { type: 'ROLLUP', label: 'ROLLUP', desc: 'Aggregate subordinate unit reports' },
+];
+
+const UNIT_OPTIONS = [
+  { value: 1, label: 'I MEF' },
+  { value: 2, label: '1ST MARDIV' },
+  { value: 3, label: '1ST MARINES' },
+  { value: 4, label: '1/1 BN' },
+  { value: 5, label: '2/1 BN' },
+  { value: 6, label: '3/1 BN' },
+];
+
+const ROLLUP_TYPE_OPTIONS = [
+  { value: 'SITREP', label: 'SITREP' },
+  { value: 'LOGSTAT', label: 'LOGSTAT' },
+  { value: 'PERSTAT', label: 'PERSTAT' },
+];
+
+export default function QuickGeneratePanel() {
+  const [selectedType, setSelectedType] = useState<QuickReportType>('SITREP');
+  const [unitId, setUnitId] = useState(3);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [generatedContent, setGeneratedContent] = useState<string | null>(null);
+
+  // SPOTREP fields
+  const [spotrepTitle, setSpotrepTitle] = useState('');
+  const [spotrepSituation, setSpotrepSituation] = useState('');
+
+  // ROLLUP fields
+  const [rollupType, setRollupType] = useState('SITREP');
+
+  const { addReport, setSelectedReport } = useReportStore();
+
+  const handleGenerate = useCallback(async () => {
+    setIsGenerating(true);
+    setError(null);
+    setGeneratedContent(null);
+    try {
+      let report: Report;
+
+      switch (selectedType) {
+        case 'SITREP':
+          report = await generateSitrep(unitId, 24);
+          break;
+        case 'PERSTAT':
+          report = await generatePerstat(unitId);
+          break;
+        case 'SPOTREP':
+          if (!spotrepTitle || !spotrepSituation) {
+            setError('SPOTREP requires title and situation text');
+            setIsGenerating(false);
+            return;
+          }
+          report = await generateSpotrep(unitId, {
+            title: spotrepTitle,
+            situation_text: spotrepSituation,
+          });
+          break;
+        case 'ROLLUP':
+          report = await generateRollup(unitId, rollupType);
+          break;
+        default: {
+          // Use the standard generate API for LOGSTAT, EQUIPMENT, MAINTENANCE
+          const typeMap: Record<string, ReportType> = {
+            LOGSTAT: ReportType.LOGSTAT,
+            EQUIPMENT: ReportType.EQUIPMENT_STATUS,
+            MAINTENANCE: ReportType.MAINTENANCE_SUMMARY,
+          };
+          const now = new Date();
+          const weekAgo = new Date(now.getTime() - 7 * 86400000);
+          const params: GenerateReportParams = {
+            type: typeMap[selectedType] || ReportType.LOGSTAT,
+            unitId: String(unitId),
+            dateRange: {
+              start: weekAgo.toISOString(),
+              end: now.toISOString(),
+            },
+          };
+          report = await generateReport(params);
+          // Parse content if needed
+          if (report.content && !report.parsedContent) {
+            try {
+              report.parsedContent = JSON.parse(report.content) as ReportContent;
+            } catch {
+              // content is plaintext
+            }
+          }
+          break;
+        }
+      }
+
+      addReport(report);
+      setSelectedReport(report);
+      setGeneratedContent(report.content || JSON.stringify(report.parsedContent, null, 2) || 'Report generated successfully.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate report');
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [selectedType, unitId, spotrepTitle, spotrepSituation, rollupType, addReport, setSelectedReport]);
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '6px 8px',
+    backgroundColor: 'var(--color-bg)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 'var(--radius)',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 11,
+    color: 'var(--color-text)',
+    boxSizing: 'border-box',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontFamily: 'var(--font-mono)',
+    fontSize: 8,
+    textTransform: 'uppercase',
+    letterSpacing: '1.5px',
+    color: 'var(--color-text-muted)',
+    display: 'block',
+    marginBottom: 3,
+  };
+
+  return (
+    <Card
+      title="QUICK GENERATE"
+      headerRight={<Zap size={14} style={{ color: 'var(--color-amber, #f59e0b)' }} />}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        {/* Report type grid */}
+        <div>
+          <label style={labelStyle}>REPORT TYPE</label>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
+              gap: 6,
+            }}
+          >
+            {QUICK_REPORT_TYPES.map((rt) => (
+              <button
+                key={rt.type}
+                onClick={() => setSelectedType(rt.type)}
+                style={{
+                  padding: '8px 10px',
+                  backgroundColor:
+                    selectedType === rt.type
+                      ? 'rgba(59,130,246,0.12)'
+                      : 'var(--color-bg)',
+                  border:
+                    selectedType === rt.type
+                      ? '1px solid var(--color-accent)'
+                      : '1px solid var(--color-border)',
+                  borderRadius: 'var(--radius)',
+                  cursor: 'pointer',
+                  textAlign: 'left',
+                  transition: 'all var(--transition)',
+                }}
+              >
+                <div
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 10,
+                    fontWeight: 700,
+                    color:
+                      selectedType === rt.type
+                        ? 'var(--color-accent)'
+                        : 'var(--color-text-bright)',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  {rt.label}
+                </div>
+                <div
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 8,
+                    color: 'var(--color-text-muted)',
+                    marginTop: 2,
+                    lineHeight: 1.3,
+                  }}
+                >
+                  {rt.desc}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Unit selector */}
+        <div>
+          <label style={labelStyle}>UNIT</label>
+          <select
+            value={unitId}
+            onChange={(e) => setUnitId(Number(e.target.value))}
+            style={inputStyle}
+          >
+            {UNIT_OPTIONS.map((u) => (
+              <option key={u.value} value={u.value}>
+                {u.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* SPOTREP fields */}
+        {selectedType === 'SPOTREP' && (
+          <>
+            <div>
+              <label style={labelStyle}>SPOTREP TITLE</label>
+              <input
+                value={spotrepTitle}
+                onChange={(e) => setSpotrepTitle(e.target.value)}
+                placeholder="Brief title for the spot report"
+                style={inputStyle}
+              />
+            </div>
+            <div>
+              <label style={labelStyle}>SITUATION TEXT</label>
+              <textarea
+                value={spotrepSituation}
+                onChange={(e) => setSpotrepSituation(e.target.value)}
+                placeholder="Describe the situation..."
+                rows={3}
+                style={{
+                  ...inputStyle,
+                  resize: 'vertical',
+                  minHeight: 50,
+                }}
+              />
+            </div>
+          </>
+        )}
+
+        {/* ROLLUP type selector */}
+        {selectedType === 'ROLLUP' && (
+          <div>
+            <label style={labelStyle}>ROLLUP REPORT TYPE</label>
+            <select
+              value={rollupType}
+              onChange={(e) => setRollupType(e.target.value)}
+              style={inputStyle}
+            >
+              {ROLLUP_TYPE_OPTIONS.map((rt) => (
+                <option key={rt.value} value={rt.value}>
+                  {rt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              color: 'var(--color-red, #ff4444)',
+              padding: '6px 8px',
+              backgroundColor: 'rgba(255,68,68,0.08)',
+              borderRadius: 'var(--radius)',
+              border: '1px solid rgba(255,68,68,0.2)',
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Generate button */}
+        <button
+          onClick={handleGenerate}
+          disabled={isGenerating}
+          style={{
+            width: '100%',
+            padding: '10px',
+            backgroundColor: isGenerating ? 'var(--color-muted)' : 'var(--color-accent)',
+            border: 'none',
+            borderRadius: 'var(--radius)',
+            color: 'var(--color-bg)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            fontWeight: 600,
+            letterSpacing: '2px',
+            textTransform: 'uppercase',
+            cursor: isGenerating ? 'not-allowed' : 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+            transition: 'opacity var(--transition)',
+          }}
+        >
+          {isGenerating ? (
+            <>
+              <Loader size={14} className="animate-spin" />
+              GENERATING...
+            </>
+          ) : (
+            <>
+              <Zap size={14} />
+              GENERATE {selectedType}
+            </>
+          )}
+        </button>
+
+        {/* Generated content preview */}
+        {generatedContent && (
+          <div>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                marginBottom: 6,
+              }}
+            >
+              <FileText size={12} style={{ color: 'var(--color-green, #22c55e)' }} />
+              <span
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 9,
+                  fontWeight: 600,
+                  color: 'var(--color-green, #22c55e)',
+                  letterSpacing: '1px',
+                  textTransform: 'uppercase',
+                }}
+              >
+                REPORT GENERATED - VIEW IN REPORTS TAB
+              </span>
+            </div>
+            <pre
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 10,
+                lineHeight: 1.5,
+                color: 'var(--color-text)',
+                whiteSpace: 'pre-wrap',
+                padding: 10,
+                backgroundColor: 'var(--color-bg)',
+                borderRadius: 'var(--radius)',
+                border: '1px solid var(--color-border)',
+                maxHeight: 300,
+                overflow: 'auto',
+              }}
+            >
+              {generatedContent}
+            </pre>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/reports/ScheduleManager.tsx
+++ b/frontend/src/components/reports/ScheduleManager.tsx
@@ -1,0 +1,521 @@
+import { useEffect, useState } from 'react';
+import { Plus, Trash2, Check, X, Loader, Clock, CalendarDays } from 'lucide-react';
+import Card from '@/components/ui/Card';
+import type { ReportTemplate, ReportSchedule } from '@/lib/types';
+import { ScheduleFrequency } from '@/lib/types';
+import { getTemplates, getSchedules, createSchedule, deleteSchedule } from '@/api/reports';
+import { formatDate } from '@/lib/utils';
+
+const FREQUENCY_OPTIONS = [
+  { value: ScheduleFrequency.DAILY, label: 'DAILY' },
+  { value: ScheduleFrequency.WEEKLY, label: 'WEEKLY' },
+  { value: ScheduleFrequency.BIWEEKLY, label: 'BIWEEKLY' },
+  { value: ScheduleFrequency.MONTHLY, label: 'MONTHLY' },
+];
+
+const DAY_OF_WEEK_OPTIONS = [
+  { value: 0, label: 'Sunday' },
+  { value: 1, label: 'Monday' },
+  { value: 2, label: 'Tuesday' },
+  { value: 3, label: 'Wednesday' },
+  { value: 4, label: 'Thursday' },
+  { value: 5, label: 'Friday' },
+  { value: 6, label: 'Saturday' },
+];
+
+const UNIT_OPTIONS = [
+  { value: 1, label: 'I MEF' },
+  { value: 2, label: '1ST MARDIV' },
+  { value: 3, label: '1ST MARINES' },
+  { value: 4, label: '1/1 BN' },
+  { value: 5, label: '2/1 BN' },
+  { value: 6, label: '3/1 BN' },
+];
+
+export default function ScheduleManager() {
+  const [schedules, setSchedules] = useState<ReportSchedule[]>([]);
+  const [templates, setTemplates] = useState<ReportTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Form state
+  const [formTemplateId, setFormTemplateId] = useState<number>(0);
+  const [formUnitId, setFormUnitId] = useState<number>(3);
+  const [formFrequency, setFormFrequency] = useState<ScheduleFrequency>(ScheduleFrequency.DAILY);
+  const [formTimeOfDay, setFormTimeOfDay] = useState('06:00');
+  const [formDayOfWeek, setFormDayOfWeek] = useState<number>(1);
+  const [formDayOfMonth, setFormDayOfMonth] = useState<number>(1);
+  const [formAutoDistribute, setFormAutoDistribute] = useState(false);
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const loadData = async () => {
+    try {
+      const [sData, tData] = await Promise.all([getSchedules(), getTemplates()]);
+      setSchedules(sData);
+      setTemplates(tData);
+      if (tData.length > 0 && formTemplateId === 0) {
+        setFormTemplateId(tData[0].id);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const resetForm = () => {
+    setFormTemplateId(templates.length > 0 ? templates[0].id : 0);
+    setFormUnitId(3);
+    setFormFrequency(ScheduleFrequency.DAILY);
+    setFormTimeOfDay('06:00');
+    setFormDayOfWeek(1);
+    setFormDayOfMonth(1);
+    setFormAutoDistribute(false);
+    setShowForm(false);
+  };
+
+  const handleSave = async () => {
+    if (!formTemplateId) return;
+    setSaving(true);
+    try {
+      const data: Omit<ReportSchedule, 'id' | 'last_generated' | 'next_generation' | 'created_at' | 'updated_at'> = {
+        template_id: formTemplateId,
+        unit_id: formUnitId,
+        frequency: formFrequency,
+        time_of_day: formTimeOfDay,
+        is_active: true,
+        auto_distribute: formAutoDistribute,
+      };
+      if (formFrequency === ScheduleFrequency.WEEKLY || formFrequency === ScheduleFrequency.BIWEEKLY) {
+        data.day_of_week = formDayOfWeek;
+      }
+      if (formFrequency === ScheduleFrequency.MONTHLY) {
+        data.day_of_month = formDayOfMonth;
+      }
+      const created = await createSchedule(data);
+      setSchedules((prev) => [...prev, created]);
+      resetForm();
+    } catch {
+      // ignore
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteSchedule(id);
+      setSchedules((prev) => prev.filter((s) => s.id !== id));
+    } catch {
+      // ignore
+    }
+  };
+
+  const getTemplateName = (templateId: number): string => {
+    return templates.find((t) => t.id === templateId)?.name || `Template #${templateId}`;
+  };
+
+  const getUnitName = (unitId: number): string => {
+    return UNIT_OPTIONS.find((u) => u.value === unitId)?.label || `Unit #${unitId}`;
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '6px 8px',
+    backgroundColor: 'var(--color-bg)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 'var(--radius)',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 11,
+    color: 'var(--color-text)',
+    boxSizing: 'border-box',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontFamily: 'var(--font-mono)',
+    fontSize: 8,
+    textTransform: 'uppercase',
+    letterSpacing: '1.5px',
+    color: 'var(--color-text-muted)',
+    display: 'block',
+    marginBottom: 3,
+  };
+
+  const thStyle: React.CSSProperties = {
+    textAlign: 'left',
+    padding: '6px 8px',
+    borderBottom: '1px solid var(--color-border)',
+    fontFamily: 'var(--font-mono)',
+    fontWeight: 600,
+    fontSize: 9,
+    textTransform: 'uppercase',
+    letterSpacing: '1px',
+    color: 'var(--color-text-muted)',
+  };
+
+  const tdStyle: React.CSSProperties = {
+    padding: '6px 8px',
+    borderBottom: '1px solid var(--color-border)',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 10,
+    color: 'var(--color-text)',
+  };
+
+  return (
+    <Card
+      title="REPORT SCHEDULES"
+      headerRight={
+        !showForm ? (
+          <button
+            onClick={() => {
+              resetForm();
+              setShowForm(true);
+            }}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 4,
+              padding: '4px 10px',
+              backgroundColor: 'var(--color-accent)',
+              border: 'none',
+              borderRadius: 'var(--radius)',
+              color: 'var(--color-bg)',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 9,
+              fontWeight: 600,
+              letterSpacing: '1px',
+              cursor: 'pointer',
+            }}
+          >
+            <Plus size={10} /> ADD SCHEDULE
+          </button>
+        ) : undefined
+      }
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {/* Add Form */}
+        {showForm && (
+          <div
+            style={{
+              padding: 12,
+              backgroundColor: 'var(--color-bg)',
+              border: '1px solid var(--color-accent)',
+              borderRadius: 'var(--radius)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 10,
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 10,
+                fontWeight: 600,
+                color: 'var(--color-accent)',
+                letterSpacing: '1px',
+              }}
+            >
+              NEW SCHEDULE
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+              <div>
+                <label style={labelStyle}>TEMPLATE</label>
+                <select
+                  value={formTemplateId}
+                  onChange={(e) => setFormTemplateId(Number(e.target.value))}
+                  style={inputStyle}
+                >
+                  {templates.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {t.name} ({t.report_type})
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label style={labelStyle}>UNIT</label>
+                <select
+                  value={formUnitId}
+                  onChange={(e) => setFormUnitId(Number(e.target.value))}
+                  style={inputStyle}
+                >
+                  {UNIT_OPTIONS.map((u) => (
+                    <option key={u.value} value={u.value}>
+                      {u.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+              <div>
+                <label style={labelStyle}>FREQUENCY</label>
+                <select
+                  value={formFrequency}
+                  onChange={(e) => setFormFrequency(e.target.value as ScheduleFrequency)}
+                  style={inputStyle}
+                >
+                  {FREQUENCY_OPTIONS.map((f) => (
+                    <option key={f.value} value={f.value}>
+                      {f.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label style={labelStyle}>TIME OF DAY</label>
+                <input
+                  type="time"
+                  value={formTimeOfDay}
+                  onChange={(e) => setFormTimeOfDay(e.target.value)}
+                  style={inputStyle}
+                />
+              </div>
+            </div>
+
+            {(formFrequency === ScheduleFrequency.WEEKLY ||
+              formFrequency === ScheduleFrequency.BIWEEKLY) && (
+              <div>
+                <label style={labelStyle}>DAY OF WEEK</label>
+                <select
+                  value={formDayOfWeek}
+                  onChange={(e) => setFormDayOfWeek(Number(e.target.value))}
+                  style={inputStyle}
+                >
+                  {DAY_OF_WEEK_OPTIONS.map((d) => (
+                    <option key={d.value} value={d.value}>
+                      {d.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {formFrequency === ScheduleFrequency.MONTHLY && (
+              <div>
+                <label style={labelStyle}>DAY OF MONTH</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={28}
+                  value={formDayOfMonth}
+                  onChange={(e) => setFormDayOfMonth(Number(e.target.value))}
+                  style={inputStyle}
+                />
+              </div>
+            )}
+
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <input
+                type="checkbox"
+                checked={formAutoDistribute}
+                onChange={(e) => setFormAutoDistribute(e.target.checked)}
+                style={{ accentColor: 'var(--color-accent)' }}
+              />
+              <span
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 10,
+                  color: 'var(--color-text)',
+                }}
+              >
+                Auto-distribute after generation
+              </span>
+            </div>
+
+            <div style={{ display: 'flex', gap: 6 }}>
+              <button
+                onClick={handleSave}
+                disabled={saving || !formTemplateId}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  padding: '6px 14px',
+                  backgroundColor: !formTemplateId || saving ? 'var(--color-bg-surface)' : 'var(--color-accent)',
+                  border: !formTemplateId || saving ? '1px solid var(--color-border)' : 'none',
+                  borderRadius: 'var(--radius)',
+                  color: !formTemplateId || saving ? 'var(--color-text-muted)' : 'var(--color-bg)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 9,
+                  fontWeight: 600,
+                  letterSpacing: '1px',
+                  cursor: !formTemplateId || saving ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {saving ? <Loader size={10} className="animate-spin" /> : <Check size={10} />}
+                {saving ? 'SAVING...' : 'SAVE'}
+              </button>
+              <button
+                onClick={resetForm}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  padding: '6px 14px',
+                  backgroundColor: 'transparent',
+                  border: '1px solid var(--color-border)',
+                  borderRadius: 'var(--radius)',
+                  color: 'var(--color-text-muted)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 9,
+                  letterSpacing: '1px',
+                  cursor: 'pointer',
+                }}
+              >
+                <X size={10} /> CANCEL
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Schedule Table */}
+        {loading ? (
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--color-text-muted)',
+              padding: 16,
+              textAlign: 'center',
+            }}
+          >
+            Loading schedules...
+          </div>
+        ) : schedules.length === 0 ? (
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--color-text-muted)',
+              padding: 16,
+              textAlign: 'center',
+            }}
+          >
+            No schedules configured yet. Click ADD SCHEDULE to create one.
+          </div>
+        ) : (
+          <div style={{ overflow: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  <th style={thStyle}>TEMPLATE</th>
+                  <th style={thStyle}>UNIT</th>
+                  <th style={thStyle}>FREQUENCY</th>
+                  <th style={thStyle}>TIME</th>
+                  <th style={thStyle}>ACTIVE</th>
+                  <th style={thStyle}>LAST GEN</th>
+                  <th style={thStyle}>NEXT</th>
+                  <th style={thStyle}>ACTIONS</th>
+                </tr>
+              </thead>
+              <tbody>
+                {schedules.map((s) => (
+                  <tr key={s.id}>
+                    <td style={tdStyle}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                        <CalendarDays
+                          size={12}
+                          style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
+                        />
+                        <span style={{ fontWeight: 600, color: 'var(--color-text-bright)' }}>
+                          {getTemplateName(s.template_id)}
+                        </span>
+                      </div>
+                    </td>
+                    <td style={tdStyle}>{getUnitName(s.unit_id)}</td>
+                    <td style={tdStyle}>
+                      <span
+                        style={{
+                          padding: '2px 6px',
+                          borderRadius: 'var(--radius)',
+                          backgroundColor: 'var(--color-bg)',
+                          border: '1px solid var(--color-border)',
+                          fontSize: 8,
+                          letterSpacing: '0.5px',
+                        }}
+                      >
+                        {s.frequency}
+                      </span>
+                    </td>
+                    <td style={tdStyle}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                        <Clock size={10} style={{ color: 'var(--color-text-muted)' }} />
+                        {s.time_of_day || '--:--'}
+                        {s.day_of_week !== undefined &&
+                          (s.frequency === ScheduleFrequency.WEEKLY ||
+                            s.frequency === ScheduleFrequency.BIWEEKLY) && (
+                            <span style={{ fontSize: 8, color: 'var(--color-text-muted)' }}>
+                              ({DAY_OF_WEEK_OPTIONS.find((d) => d.value === s.day_of_week)?.label || ''})
+                            </span>
+                          )}
+                      </div>
+                    </td>
+                    <td style={tdStyle}>
+                      <span
+                        style={{
+                          padding: '2px 6px',
+                          borderRadius: 'var(--radius)',
+                          backgroundColor: s.is_active
+                            ? 'rgba(34,197,94,0.1)'
+                            : 'rgba(255,255,255,0.05)',
+                          border: s.is_active
+                            ? '1px solid rgba(34,197,94,0.3)'
+                            : '1px solid var(--color-border)',
+                          color: s.is_active
+                            ? 'var(--color-green, #22c55e)'
+                            : 'var(--color-text-muted)',
+                          fontSize: 8,
+                          letterSpacing: '0.5px',
+                        }}
+                      >
+                        {s.is_active ? 'YES' : 'NO'}
+                      </span>
+                    </td>
+                    <td style={tdStyle}>
+                      <span style={{ fontSize: 9, color: 'var(--color-text-muted)' }}>
+                        {s.last_generated ? formatDate(s.last_generated) : '--'}
+                      </span>
+                    </td>
+                    <td style={tdStyle}>
+                      <span style={{ fontSize: 9, color: 'var(--color-text-muted)' }}>
+                        {s.next_generation ? formatDate(s.next_generation) : '--'}
+                      </span>
+                    </td>
+                    <td style={tdStyle}>
+                      <button
+                        onClick={() => handleDelete(s.id)}
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 3,
+                          padding: '3px 6px',
+                          backgroundColor: 'transparent',
+                          border: '1px solid rgba(239,68,68,0.3)',
+                          borderRadius: 'var(--radius)',
+                          cursor: 'pointer',
+                          fontFamily: 'var(--font-mono)',
+                          fontSize: 8,
+                          color: 'var(--color-red, #ef4444)',
+                          letterSpacing: '0.5px',
+                        }}
+                      >
+                        <Trash2 size={9} /> DEL
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/reports/TemplateManager.tsx
+++ b/frontend/src/components/reports/TemplateManager.tsx
@@ -1,0 +1,622 @@
+import { useEffect, useState } from 'react';
+import { Plus, Trash2, Edit2, Check, X, Loader, FileText } from 'lucide-react';
+import Card from '@/components/ui/Card';
+import type { ReportTemplate } from '@/lib/types';
+import { ReportType, ReportClassification } from '@/lib/types';
+import { getTemplates, createTemplate, updateTemplate, deleteTemplate } from '@/api/reports';
+
+const REPORT_TYPE_OPTIONS = [
+  ReportType.LOGSTAT,
+  ReportType.SITREP,
+  ReportType.PERSTAT,
+  ReportType.SPOTREP,
+  ReportType.READINESS,
+  ReportType.SUPPLY_STATUS,
+  ReportType.EQUIPMENT_STATUS,
+  ReportType.MAINTENANCE_SUMMARY,
+  ReportType.MOVEMENT_SUMMARY,
+  ReportType.PERSONNEL_STRENGTH,
+  ReportType.INTSUM,
+  ReportType.COMMAND_BRIEF,
+  ReportType.AAR,
+];
+
+const CLASSIFICATION_OPTIONS = [
+  ReportClassification.UNCLASS,
+  ReportClassification.CUI,
+  ReportClassification.SECRET,
+  ReportClassification.TS,
+  ReportClassification.TS_SCI,
+];
+
+const SECTION_OPTIONS = [
+  'HEADER',
+  'SITUATION',
+  'PERSONNEL_STRENGTH',
+  'LOGISTICS_SUMMARY',
+  'SUPPLY_CLASS_I',
+  'SUPPLY_CLASS_III',
+  'SUPPLY_CLASS_V',
+  'SUPPLY_CLASS_IX',
+  'EQUIPMENT_STATUS',
+  'MAINTENANCE_STATUS',
+  'MOVEMENT_STATUS',
+  'COMMANDER_ASSESSMENT',
+  'FOOTER',
+];
+
+export default function TemplateManager() {
+  const [templates, setTemplates] = useState<ReportTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  // Form state
+  const [formName, setFormName] = useState('');
+  const [formType, setFormType] = useState<string>(ReportType.SITREP);
+  const [formDescription, setFormDescription] = useState('');
+  const [formBody, setFormBody] = useState('');
+  const [formSections, setFormSections] = useState<string[]>(['HEADER', 'FOOTER']);
+  const [formClassification, setFormClassification] = useState<string>(ReportClassification.CUI);
+  const [formIsDefault, setFormIsDefault] = useState(false);
+
+  useEffect(() => {
+    loadTemplates();
+  }, []);
+
+  const loadTemplates = async () => {
+    try {
+      const data = await getTemplates();
+      setTemplates(data);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const resetForm = () => {
+    setFormName('');
+    setFormType(ReportType.SITREP);
+    setFormDescription('');
+    setFormBody('');
+    setFormSections(['HEADER', 'FOOTER']);
+    setFormClassification(ReportClassification.CUI);
+    setFormIsDefault(false);
+    setEditingId(null);
+    setShowForm(false);
+  };
+
+  const startEdit = (t: ReportTemplate) => {
+    setFormName(t.name);
+    setFormType(t.report_type);
+    setFormDescription(t.description || '');
+    setFormBody(t.template_body);
+    setFormSections([...t.sections]);
+    setFormClassification(t.classification_default);
+    setFormIsDefault(t.is_default);
+    setEditingId(t.id);
+    setShowForm(true);
+  };
+
+  const toggleSection = (section: string) => {
+    setFormSections((prev) =>
+      prev.includes(section) ? prev.filter((s) => s !== section) : [...prev, section],
+    );
+  };
+
+  const handleSave = async () => {
+    if (!formName || !formType) return;
+    setSaving(true);
+    try {
+      if (editingId) {
+        const updated = await updateTemplate(editingId, {
+          name: formName,
+          report_type: formType,
+          description: formDescription || undefined,
+          template_body: formBody,
+          sections: formSections,
+          classification_default: formClassification,
+          is_default: formIsDefault,
+        });
+        setTemplates((prev) => prev.map((t) => (t.id === editingId ? updated : t)));
+      } else {
+        const created = await createTemplate({
+          name: formName,
+          report_type: formType,
+          description: formDescription || undefined,
+          template_body: formBody,
+          sections: formSections,
+          classification_default: formClassification,
+          is_default: formIsDefault,
+        });
+        setTemplates((prev) => [...prev, created]);
+      }
+      resetForm();
+    } catch {
+      // ignore
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteTemplate(id);
+      setTemplates((prev) => prev.filter((t) => t.id !== id));
+    } catch {
+      // ignore
+    }
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '6px 8px',
+    backgroundColor: 'var(--color-bg)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 'var(--radius)',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 11,
+    color: 'var(--color-text)',
+    boxSizing: 'border-box',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontFamily: 'var(--font-mono)',
+    fontSize: 8,
+    textTransform: 'uppercase',
+    letterSpacing: '1.5px',
+    color: 'var(--color-text-muted)',
+    display: 'block',
+    marginBottom: 3,
+  };
+
+  const smallBtnStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 3,
+    padding: '3px 6px',
+    backgroundColor: 'transparent',
+    border: '1px solid var(--color-border)',
+    borderRadius: 'var(--radius)',
+    cursor: 'pointer',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 8,
+    color: 'var(--color-text-muted)',
+    letterSpacing: '0.5px',
+  };
+
+  const thStyle: React.CSSProperties = {
+    textAlign: 'left',
+    padding: '6px 8px',
+    borderBottom: '1px solid var(--color-border)',
+    fontFamily: 'var(--font-mono)',
+    fontWeight: 600,
+    fontSize: 9,
+    textTransform: 'uppercase',
+    letterSpacing: '1px',
+    color: 'var(--color-text-muted)',
+  };
+
+  const tdStyle: React.CSSProperties = {
+    padding: '6px 8px',
+    borderBottom: '1px solid var(--color-border)',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 10,
+    color: 'var(--color-text)',
+  };
+
+  return (
+    <Card
+      title="REPORT TEMPLATES"
+      headerRight={
+        !showForm ? (
+          <button
+            onClick={() => {
+              resetForm();
+              setShowForm(true);
+            }}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 4,
+              padding: '4px 10px',
+              backgroundColor: 'var(--color-accent)',
+              border: 'none',
+              borderRadius: 'var(--radius)',
+              color: 'var(--color-bg)',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 9,
+              fontWeight: 600,
+              letterSpacing: '1px',
+              cursor: 'pointer',
+            }}
+          >
+            <Plus size={10} /> ADD TEMPLATE
+          </button>
+        ) : undefined
+      }
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {/* Add/Edit Form */}
+        {showForm && (
+          <div
+            style={{
+              padding: 12,
+              backgroundColor: 'var(--color-bg)',
+              border: '1px solid var(--color-accent)',
+              borderRadius: 'var(--radius)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 10,
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 10,
+                fontWeight: 600,
+                color: 'var(--color-accent)',
+                letterSpacing: '1px',
+              }}
+            >
+              {editingId ? 'EDIT TEMPLATE' : 'NEW TEMPLATE'}
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+              <div>
+                <label style={labelStyle}>NAME</label>
+                <input
+                  value={formName}
+                  onChange={(e) => setFormName(e.target.value)}
+                  placeholder="Template name"
+                  style={inputStyle}
+                />
+              </div>
+              <div>
+                <label style={labelStyle}>REPORT TYPE</label>
+                <select
+                  value={formType}
+                  onChange={(e) => setFormType(e.target.value)}
+                  style={inputStyle}
+                >
+                  {REPORT_TYPE_OPTIONS.map((rt) => (
+                    <option key={rt} value={rt}>
+                      {rt}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div>
+              <label style={labelStyle}>DESCRIPTION</label>
+              <input
+                value={formDescription}
+                onChange={(e) => setFormDescription(e.target.value)}
+                placeholder="Optional description"
+                style={inputStyle}
+              />
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+              <div>
+                <label style={labelStyle}>CLASSIFICATION</label>
+                <select
+                  value={formClassification}
+                  onChange={(e) => setFormClassification(e.target.value)}
+                  style={inputStyle}
+                >
+                  {CLASSIFICATION_OPTIONS.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'flex-end', paddingBottom: 4 }}>
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 10,
+                    color: 'var(--color-text)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={formIsDefault}
+                    onChange={(e) => setFormIsDefault(e.target.checked)}
+                    style={{ accentColor: 'var(--color-accent)' }}
+                  />
+                  DEFAULT TEMPLATE
+                </label>
+              </div>
+            </div>
+
+            <div>
+              <label style={labelStyle}>TEMPLATE BODY</label>
+              <textarea
+                value={formBody}
+                onChange={(e) => setFormBody(e.target.value)}
+                placeholder="Template body content..."
+                rows={4}
+                style={{
+                  ...inputStyle,
+                  resize: 'vertical',
+                  minHeight: 60,
+                }}
+              />
+            </div>
+
+            <div>
+              <label style={labelStyle}>SECTIONS</label>
+              <div
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: 6,
+                  padding: 8,
+                  backgroundColor: 'var(--color-bg-surface)',
+                  borderRadius: 'var(--radius)',
+                  border: '1px solid var(--color-border)',
+                }}
+              >
+                {SECTION_OPTIONS.map((section) => (
+                  <label
+                    key={section}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 4,
+                      padding: '3px 8px',
+                      backgroundColor: formSections.includes(section)
+                        ? 'rgba(59,130,246,0.15)'
+                        : 'var(--color-bg)',
+                      border: formSections.includes(section)
+                        ? '1px solid var(--color-accent)'
+                        : '1px solid var(--color-border)',
+                      borderRadius: 'var(--radius)',
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 8,
+                      color: formSections.includes(section)
+                        ? 'var(--color-accent)'
+                        : 'var(--color-text-muted)',
+                      cursor: 'pointer',
+                      letterSpacing: '0.5px',
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={formSections.includes(section)}
+                      onChange={() => toggleSection(section)}
+                      style={{
+                        accentColor: 'var(--color-accent)',
+                        width: 10,
+                        height: 10,
+                      }}
+                    />
+                    {section}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', gap: 6 }}>
+              <button
+                onClick={handleSave}
+                disabled={saving || !formName}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  padding: '6px 14px',
+                  backgroundColor: !formName || saving ? 'var(--color-bg-surface)' : 'var(--color-accent)',
+                  border: !formName || saving ? '1px solid var(--color-border)' : 'none',
+                  borderRadius: 'var(--radius)',
+                  color: !formName || saving ? 'var(--color-text-muted)' : 'var(--color-bg)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 9,
+                  fontWeight: 600,
+                  letterSpacing: '1px',
+                  cursor: !formName || saving ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {saving ? <Loader size={10} className="animate-spin" /> : <Check size={10} />}
+                {saving ? 'SAVING...' : 'SAVE'}
+              </button>
+              <button
+                onClick={resetForm}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  padding: '6px 14px',
+                  backgroundColor: 'transparent',
+                  border: '1px solid var(--color-border)',
+                  borderRadius: 'var(--radius)',
+                  color: 'var(--color-text-muted)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 9,
+                  letterSpacing: '1px',
+                  cursor: 'pointer',
+                }}
+              >
+                <X size={10} /> CANCEL
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Template Table */}
+        {loading ? (
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--color-text-muted)',
+              padding: 16,
+              textAlign: 'center',
+            }}
+          >
+            Loading templates...
+          </div>
+        ) : templates.length === 0 ? (
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--color-text-muted)',
+              padding: 16,
+              textAlign: 'center',
+            }}
+          >
+            No templates configured yet. Click ADD TEMPLATE to create one.
+          </div>
+        ) : (
+          <div style={{ overflow: 'auto' }}>
+            <table
+              style={{
+                width: '100%',
+                borderCollapse: 'collapse',
+              }}
+            >
+              <thead>
+                <tr>
+                  <th style={thStyle}>NAME</th>
+                  <th style={thStyle}>TYPE</th>
+                  <th style={thStyle}>CLASSIFICATION</th>
+                  <th style={thStyle}>DEFAULT</th>
+                  <th style={thStyle}>SECTIONS</th>
+                  <th style={thStyle}>ACTIONS</th>
+                </tr>
+              </thead>
+              <tbody>
+                {templates.map((t) => (
+                  <tr key={t.id}>
+                    <td style={tdStyle}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                        <FileText
+                          size={12}
+                          style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
+                        />
+                        <div>
+                          <div
+                            style={{
+                              fontWeight: 600,
+                              color: 'var(--color-text-bright)',
+                            }}
+                          >
+                            {t.name}
+                          </div>
+                          {t.description && (
+                            <div
+                              style={{
+                                fontSize: 8,
+                                color: 'var(--color-text-muted)',
+                                marginTop: 1,
+                              }}
+                            >
+                              {t.description}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td style={tdStyle}>
+                      <span
+                        style={{
+                          padding: '2px 6px',
+                          borderRadius: 'var(--radius)',
+                          backgroundColor: 'var(--color-bg)',
+                          border: '1px solid var(--color-border)',
+                          fontSize: 8,
+                          letterSpacing: '0.5px',
+                        }}
+                      >
+                        {t.report_type}
+                      </span>
+                    </td>
+                    <td style={tdStyle}>
+                      <span
+                        style={{
+                          padding: '2px 6px',
+                          borderRadius: 'var(--radius)',
+                          backgroundColor:
+                            t.classification_default === 'SECRET' ||
+                            t.classification_default === 'TS' ||
+                            t.classification_default === 'TS_SCI'
+                              ? 'rgba(239,68,68,0.1)'
+                              : 'var(--color-bg)',
+                          border:
+                            t.classification_default === 'SECRET' ||
+                            t.classification_default === 'TS' ||
+                            t.classification_default === 'TS_SCI'
+                              ? '1px solid rgba(239,68,68,0.3)'
+                              : '1px solid var(--color-border)',
+                          color:
+                            t.classification_default === 'SECRET' ||
+                            t.classification_default === 'TS' ||
+                            t.classification_default === 'TS_SCI'
+                              ? 'var(--color-red, #ef4444)'
+                              : 'var(--color-text-muted)',
+                          fontSize: 8,
+                          letterSpacing: '0.5px',
+                        }}
+                      >
+                        {t.classification_default}
+                      </span>
+                    </td>
+                    <td style={tdStyle}>
+                      {t.is_default && (
+                        <span
+                          style={{
+                            padding: '2px 6px',
+                            borderRadius: 'var(--radius)',
+                            backgroundColor: 'rgba(34,197,94,0.1)',
+                            border: '1px solid rgba(34,197,94,0.3)',
+                            color: 'var(--color-green, #22c55e)',
+                            fontSize: 8,
+                            letterSpacing: '0.5px',
+                          }}
+                        >
+                          YES
+                        </span>
+                      )}
+                    </td>
+                    <td style={tdStyle}>
+                      <span style={{ fontSize: 9, color: 'var(--color-text-muted)' }}>
+                        {t.sections.length} sections
+                      </span>
+                    </td>
+                    <td style={tdStyle}>
+                      <div style={{ display: 'flex', gap: 4 }}>
+                        <button onClick={() => startEdit(t)} style={smallBtnStyle}>
+                          <Edit2 size={9} /> EDIT
+                        </button>
+                        <button
+                          onClick={() => handleDelete(t.id)}
+                          style={{
+                            ...smallBtnStyle,
+                            borderColor: 'rgba(239,68,68,0.3)',
+                            color: 'var(--color-red, #ef4444)',
+                          }}
+                        >
+                          <Trash2 size={9} /> DEL
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -76,6 +76,12 @@ export enum ReportType {
   MAINTENANCE_SUMMARY = 'MAINTENANCE_SUMMARY',
   MOVEMENT_SUMMARY = 'MOVEMENT_SUMMARY',
   PERSONNEL_STRENGTH = 'PERSONNEL_STRENGTH',
+  SITREP = 'SITREP',
+  SPOTREP = 'SPOTREP',
+  PERSTAT = 'PERSTAT',
+  INTSUM = 'INTSUM',
+  COMMAND_BRIEF = 'COMMAND_BRIEF',
+  AAR = 'AAR',
   CUSTOM = 'CUSTOM',
 }
 
@@ -85,6 +91,29 @@ export enum ReportStatus {
   READY = 'READY',
   FINALIZED = 'FINALIZED',
   ERROR = 'ERROR',
+  ARCHIVED = 'ARCHIVED',
+}
+
+export enum ReportFormat {
+  TEXT = 'TEXT',
+  HTML = 'HTML',
+  PDF = 'PDF',
+  JSON = 'JSON',
+}
+
+export enum ReportClassification {
+  UNCLASS = 'UNCLASS',
+  CUI = 'CUI',
+  SECRET = 'SECRET',
+  TS = 'TS',
+  TS_SCI = 'TS_SCI',
+}
+
+export enum ScheduleFrequency {
+  DAILY = 'DAILY',
+  WEEKLY = 'WEEKLY',
+  BIWEEKLY = 'BIWEEKLY',
+  MONTHLY = 'MONTHLY',
 }
 
 // Interfaces
@@ -390,6 +419,37 @@ export interface ReportClassSummary {
     required: number;
     dos: number;
   }[];
+}
+
+export interface ReportTemplate {
+  id: number;
+  name: string;
+  report_type: string;
+  description?: string;
+  template_body: string;
+  sections: string[];
+  classification_default: string;
+  is_default: boolean;
+  created_by: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ReportSchedule {
+  id: number;
+  template_id: number;
+  unit_id: number;
+  frequency: ScheduleFrequency;
+  time_of_day?: string;
+  day_of_week?: number;
+  day_of_month?: number;
+  is_active: boolean;
+  last_generated?: string;
+  next_generation?: string;
+  auto_distribute: boolean;
+  distribution_list?: Array<{ user_id: number; role: string }>;
+  created_at?: string;
+  updated_at?: string;
 }
 
 export interface RawData {

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -1,17 +1,79 @@
+import { useState } from 'react';
 import ReportGenerator from '@/components/reports/ReportGenerator';
 import ReportViewer from '@/components/reports/ReportViewer';
 import ExportDestinations from '@/components/reports/ExportDestinations';
+import TemplateManager from '@/components/reports/TemplateManager';
+import ScheduleManager from '@/components/reports/ScheduleManager';
+import QuickGeneratePanel from '@/components/reports/QuickGeneratePanel';
+
+const TABS = [
+  { key: 'REPORTS' as const, label: 'REPORTS' },
+  { key: 'GENERATE' as const, label: 'GENERATE' },
+  { key: 'TEMPLATES' as const, label: 'TEMPLATES' },
+  { key: 'SCHEDULES' as const, label: 'SCHEDULES' },
+  { key: 'EXPORT' as const, label: 'EXPORT' },
+];
+
+type TabKey = (typeof TABS)[number]['key'];
 
 export default function ReportsPage() {
+  const [activeTab, setActiveTab] = useState<TabKey>('REPORTS');
+
   return (
     <div className="animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-      <div className="grid-responsive-sidebar-content">
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-          <ReportGenerator />
-          <ExportDestinations />
-        </div>
-        <ReportViewer />
+      {/* Tab bar */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 2,
+          borderBottom: '1px solid var(--color-border)',
+          paddingBottom: 0,
+        }}
+      >
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
+            style={{
+              padding: '8px 16px',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              fontWeight: activeTab === tab.key ? 700 : 400,
+              letterSpacing: '1.5px',
+              color: activeTab === tab.key ? 'var(--color-accent)' : 'var(--color-text-muted)',
+              backgroundColor: 'transparent',
+              border: 'none',
+              borderBottom:
+                activeTab === tab.key
+                  ? '2px solid var(--color-accent)'
+                  : '2px solid transparent',
+              cursor: 'pointer',
+              transition: 'all var(--transition)',
+              marginBottom: -1,
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
       </div>
+
+      {/* Tab content */}
+      {activeTab === 'REPORTS' && <ReportViewer />}
+
+      {activeTab === 'GENERATE' && (
+        <div className="grid-responsive-sidebar-content">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <QuickGeneratePanel />
+          </div>
+          <ReportGenerator />
+        </div>
+      )}
+
+      {activeTab === 'TEMPLATES' && <TemplateManager />}
+
+      {activeTab === 'SCHEDULES' && <ScheduleManager />}
+
+      {activeTab === 'EXPORT' && <ExportDestinations />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Expand reporting system with **SITREP/PERSTAT/SPOTREP** generation, **report templates** (Jinja2), **automated schedules**, **classification handling**, and **rollup aggregation**
- Add 18 new API endpoints across quick generation, template CRUD, and schedule CRUD
- Add 3 new frontend components (QuickGeneratePanel, TemplateManager, ScheduleManager) with 5-tab ReportsPage layout
- Comprehensive security hardening: sandboxed Jinja2, classification-aware rollups, state machine enforcement, credential masking

### New Backend Files
- `backend/app/services/sitrep_generator.py` — SitrepGeneratorService with 5 generation methods

### Modified Backend Files  
- `backend/app/models/report.py` — ReportTemplate, ReportSchedule models + expanded Report model (format, classification, template/schedule FKs, distribution_list, parent_report_id)
- `backend/app/schemas/report.py` — Template, Schedule, SPOTREP, and enhanced Report schemas
- `backend/app/api/reports.py` — 18 new endpoints with security hardening

### New Frontend Files
- `frontend/src/components/reports/QuickGeneratePanel.tsx` — SITREP/PERSTAT/SPOTREP/ROLLUP generation
- `frontend/src/components/reports/TemplateManager.tsx` — Template CRUD with section selection
- `frontend/src/components/reports/ScheduleManager.tsx` — Schedule management with frequency/timing

### Modified Frontend Files
- `frontend/src/pages/ReportsPage.tsx` — 5-tab layout (Reports, Generate, Templates, Schedules, Export)
- `frontend/src/lib/types.ts` — New enums (ReportFormat, ReportClassification, ScheduleFrequency) and interfaces
- `frontend/src/api/reports.ts` — 11 new API functions
- `frontend/src/api/mockClient.ts` — Full mock data for all new report types

## Security Fixes Applied
- **CRITICAL**: Jinja2 SandboxedEnvironment (prevents SSTI/RCE)
- **HIGH**: Classification-aware rollup aggregation (max classification from children)
- **HIGH**: Credential masking in ExportDestinationResponse
- **HIGH**: Admin-only access to export destinations
- **MEDIUM**: State machine enforcement (DRAFT→READY→FINAL→ARCHIVED only)
- **MEDIUM**: Template ownership checks (creator or ADMIN only)
- **MEDIUM**: Role check on legacy POST / endpoint
- **MEDIUM**: SpotrepCreate classification uses validated enum

## Test plan
- [x] `ruff check .` — PASS
- [x] `mypy` on changed files — PASS (0 errors)
- [x] `pytest tests/ -v` — 123/123 PASS
- [x] `npx tsc -b` — PASS (0 errors)
- [x] `npx vitest run` — 4/4 PASS
- [ ] Manual: Navigate to /reports, verify 5-tab layout
- [ ] Manual: Generate SITREP/PERSTAT/SPOTREP from Quick Generate tab
- [ ] Manual: Create/edit/delete templates
- [ ] Manual: Create/delete schedules

🤖 Generated with [Claude Code](https://claude.com/claude-code)