### PR TITLE
feat: granular RBAC system with permission-based access control

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -32,6 +32,7 @@ from app.api.medical import router as medical_router
 from app.api.notifications import router as notifications_router
 from app.api.fuel import router as fuel_router
 from app.api.custody import router as custody_router
+from app.api.rbac import router as rbac_router
 
 api_router = APIRouter()
 
@@ -91,3 +92,4 @@ api_router.include_router(fuel_router, prefix="/fuel", tags=["Fuel"])
 api_router.include_router(
     custody_router, prefix="/custody", tags=["Custody & Accountability"]
 )
+api_router.include_router(rbac_router, prefix="/rbac", tags=["RBAC"])

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -13,7 +13,7 @@ from app.core.auth import (
     hash_password,
     verify_password,
 )
-from app.core.permissions import require_role
+from app.core.permissions import get_user_permissions, require_role
 from app.database import get_db
 from app.models.user import Role, User
 from app.schemas.auth import (
@@ -104,9 +104,14 @@ async def login(request: LoginRequest, db: AsyncSession = Depends(get_db)):
     # Only include 'sub' in JWT payload
     access_token = create_access_token(data={"sub": user.username})
 
+    # Build response with effective permissions
+    perms = await get_user_permissions(db, user)
+    user_data = UserResponse.model_validate(user).model_dump()
+    user_data["permissions"] = sorted(perms)
+
     return {
         "token": access_token,
-        "user": UserResponse.model_validate(user).model_dump(),
+        "user": user_data,
     }
 
 
@@ -150,9 +155,15 @@ async def register(
 
 
 @router.get("/me", response_model=UserResponse)
-async def get_me(current_user: User = Depends(get_current_user)):
-    """Get the current authenticated user."""
-    return current_user
+async def get_me(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get the current authenticated user with effective permissions."""
+    perms = await get_user_permissions(db, current_user)
+    user_data = UserResponse.model_validate(current_user).model_dump()
+    user_data["permissions"] = sorted(perms)
+    return user_data
 
 
 @router.get("/users", response_model=List[UserResponse])

--- a/backend/app/api/equipment.py
+++ b/backend/app/api/equipment.py
@@ -9,7 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user
 from app.core.exceptions import NotFoundError
-from app.core.permissions import check_unit_access, get_accessible_units
+from app.core.permissions import (
+    check_unit_access,
+    get_accessible_units,
+    require_permission,
+)
 from app.database import get_db
 from app.models.equipment import EquipmentStatus
 from app.models.user import User
@@ -62,7 +66,7 @@ async def get_equipment(
 async def create_equipment(
     data: EquipmentCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_permission("equipment:create")),
 ):
     """Create a new equipment status record."""
     await check_unit_access(current_user, data.unit_id, db)
@@ -79,7 +83,7 @@ async def update_equipment(
     record_id: int,
     data: EquipmentUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_permission("equipment:edit")),
 ):
     """Update an equipment status record."""
     result = await db.execute(

--- a/backend/app/api/rbac.py
+++ b/backend/app/api/rbac.py
@@ -1,0 +1,260 @@
+"""RBAC management endpoints: permissions, custom roles, user role assignment."""
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import get_current_user
+from app.core.permissions import get_user_permissions, require_role
+from app.database import get_db
+from app.models.rbac import CustomRole, Permission
+from app.models.user import Role, User
+from app.schemas.rbac import (
+    AssignRoleRequest,
+    CustomRoleCreate,
+    CustomRoleResponse,
+    CustomRoleUpdate,
+    PermissionResponse,
+    UserPermissionsResponse,
+)
+
+router = APIRouter()
+
+
+@router.get("/permissions", response_model=List[PermissionResponse])
+async def list_permissions(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List all available permissions. Any authenticated user can view."""
+    result = await db.execute(
+        select(Permission).order_by(Permission.category, Permission.code)
+    )
+    return result.scalars().all()
+
+
+@router.get("/roles", response_model=List[CustomRoleResponse])
+async def list_roles(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role([Role.ADMIN])),
+):
+    """List all custom roles with their permissions. Admin only."""
+    result = await db.execute(select(CustomRole).order_by(CustomRole.name))
+    return result.scalars().all()
+
+
+@router.get("/roles/{role_id}", response_model=CustomRoleResponse)
+async def get_role(
+    role_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role([Role.ADMIN])),
+):
+    """Get a single custom role by ID. Admin only."""
+    result = await db.execute(select(CustomRole).where(CustomRole.id == role_id))
+    role = result.scalar_one_or_none()
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Custom role {role_id} not found",
+        )
+    return role
+
+
+@router.post("/roles", response_model=CustomRoleResponse, status_code=201)
+async def create_role(
+    data: CustomRoleCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role([Role.ADMIN])),
+):
+    """Create a new custom role. Admin only."""
+    # Check for duplicate name
+    existing = await db.execute(select(CustomRole).where(CustomRole.name == data.name))
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Role with name '{data.name}' already exists",
+        )
+
+    # Validate permission IDs
+    perm_result = await db.execute(
+        select(Permission).where(Permission.id.in_(data.permission_ids))
+    )
+    perms = perm_result.scalars().all()
+    if len(perms) != len(data.permission_ids):
+        found_ids = {int(p.id) for p in perms}
+        missing = set(data.permission_ids) - found_ids
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid permission IDs: {sorted(missing)}",
+        )
+
+    role = CustomRole(
+        name=data.name,
+        description=data.description,
+        is_system=False,
+        created_by_user_id=current_user.id,
+    )
+    role.permissions = list(perms)
+    db.add(role)
+    await db.flush()
+    await db.refresh(role)
+    return role
+
+
+@router.put("/roles/{role_id}", response_model=CustomRoleResponse)
+async def update_role(
+    role_id: int,
+    data: CustomRoleUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role([Role.ADMIN])),
+):
+    """Update a custom role. Admin only. System roles cannot be modified."""
+    result = await db.execute(select(CustomRole).where(CustomRole.id == role_id))
+    role = result.scalar_one_or_none()
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Custom role {role_id} not found",
+        )
+
+    if role.is_system:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="System roles cannot be modified",
+        )
+
+    if data.name is not None:
+        # Check for duplicate name (excluding self)
+        dup = await db.execute(
+            select(CustomRole).where(
+                CustomRole.name == data.name, CustomRole.id != role_id
+            )
+        )
+        if dup.scalar_one_or_none():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Role with name '{data.name}' already exists",
+            )
+        role.name = data.name
+
+    if data.description is not None:
+        role.description = data.description
+
+    if data.permission_ids is not None:
+        perm_result = await db.execute(
+            select(Permission).where(Permission.id.in_(data.permission_ids))
+        )
+        perms = perm_result.scalars().all()
+        if len(perms) != len(data.permission_ids):
+            found_ids = {int(p.id) for p in perms}
+            missing = set(data.permission_ids) - found_ids
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid permission IDs: {sorted(missing)}",
+            )
+        role.permissions = list(perms)
+
+    await db.flush()
+    await db.refresh(role)
+    return role
+
+
+@router.delete("/roles/{role_id}", status_code=204)
+async def delete_role(
+    role_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role([Role.ADMIN])),
+):
+    """Delete a custom role. Admin only. System roles cannot be deleted."""
+    result = await db.execute(select(CustomRole).where(CustomRole.id == role_id))
+    role = result.scalar_one_or_none()
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Custom role {role_id} not found",
+        )
+
+    if role.is_system:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="System roles cannot be deleted",
+        )
+
+    await db.delete(role)
+    await db.flush()
+    return None
+
+
+@router.get("/users/{user_id}/permissions", response_model=UserPermissionsResponse)
+async def get_user_effective_permissions(
+    user_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get effective permissions for a user. Admin or the user themselves."""
+    if current_user.role != Role.ADMIN and current_user.id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only view your own permissions or must be an admin",
+        )
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    target_user = result.scalar_one_or_none()
+    if not target_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"User {user_id} not found",
+        )
+
+    perms = await get_user_permissions(db, target_user)
+
+    # Determine role name
+    if target_user.custom_role_id is not None:
+        cr_result = await db.execute(
+            select(CustomRole).where(CustomRole.id == target_user.custom_role_id)
+        )
+        custom_role = cr_result.scalar_one_or_none()
+        role_name = custom_role.name if custom_role else target_user.role.value
+    else:
+        role_name = target_user.role.value
+
+    return UserPermissionsResponse(
+        role_name=role_name,
+        permissions=sorted(perms),
+    )
+
+
+@router.put("/users/{user_id}/role")
+async def assign_role_to_user(
+    user_id: int,
+    data: AssignRoleRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role([Role.ADMIN])),
+):
+    """Assign a custom role to a user. Admin only."""
+    result = await db.execute(select(User).where(User.id == user_id))
+    target_user = result.scalar_one_or_none()
+    if not target_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"User {user_id} not found",
+        )
+
+    # Validate custom role exists
+    cr_result = await db.execute(
+        select(CustomRole).where(CustomRole.id == data.custom_role_id)
+    )
+    custom_role = cr_result.scalar_one_or_none()
+    if not custom_role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Custom role {data.custom_role_id} not found",
+        )
+
+    target_user.custom_role_id = data.custom_role_id
+    await db.flush()
+    await db.refresh(target_user)
+
+    return {"detail": f"User {user_id} assigned to role '{custom_role.name}'"}

--- a/backend/app/api/readiness.py
+++ b/backend/app/api/readiness.py
@@ -9,7 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user
 from app.core.exceptions import NotFoundError
-from app.core.permissions import check_unit_access, get_accessible_units
+from app.core.permissions import (
+    check_unit_access,
+    get_accessible_units,
+    require_permission,
+)
 from app.database import get_db
 from app.models.readiness_snapshot import UnitReadinessSnapshot
 from app.models.unit import Unit
@@ -108,7 +112,7 @@ async def update_unit_strength(
     unit_id: int,
     data: UnitStrengthUpdateRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_permission("readiness:create")),
 ):
     """Create a new timestamped unit strength record."""
     await check_unit_access(current_user, unit_id, db)
@@ -244,7 +248,7 @@ async def create_readiness_snapshot(
     unit_id: int,
     data: Optional[SnapshotCreateRequest] = None,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_permission("readiness:create")),
 ):
     """Manually trigger readiness snapshot generation for a unit."""
     await check_unit_access(current_user, unit_id, db)

--- a/backend/app/api/supply.py
+++ b/backend/app/api/supply.py
@@ -9,7 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user
 from app.core.exceptions import NotFoundError
-from app.core.permissions import check_unit_access, get_accessible_units
+from app.core.permissions import (
+    check_unit_access,
+    get_accessible_units,
+    require_permission,
+)
 from app.database import get_db
 from app.models.supply import SupplyClass, SupplyStatus, SupplyStatusRecord
 from app.models.user import User
@@ -76,7 +80,7 @@ async def get_supply_record(
 async def create_supply_record(
     data: SupplyCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_permission("supply:create")),
 ):
     """Create a new supply status record."""
     await check_unit_access(current_user, data.unit_id, db)
@@ -93,7 +97,7 @@ async def update_supply_record(
     record_id: int,
     data: SupplyUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_permission("supply:edit")),
 ):
     """Update an existing supply record."""
     result = await db.execute(

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -1,14 +1,238 @@
-"""Role-based and unit-based access control."""
+"""Role-based, unit-based, and granular permission-based access control."""
 
-from typing import Callable, List
+from typing import Callable, List, Set
 
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user
+from app.database import get_db
 from app.models.unit import Unit
 from app.models.user import Role, User
+
+# ---------------------------------------------------------------------------
+# Granular permission definitions
+# ---------------------------------------------------------------------------
+
+ALL_PERMISSIONS = [
+    "dashboard:view",
+    "map:view",
+    "map:edit",
+    "supply:view",
+    "supply:create",
+    "supply:edit",
+    "supply:delete",
+    "equipment:view",
+    "equipment:create",
+    "equipment:edit",
+    "equipment:delete",
+    "maintenance:view",
+    "maintenance:create",
+    "maintenance:edit",
+    "maintenance:delete",
+    "requisitions:view",
+    "requisitions:create",
+    "requisitions:edit",
+    "requisitions:approve",
+    "personnel:view",
+    "personnel:create",
+    "personnel:edit",
+    "personnel:delete",
+    "readiness:view",
+    "readiness:create",
+    "readiness:edit",
+    "medical:view",
+    "medical:create",
+    "medical:edit",
+    "medical:delete",
+    "transportation:view",
+    "transportation:create",
+    "transportation:edit",
+    "transportation:delete",
+    "fuel:view",
+    "fuel:create",
+    "fuel:edit",
+    "fuel:delete",
+    "custody:view",
+    "custody:create",
+    "custody:edit",
+    "custody:delete",
+    "audit:view",
+    "ingestion:view",
+    "ingestion:upload",
+    "data_sources:view",
+    "data_sources:manage",
+    "reports:view",
+    "reports:create",
+    "reports:edit",
+    "reports:delete",
+    "alerts:view",
+    "alerts:create",
+    "alerts:manage",
+    "admin:users",
+    "admin:units",
+    "admin:settings",
+    "admin:roles",
+    "docs:view",
+    "simulator:manage",
+]
+
+DEFAULT_ROLE_PERMISSIONS: dict[str, Set[str]] = {
+    "admin": set(ALL_PERMISSIONS),
+    "commander": set(ALL_PERMISSIONS)
+    - {
+        "admin:users",
+        "admin:settings",
+        "admin:roles",
+        "data_sources:manage",
+        "simulator:manage",
+    },
+    "s4": {
+        "dashboard:view",
+        "map:view",
+        "map:edit",
+        "supply:view",
+        "supply:create",
+        "supply:edit",
+        "supply:delete",
+        "equipment:view",
+        "equipment:create",
+        "equipment:edit",
+        "equipment:delete",
+        "maintenance:view",
+        "maintenance:create",
+        "maintenance:edit",
+        "maintenance:delete",
+        "requisitions:view",
+        "requisitions:create",
+        "requisitions:edit",
+        "requisitions:approve",
+        "readiness:view",
+        "readiness:create",
+        "readiness:edit",
+        "fuel:view",
+        "fuel:create",
+        "fuel:edit",
+        "fuel:delete",
+        "custody:view",
+        "custody:create",
+        "custody:edit",
+        "custody:delete",
+        "reports:view",
+        "reports:create",
+        "reports:edit",
+        "reports:delete",
+        "alerts:view",
+        "alerts:create",
+        "transportation:view",
+        "transportation:create",
+        "transportation:edit",
+        "personnel:view",
+        "docs:view",
+    },
+    "s3": {
+        "dashboard:view",
+        "map:view",
+        "map:edit",
+        "personnel:view",
+        "personnel:create",
+        "personnel:edit",
+        "personnel:delete",
+        "medical:view",
+        "medical:create",
+        "medical:edit",
+        "medical:delete",
+        "transportation:view",
+        "transportation:create",
+        "transportation:edit",
+        "transportation:delete",
+        "readiness:view",
+        "readiness:create",
+        "readiness:edit",
+        "alerts:view",
+        "alerts:create",
+        "reports:view",
+        "reports:create",
+        "requisitions:view",
+        "supply:view",
+        "equipment:view",
+        "ingestion:view",
+        "ingestion:upload",
+        "docs:view",
+    },
+    "operator": {
+        "dashboard:view",
+        "map:view",
+        "supply:view",
+        "equipment:view",
+        "requisitions:view",
+        "requisitions:create",
+        "requisitions:edit",
+        "readiness:view",
+        "alerts:view",
+        "personnel:view",
+        "medical:view",
+        "transportation:view",
+        "maintenance:view",
+        "fuel:view",
+        "docs:view",
+    },
+    "viewer": {
+        "dashboard:view",
+        "map:view",
+        "supply:view",
+        "equipment:view",
+        "readiness:view",
+        "alerts:view",
+        "reports:view",
+        "personnel:view",
+        "docs:view",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Permission helpers
+# ---------------------------------------------------------------------------
+
+
+async def get_user_permissions(db: AsyncSession, user: User) -> Set[str]:
+    """Return the effective set of permission codes for *user*.
+
+    Resolution order:
+    1. If the user has a ``custom_role_id`` assigned, query the
+       ``role_permissions`` junction table and return those codes.
+    2. Otherwise fall back to the ``DEFAULT_ROLE_PERMISSIONS`` mapping
+       keyed by the legacy ``Role`` enum value.
+    3. ADMINs always receive **all** permissions regardless of custom role.
+    """
+    # Admins always get everything
+    if user.role == Role.ADMIN:
+        return set(ALL_PERMISSIONS)
+
+    # Custom role takes precedence when set
+    if user.custom_role_id is not None:
+        from app.models.rbac import Permission, role_permissions
+
+        stmt = (
+            select(Permission.code)
+            .join(
+                role_permissions,
+                Permission.id == role_permissions.c.permission_id,
+            )
+            .where(role_permissions.c.role_id == user.custom_role_id)
+        )
+        result = await db.execute(stmt)
+        return {row[0] for row in result.all()}
+
+    # Legacy role fallback
+    role_key = user.role.value if user.role else "viewer"
+    return set(DEFAULT_ROLE_PERMISSIONS.get(role_key, set()))
+
+
+# ---------------------------------------------------------------------------
+# FastAPI dependency factories
+# ---------------------------------------------------------------------------
 
 
 def require_role(roles: List[Role]) -> Callable:
@@ -24,6 +248,41 @@ def require_role(roles: List[Role]) -> Callable:
         return current_user
 
     return role_checker
+
+
+def require_permission(permission_code: str) -> Callable:
+    """Dependency factory that restricts access based on granular permissions.
+
+    Usage::
+
+        @router.post("/", dependencies=[Depends(require_permission("supply:create"))])
+        async def create_supply(...): ...
+
+    Or as a parameter dependency that also returns the current user::
+
+        async def create_supply(
+            current_user: User = Depends(require_permission("supply:create")),
+        ): ...
+    """
+
+    async def permission_checker(
+        current_user: User = Depends(get_current_user),
+        db: AsyncSession = Depends(get_db),
+    ) -> User:
+        perms = await get_user_permissions(db, current_user)
+        if permission_code not in perms:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Missing required permission: {permission_code}",
+            )
+        return current_user
+
+    return permission_checker
+
+
+# ---------------------------------------------------------------------------
+# Unit-scoped access helpers (unchanged)
+# ---------------------------------------------------------------------------
 
 
 async def get_accessible_units(db: AsyncSession, user: User) -> List[int]:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -160,6 +160,7 @@ from app.models.fuel import (
     FuelConsumptionRate,
     FuelForecast,
 )
+from app.models.rbac import Permission, CustomRole, role_permissions
 from app.models.custody import (
     SensitiveItem,
     SensitiveItemType,
@@ -336,4 +337,7 @@ __all__ = [
     "InventoryEvent",
     "InventoryLineItem",
     "AuditLog",
+    "Permission",
+    "CustomRole",
+    "role_permissions",
 ]

--- a/backend/app/models/rbac.py
+++ b/backend/app/models/rbac.py
@@ -1,0 +1,67 @@
+"""RBAC models: Permission, CustomRole, and role_permissions junction table."""
+
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Table,
+    Text,
+)
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+role_permissions = Table(
+    "role_permissions",
+    Base.metadata,
+    Column(
+        "role_id",
+        Integer,
+        ForeignKey("custom_roles.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "permission_id",
+        Integer,
+        ForeignKey("permissions.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+)
+
+
+class Permission(Base):
+    __tablename__ = "permissions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    code = Column(String(80), unique=True, nullable=False, index=True)
+    display_name = Column(String(100), nullable=False)
+    category = Column(String(50), nullable=False)
+    description = Column(Text, nullable=True)
+
+
+class CustomRole(Base):
+    __tablename__ = "custom_roles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(80), unique=True, nullable=False)
+    description = Column(Text, nullable=True)
+    is_system = Column(Boolean, default=False, nullable=False)
+    created_by_user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    permissions = relationship(
+        "Permission", secondary=role_permissions, lazy="selectin"
+    )
+    users = relationship(
+        "User", back_populates="custom_role", foreign_keys="[User.custom_role_id]"
+    )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -42,4 +42,9 @@ class User(Base):
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
 
+    custom_role_id = Column(Integer, ForeignKey("custom_roles.id"), nullable=True)
+
     unit = relationship("Unit", back_populates="users")
+    custom_role = relationship(
+        "CustomRole", back_populates="users", foreign_keys=[custom_role_id]
+    )

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -2,7 +2,7 @@
 
 import re
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -65,5 +65,6 @@ class UserResponse(UserBase):
     is_active: bool
     created_at: datetime
     updated_at: Optional[datetime] = None
+    permissions: List[str] = []
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/rbac.py
+++ b/backend/app/schemas/rbac.py
@@ -1,0 +1,49 @@
+"""Pydantic schemas for granular RBAC."""
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PermissionResponse(BaseModel):
+    id: int
+    code: str
+    display_name: str
+    category: str
+    description: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CustomRoleCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+    permission_ids: List[int]
+
+
+class CustomRoleUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    permission_ids: Optional[List[int]] = None
+
+
+class CustomRoleResponse(BaseModel):
+    id: int
+    name: str
+    description: Optional[str] = None
+    is_system: bool
+    permissions: List[PermissionResponse]
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserPermissionsResponse(BaseModel):
+    role_name: str
+    permissions: List[str]
+
+
+class AssignRoleRequest(BaseModel):
+    custom_role_id: int

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
+import { usePermission } from '@/hooks/usePermission';
 import MainLayout from '@/components/layout/MainLayout';
 import LoginPage from '@/pages/LoginPage';
 import DashboardPage from '@/pages/DashboardPage';
@@ -23,12 +24,68 @@ import FuelPage from '@/pages/FuelPage';
 import CustodyPage from '@/pages/CustodyPage';
 import AuditPage from '@/pages/AuditPage';
 
-function ProtectedRoute({ children }: { children: React.ReactNode }) {
+function ProtectedRoute({
+  children,
+  requiredPermission,
+}: {
+  children: React.ReactNode;
+  requiredPermission?: string | string[];
+}) {
   const token = useAuthStore((s) => s.token);
   const user = useAuthStore((s) => s.user);
+  const { hasPermission, hasAnyPermission } = usePermission();
 
   if (!token || !user) {
     return <Navigate to="/login" replace />;
+  }
+
+  if (requiredPermission) {
+    const permitted = Array.isArray(requiredPermission)
+      ? hasAnyPermission(...requiredPermission)
+      : hasPermission(requiredPermission);
+
+    if (!permitted) {
+      return (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: '100%',
+            padding: 40,
+            fontFamily: 'var(--font-mono)',
+            color: 'var(--color-text-muted)',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 48,
+              fontWeight: 700,
+              color: 'var(--color-danger)',
+              marginBottom: 16,
+            }}
+          >
+            403
+          </div>
+          <div
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              color: 'var(--color-text-bright)',
+              marginBottom: 8,
+              letterSpacing: '1px',
+            }}
+          >
+            ACCESS DENIED
+          </div>
+          <div style={{ fontSize: 12, textAlign: 'center', maxWidth: 400 }}>
+            You do not have the required permissions to access this page.
+            Contact your administrator to request access.
+          </div>
+        </div>
+      );
+    }
   }
 
   return <>{children}</>;
@@ -47,25 +104,46 @@ export default function App() {
         }
       >
         <Route index element={<Navigate to="/dashboard" replace />} />
-        <Route path="dashboard" element={<DashboardPage />} />
-        <Route path="map" element={<MapPage />} />
-        <Route path="supply" element={<SupplyPage />} />
-        <Route path="equipment" element={<EquipmentPage />} />
-        <Route path="maintenance" element={<MaintenanceDashboardPage />} />
-        <Route path="requisitions" element={<RequisitionsPage />} />
-        <Route path="personnel" element={<PersonnelPage />} />
-        <Route path="medical" element={<MedicalPage />} />
-        <Route path="fuel" element={<FuelPage />} />
-        <Route path="custody" element={<CustodyPage />} />
-        <Route path="audit" element={<AuditPage />} />
-        <Route path="equipment/:id" element={<EquipmentDetailPage />} />
-        <Route path="transportation" element={<TransportationPage />} />
-        <Route path="ingestion" element={<IngestionPage />} />
-        <Route path="data-sources" element={<DataSourcesPage />} />
-        <Route path="reports" element={<ReportsPage />} />
-        <Route path="alerts" element={<AlertsPage />} />
-        <Route path="readiness" element={<ReadinessPage />} />
-        <Route path="admin" element={<AdminPage />} />
+        <Route path="dashboard" element={<ProtectedRoute requiredPermission="dashboard:view"><DashboardPage /></ProtectedRoute>} />
+        <Route path="map" element={<ProtectedRoute requiredPermission="map:view"><MapPage /></ProtectedRoute>} />
+        <Route path="supply" element={<ProtectedRoute requiredPermission="supply:view"><SupplyPage /></ProtectedRoute>} />
+        <Route path="equipment" element={<ProtectedRoute requiredPermission="equipment:view"><EquipmentPage /></ProtectedRoute>} />
+        <Route path="maintenance" element={<ProtectedRoute requiredPermission="maintenance:view"><MaintenanceDashboardPage /></ProtectedRoute>} />
+        <Route path="requisitions" element={<ProtectedRoute requiredPermission="requisitions:view"><RequisitionsPage /></ProtectedRoute>} />
+        <Route path="personnel" element={<ProtectedRoute requiredPermission="personnel:view"><PersonnelPage /></ProtectedRoute>} />
+        <Route path="medical" element={<ProtectedRoute requiredPermission="medical:view"><MedicalPage /></ProtectedRoute>} />
+        <Route path="fuel" element={<ProtectedRoute requiredPermission="fuel:view"><FuelPage /></ProtectedRoute>} />
+        <Route path="custody" element={<ProtectedRoute requiredPermission="custody:view"><CustodyPage /></ProtectedRoute>} />
+        <Route path="audit" element={<ProtectedRoute requiredPermission="audit:view"><AuditPage /></ProtectedRoute>} />
+        <Route path="equipment/:id" element={<ProtectedRoute requiredPermission="equipment:view"><EquipmentDetailPage /></ProtectedRoute>} />
+        <Route path="transportation" element={<ProtectedRoute requiredPermission="transportation:view"><TransportationPage /></ProtectedRoute>} />
+        <Route
+          path="ingestion"
+          element={
+            <ProtectedRoute requiredPermission="ingestion:upload">
+              <IngestionPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="data-sources"
+          element={
+            <ProtectedRoute requiredPermission="data_sources:view">
+              <DataSourcesPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="reports" element={<ProtectedRoute requiredPermission="reports:view"><ReportsPage /></ProtectedRoute>} />
+        <Route path="alerts" element={<ProtectedRoute requiredPermission="alerts:view"><AlertsPage /></ProtectedRoute>} />
+        <Route path="readiness" element={<ProtectedRoute requiredPermission="readiness:view"><ReadinessPage /></ProtectedRoute>} />
+        <Route
+          path="admin"
+          element={
+            <ProtectedRoute requiredPermission={['admin:users', 'admin:settings', 'admin:roles']}>
+              <AdminPage />
+            </ProtectedRoute>
+          }
+        />
         <Route path="docs" element={<DocsPage />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/api/mockData.ts
+++ b/frontend/src/api/mockData.ts
@@ -86,6 +86,7 @@ export const DEMO_USERS: User[] = [
     email: 'admin@keystone.usmc.mil',
     is_active: true,
     created_at: '2026-01-01T00:00:00Z',
+    permissions: ['*'],
   },
   {
     id: 2,
@@ -96,6 +97,14 @@ export const DEMO_USERS: User[] = [
     email: 'j.mitchell@keystone.usmc.mil',
     is_active: true,
     created_at: '2026-01-01T00:00:00Z',
+    permissions: [
+      'dashboard:view', 'map:view', 'supply:view', 'equipment:view',
+      'maintenance:view', 'requisitions:view', 'requisitions:approve',
+      'personnel:view', 'readiness:view', 'medical:view', 'fuel:view',
+      'custody:view', 'audit:view', 'transportation:view', 'ingestion:view',
+      'ingestion:upload', 'reports:view', 'reports:generate', 'alerts:view',
+      'alerts:acknowledge', 'docs:view',
+    ],
   },
   {
     id: 3,
@@ -106,6 +115,16 @@ export const DEMO_USERS: User[] = [
     email: 's4@keystone.usmc.mil',
     is_active: true,
     created_at: '2026-01-01T00:00:00Z',
+    permissions: [
+      'dashboard:view', 'map:view', 'supply:view', 'supply:edit',
+      'equipment:view', 'equipment:edit', 'maintenance:view', 'maintenance:create',
+      'maintenance:edit', 'requisitions:view', 'requisitions:create',
+      'requisitions:edit', 'requisitions:approve', 'readiness:view',
+      'fuel:view', 'fuel:edit', 'custody:view', 'custody:edit',
+      'transportation:view', 'transportation:edit', 'ingestion:view',
+      'ingestion:upload', 'reports:view', 'reports:generate', 'alerts:view',
+      'alerts:acknowledge', 'docs:view',
+    ],
   },
   {
     id: 4,
@@ -116,6 +135,12 @@ export const DEMO_USERS: User[] = [
     email: 's3@keystone.usmc.mil',
     is_active: true,
     created_at: '2026-01-15T00:00:00Z',
+    permissions: [
+      'dashboard:view', 'map:view', 'personnel:view', 'personnel:edit',
+      'medical:view', 'readiness:view', 'readiness:edit', 'equipment:view',
+      'transportation:view', 'transportation:edit', 'reports:view',
+      'reports:generate', 'alerts:view', 'alerts:acknowledge', 'docs:view',
+    ],
   },
   {
     id: 5,
@@ -126,6 +151,13 @@ export const DEMO_USERS: User[] = [
     email: 'operator@keystone.usmc.mil',
     is_active: true,
     created_at: '2026-02-01T00:00:00Z',
+    permissions: [
+      'dashboard:view', 'map:view', 'supply:view', 'equipment:view',
+      'maintenance:view', 'requisitions:view', 'requisitions:create',
+      'requisitions:edit', 'personnel:view', 'readiness:view', 'medical:view',
+      'fuel:view', 'custody:view', 'transportation:view', 'ingestion:view',
+      'ingestion:upload', 'reports:view', 'alerts:view', 'docs:view',
+    ],
   },
 ];
 

--- a/frontend/src/api/rbac.ts
+++ b/frontend/src/api/rbac.ts
@@ -1,0 +1,299 @@
+import apiClient from './client';
+import { isDemoMode } from './mockClient';
+import type { Permission, CustomRole, ApiResponse } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Mock data for demo mode
+// ---------------------------------------------------------------------------
+
+const MOCK_PERMISSIONS: Permission[] = [
+  // Dashboard
+  { id: 1, code: 'dashboard:view', display_name: 'View Dashboard', category: 'Dashboard' },
+
+  // Map
+  { id: 2, code: 'map:view', display_name: 'View Map', category: 'Map' },
+
+  // Supply
+  { id: 3, code: 'supply:view', display_name: 'View Supply', category: 'Supply' },
+  { id: 4, code: 'supply:edit', display_name: 'Edit Supply', category: 'Supply' },
+
+  // Equipment
+  { id: 5, code: 'equipment:view', display_name: 'View Equipment', category: 'Equipment' },
+  { id: 6, code: 'equipment:edit', display_name: 'Edit Equipment', category: 'Equipment' },
+
+  // Maintenance
+  { id: 7, code: 'maintenance:view', display_name: 'View Maintenance', category: 'Maintenance' },
+  { id: 8, code: 'maintenance:create', display_name: 'Create Work Orders', category: 'Maintenance' },
+  { id: 9, code: 'maintenance:edit', display_name: 'Edit Work Orders', category: 'Maintenance' },
+
+  // Requisitions
+  { id: 10, code: 'requisitions:view', display_name: 'View Requisitions', category: 'Requisitions' },
+  { id: 11, code: 'requisitions:create', display_name: 'Create Requisitions', category: 'Requisitions' },
+  { id: 12, code: 'requisitions:edit', display_name: 'Edit Requisitions', category: 'Requisitions' },
+  { id: 13, code: 'requisitions:approve', display_name: 'Approve Requisitions', category: 'Requisitions' },
+
+  // Personnel
+  { id: 14, code: 'personnel:view', display_name: 'View Personnel', category: 'Personnel' },
+  { id: 15, code: 'personnel:edit', display_name: 'Edit Personnel', category: 'Personnel' },
+
+  // Readiness
+  { id: 16, code: 'readiness:view', display_name: 'View Readiness', category: 'Readiness' },
+  { id: 17, code: 'readiness:edit', display_name: 'Edit Readiness', category: 'Readiness' },
+
+  // Medical
+  { id: 18, code: 'medical:view', display_name: 'View Medical', category: 'Medical' },
+  { id: 19, code: 'medical:edit', display_name: 'Edit Medical', category: 'Medical' },
+
+  // Fuel
+  { id: 20, code: 'fuel:view', display_name: 'View Fuel', category: 'Fuel' },
+  { id: 21, code: 'fuel:edit', display_name: 'Edit Fuel', category: 'Fuel' },
+
+  // Custody
+  { id: 22, code: 'custody:view', display_name: 'View Chain of Custody', category: 'Custody' },
+  { id: 23, code: 'custody:edit', display_name: 'Edit Chain of Custody', category: 'Custody' },
+
+  // Audit
+  { id: 24, code: 'audit:view', display_name: 'View Audit Log', category: 'Audit' },
+
+  // Transportation
+  { id: 25, code: 'transportation:view', display_name: 'View Transportation', category: 'Transportation' },
+  { id: 26, code: 'transportation:edit', display_name: 'Edit Transportation', category: 'Transportation' },
+
+  // Ingestion
+  { id: 27, code: 'ingestion:view', display_name: 'View Ingestion', category: 'Ingestion' },
+  { id: 28, code: 'ingestion:upload', display_name: 'Upload Data', category: 'Ingestion' },
+
+  // Data Sources
+  { id: 29, code: 'data_sources:view', display_name: 'View Data Sources', category: 'Data Sources' },
+  { id: 30, code: 'data_sources:manage', display_name: 'Manage Data Sources', category: 'Data Sources' },
+
+  // Reports
+  { id: 31, code: 'reports:view', display_name: 'View Reports', category: 'Reports' },
+  { id: 32, code: 'reports:generate', display_name: 'Generate Reports', category: 'Reports' },
+
+  // Alerts
+  { id: 33, code: 'alerts:view', display_name: 'View Alerts', category: 'Alerts' },
+  { id: 34, code: 'alerts:acknowledge', display_name: 'Acknowledge Alerts', category: 'Alerts' },
+
+  // Admin
+  { id: 35, code: 'admin:users', display_name: 'Manage Users', category: 'Admin' },
+  { id: 36, code: 'admin:settings', display_name: 'Manage Settings', category: 'Admin' },
+  { id: 37, code: 'admin:roles', display_name: 'Manage Roles', category: 'Admin' },
+
+  // Docs
+  { id: 38, code: 'docs:view', display_name: 'View Documentation', category: 'Docs' },
+
+  // Simulator
+  { id: 39, code: 'simulator:manage', display_name: 'Manage Simulator', category: 'Simulator' },
+];
+
+function permsForCodes(codes: string[]): Permission[] {
+  return MOCK_PERMISSIONS.filter((p) => codes.includes(p.code));
+}
+
+const MOCK_ROLES: CustomRole[] = [
+  {
+    id: 1,
+    name: 'Admin',
+    description: 'Full system access — all permissions granted',
+    is_system: true,
+    permissions: [...MOCK_PERMISSIONS],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    name: 'Commander',
+    description: 'Command-level oversight — view all, approve requisitions, manage alerts',
+    is_system: true,
+    permissions: permsForCodes([
+      'dashboard:view', 'map:view', 'supply:view', 'equipment:view',
+      'maintenance:view', 'requisitions:view', 'requisitions:approve',
+      'personnel:view', 'readiness:view', 'medical:view', 'fuel:view',
+      'custody:view', 'audit:view', 'transportation:view', 'ingestion:view',
+      'ingestion:upload', 'reports:view', 'reports:generate', 'alerts:view',
+      'alerts:acknowledge', 'docs:view',
+    ]),
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 3,
+    name: 'S-4 (Logistics)',
+    description: 'Supply, equipment, maintenance, fuel, custody, transportation management',
+    is_system: true,
+    permissions: permsForCodes([
+      'dashboard:view', 'map:view', 'supply:view', 'supply:edit',
+      'equipment:view', 'equipment:edit', 'maintenance:view', 'maintenance:create',
+      'maintenance:edit', 'requisitions:view', 'requisitions:create',
+      'requisitions:edit', 'requisitions:approve', 'readiness:view',
+      'fuel:view', 'fuel:edit', 'custody:view', 'custody:edit',
+      'transportation:view', 'transportation:edit', 'ingestion:view',
+      'ingestion:upload', 'reports:view', 'reports:generate', 'alerts:view',
+      'alerts:acknowledge', 'docs:view',
+    ]),
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 4,
+    name: 'S-3 (Operations)',
+    description: 'Personnel, medical, readiness, transportation, and operations management',
+    is_system: true,
+    permissions: permsForCodes([
+      'dashboard:view', 'map:view', 'personnel:view', 'personnel:edit',
+      'medical:view', 'readiness:view', 'readiness:edit', 'equipment:view',
+      'transportation:view', 'transportation:edit', 'reports:view',
+      'reports:generate', 'alerts:view', 'alerts:acknowledge', 'docs:view',
+    ]),
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 5,
+    name: 'Operator',
+    description: 'Day-to-day operations — view most data, create requisitions and upload data',
+    is_system: true,
+    permissions: permsForCodes([
+      'dashboard:view', 'map:view', 'supply:view', 'equipment:view',
+      'maintenance:view', 'requisitions:view', 'requisitions:create',
+      'requisitions:edit', 'personnel:view', 'readiness:view', 'medical:view',
+      'fuel:view', 'custody:view', 'transportation:view', 'ingestion:view',
+      'ingestion:upload', 'reports:view', 'alerts:view', 'docs:view',
+    ]),
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 6,
+    name: 'Viewer',
+    description: 'Read-only access to dashboards, supply, equipment, readiness, and reports',
+    is_system: true,
+    permissions: permsForCodes([
+      'dashboard:view', 'map:view', 'supply:view', 'equipment:view',
+      'readiness:view', 'alerts:view', 'reports:view', 'personnel:view',
+      'docs:view',
+    ]),
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+// In-memory state for demo mode custom role CRUD
+let demoRoles = [...MOCK_ROLES];
+let nextRoleId = 100;
+
+const mockDelay = (ms = 200 + Math.random() * 200): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// API functions
+// ---------------------------------------------------------------------------
+
+export async function fetchPermissions(): Promise<Permission[]> {
+  if (isDemoMode) {
+    await mockDelay();
+    return [...MOCK_PERMISSIONS];
+  }
+  const response = await apiClient.get<ApiResponse<Permission[]>>('/rbac/permissions');
+  return response.data.data;
+}
+
+export async function fetchRoles(): Promise<CustomRole[]> {
+  if (isDemoMode) {
+    await mockDelay();
+    return [...demoRoles];
+  }
+  const response = await apiClient.get<ApiResponse<CustomRole[]>>('/rbac/roles');
+  return response.data.data;
+}
+
+export async function fetchRole(id: number): Promise<CustomRole> {
+  if (isDemoMode) {
+    await mockDelay();
+    const role = demoRoles.find((r) => r.id === id);
+    if (!role) throw new Error('Role not found');
+    return { ...role };
+  }
+  const response = await apiClient.get<ApiResponse<CustomRole>>(`/rbac/roles/${id}`);
+  return response.data.data;
+}
+
+export async function createRole(data: {
+  name: string;
+  description?: string;
+  permission_ids: number[];
+}): Promise<CustomRole> {
+  if (isDemoMode) {
+    await mockDelay();
+    const newRole: CustomRole = {
+      id: nextRoleId++,
+      name: data.name,
+      description: data.description,
+      is_system: false,
+      permissions: MOCK_PERMISSIONS.filter((p) => data.permission_ids.includes(p.id)),
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+    demoRoles.push(newRole);
+    return { ...newRole };
+  }
+  const response = await apiClient.post<ApiResponse<CustomRole>>('/rbac/roles', data);
+  return response.data.data;
+}
+
+export async function updateRole(
+  id: number,
+  data: { name?: string; description?: string; permission_ids?: number[] },
+): Promise<CustomRole> {
+  if (isDemoMode) {
+    await mockDelay();
+    const idx = demoRoles.findIndex((r) => r.id === id);
+    if (idx === -1) throw new Error('Role not found');
+    if (demoRoles[idx].is_system) throw new Error('Cannot modify system roles');
+    const updated: CustomRole = {
+      ...demoRoles[idx],
+      ...(data.name !== undefined && { name: data.name }),
+      ...(data.description !== undefined && { description: data.description }),
+      ...(data.permission_ids !== undefined && {
+        permissions: MOCK_PERMISSIONS.filter((p) => data.permission_ids!.includes(p.id)),
+      }),
+      updated_at: new Date().toISOString(),
+    };
+    demoRoles[idx] = updated;
+    return { ...updated };
+  }
+  const response = await apiClient.put<ApiResponse<CustomRole>>(`/rbac/roles/${id}`, data);
+  return response.data.data;
+}
+
+export async function deleteRole(id: number): Promise<void> {
+  if (isDemoMode) {
+    await mockDelay();
+    const role = demoRoles.find((r) => r.id === id);
+    if (!role) throw new Error('Role not found');
+    if (role.is_system) throw new Error('Cannot delete system roles');
+    demoRoles = demoRoles.filter((r) => r.id !== id);
+    return;
+  }
+  await apiClient.delete(`/rbac/roles/${id}`);
+}
+
+export async function fetchUserPermissions(userId: number): Promise<string[]> {
+  if (isDemoMode) {
+    await mockDelay();
+    return MOCK_PERMISSIONS.map((p) => p.code);
+  }
+  const response = await apiClient.get<ApiResponse<{ role_name: string; permissions: string[] }>>(`/rbac/users/${userId}/permissions`);
+  return response.data.data.permissions;
+}
+
+export async function assignUserRole(userId: number, roleId: number): Promise<void> {
+  if (isDemoMode) {
+    await mockDelay();
+    return;
+  }
+  await apiClient.put(`/rbac/users/${userId}/role`, { custom_role_id: roleId });
+}
+
+export { MOCK_PERMISSIONS };

--- a/frontend/src/components/admin/RoleManager.tsx
+++ b/frontend/src/components/admin/RoleManager.tsx
@@ -1,0 +1,573 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { Plus, Edit3, Trash2, X, Save, Shield, ChevronDown, ChevronRight } from 'lucide-react';
+import Card from '@/components/ui/Card';
+import type { Permission, CustomRole } from '@/lib/types';
+import { fetchPermissions, fetchRoles, createRole, updateRole, deleteRole } from '@/api/rbac';
+
+// ---------------------------------------------------------------------------
+// Shared styles (matching AdminPage patterns)
+// ---------------------------------------------------------------------------
+
+const tableHeaderStyle: React.CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10,
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: '1.5px',
+  padding: '8px 12px',
+  textAlign: 'left',
+  color: 'var(--color-text-muted)',
+  borderBottom: '1px solid var(--color-border)',
+};
+
+const tableCellStyle: React.CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 12,
+  padding: '8px 12px',
+  borderBottom: '1px solid var(--color-border)',
+  color: 'var(--color-text)',
+};
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 9,
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: '1.5px',
+  color: 'var(--color-text-muted)',
+  marginBottom: 4,
+};
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '6px 10px',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 12,
+  backgroundColor: 'var(--color-bg)',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius)',
+  color: 'var(--color-text)',
+  outline: 'none',
+};
+
+const btnPrimaryStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '6px 14px',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10,
+  fontWeight: 600,
+  letterSpacing: '1px',
+  textTransform: 'uppercase',
+  backgroundColor: 'var(--color-accent)',
+  color: '#000',
+  border: 'none',
+  borderRadius: 'var(--radius)',
+  cursor: 'pointer',
+};
+
+const btnSecondaryStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+  padding: '4px 10px',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 10,
+  fontWeight: 500,
+  backgroundColor: 'transparent',
+  color: 'var(--color-text-muted)',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius)',
+  cursor: 'pointer',
+};
+
+const btnDangerStyle: React.CSSProperties = {
+  ...btnSecondaryStyle,
+  color: 'var(--color-danger)',
+  borderColor: 'var(--color-danger)',
+};
+
+// ---------------------------------------------------------------------------
+// Permission category component
+// ---------------------------------------------------------------------------
+
+function PermissionCategory({
+  category,
+  permissions,
+  selectedIds,
+  onToggle,
+  disabled,
+}: {
+  category: string;
+  permissions: Permission[];
+  selectedIds: Set<number>;
+  onToggle: (id: number) => void;
+  disabled: boolean;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  const allSelected = permissions.every((p) => selectedIds.has(p.id));
+  const someSelected = permissions.some((p) => selectedIds.has(p.id));
+
+  const toggleAll = () => {
+    if (disabled) return;
+    permissions.forEach((p) => {
+      if (allSelected) {
+        if (selectedIds.has(p.id)) onToggle(p.id);
+      } else {
+        if (!selectedIds.has(p.id)) onToggle(p.id);
+      }
+    });
+  };
+
+  return (
+    <div
+      style={{
+        border: '1px solid var(--color-border)',
+        borderRadius: 'var(--radius)',
+        marginBottom: 8,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '8px 12px',
+          backgroundColor: 'var(--color-bg)',
+          cursor: 'pointer',
+          userSelect: 'none',
+        }}
+        onClick={() => setExpanded(!expanded)}
+      >
+        {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        <input
+          type="checkbox"
+          checked={allSelected}
+          ref={(el) => {
+            if (el) el.indeterminate = someSelected && !allSelected;
+          }}
+          onChange={toggleAll}
+          disabled={disabled}
+          onClick={(e) => e.stopPropagation()}
+          style={{ accentColor: 'var(--color-accent)' }}
+        />
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: '1px',
+            textTransform: 'uppercase',
+            color: 'var(--color-text-bright)',
+          }}
+        >
+          {category}
+        </span>
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10,
+            color: 'var(--color-text-muted)',
+            marginLeft: 'auto',
+          }}
+        >
+          {permissions.filter((p) => selectedIds.has(p.id)).length}/{permissions.length}
+        </span>
+      </div>
+      {expanded && (
+        <div style={{ padding: '4px 12px 8px 36px' }}>
+          {permissions.map((perm) => (
+            <label
+              key={perm.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                padding: '4px 0',
+                cursor: disabled ? 'default' : 'pointer',
+                opacity: disabled ? 0.6 : 1,
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={selectedIds.has(perm.id)}
+                onChange={() => onToggle(perm.id)}
+                disabled={disabled}
+                style={{ accentColor: 'var(--color-accent)' }}
+              />
+              <span
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 11,
+                  color: 'var(--color-text)',
+                }}
+              >
+                {perm.display_name}
+              </span>
+              <span
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 9,
+                  color: 'var(--color-text-muted)',
+                  marginLeft: 'auto',
+                }}
+              >
+                {perm.code}
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// RoleManager component
+// ---------------------------------------------------------------------------
+
+export default function RoleManager() {
+  const [permissions, setPermissions] = useState<Permission[]>([]);
+  const [roles, setRoles] = useState<CustomRole[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedRole, setSelectedRole] = useState<CustomRole | null>(null);
+
+  // Form state for create/edit
+  const [formOpen, setFormOpen] = useState(false);
+  const [formMode, setFormMode] = useState<'create' | 'edit' | 'view'>('create');
+  const [formName, setFormName] = useState('');
+  const [formDescription, setFormDescription] = useState('');
+  const [formPermissionIds, setFormPermissionIds] = useState<Set<number>>(new Set());
+  const [saving, setSaving] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
+
+  // Group permissions by category
+  const permsByCategory = useMemo(() => {
+    const grouped: Record<string, Permission[]> = {};
+    for (const perm of permissions) {
+      if (!grouped[perm.category]) grouped[perm.category] = [];
+      grouped[perm.category].push(perm);
+    }
+    return grouped;
+  }, [permissions]);
+
+  // Load data
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const [perms, roleList] = await Promise.all([fetchPermissions(), fetchRoles()]);
+        if (!cancelled) {
+          setPermissions(perms);
+          setRoles(roleList);
+          setLoading(false);
+        }
+      } catch {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, []);
+
+  const togglePermission = useCallback((id: number) => {
+    setFormPermissionIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  // Open create form
+  const openCreate = () => {
+    setSelectedRole(null);
+    setFormMode('create');
+    setFormName('');
+    setFormDescription('');
+    setFormPermissionIds(new Set());
+    setFormOpen(true);
+  };
+
+  // Open view/edit form
+  const openRole = (role: CustomRole) => {
+    setSelectedRole(role);
+    setFormMode(role.is_system ? 'view' : 'edit');
+    setFormName(role.name);
+    setFormDescription(role.description || '');
+    setFormPermissionIds(new Set(role.permissions.map((p) => p.id)));
+    setFormOpen(true);
+  };
+
+  // Save (create or update)
+  const handleSave = async () => {
+    if (!formName.trim()) return;
+    setSaving(true);
+    try {
+      if (formMode === 'create') {
+        const created = await createRole({
+          name: formName.trim(),
+          description: formDescription.trim() || undefined,
+          permission_ids: Array.from(formPermissionIds),
+        });
+        setRoles((prev) => [...prev, created]);
+      } else if (formMode === 'edit' && selectedRole) {
+        const updated = await updateRole(selectedRole.id, {
+          name: formName.trim(),
+          description: formDescription.trim() || undefined,
+          permission_ids: Array.from(formPermissionIds),
+        });
+        setRoles((prev) => prev.map((r) => (r.id === updated.id ? updated : r)));
+        setSelectedRole(updated);
+      }
+      setFormOpen(false);
+    } catch (err) {
+      console.error('Failed to save role:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Delete
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteRole(id);
+      setRoles((prev) => prev.filter((r) => r.id !== id));
+      if (selectedRole?.id === id) {
+        setSelectedRole(null);
+        setFormOpen(false);
+      }
+      setDeleteConfirm(null);
+    } catch (err) {
+      console.error('Failed to delete role:', err);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Card title="ROLES & PERMISSIONS">
+        <div
+          style={{
+            padding: 40,
+            textAlign: 'center',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            color: 'var(--color-text-muted)',
+          }}
+        >
+          Loading roles...
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {/* Role list */}
+      <Card
+        title="ROLES"
+        headerRight={
+          <button style={btnPrimaryStyle} onClick={openCreate}>
+            <Plus size={12} /> CREATE ROLE
+          </button>
+        }
+      >
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr>
+              <th style={tableHeaderStyle}>ROLE</th>
+              <th style={tableHeaderStyle}>DESCRIPTION</th>
+              <th style={tableHeaderStyle}>TYPE</th>
+              <th style={tableHeaderStyle}>PERMISSIONS</th>
+              <th style={{ ...tableHeaderStyle, textAlign: 'right' }}>ACTIONS</th>
+            </tr>
+          </thead>
+          <tbody>
+            {roles.map((role) => (
+              <tr
+                key={role.id}
+                style={{
+                  cursor: 'pointer',
+                  backgroundColor:
+                    selectedRole?.id === role.id ? 'var(--color-bg-hover)' : 'transparent',
+                }}
+                onClick={() => openRole(role)}
+              >
+                <td style={tableCellStyle}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <Shield size={14} style={{ color: 'var(--color-accent)' }} />
+                    <span style={{ fontWeight: 600, color: 'var(--color-text-bright)' }}>
+                      {role.name}
+                    </span>
+                  </div>
+                </td>
+                <td style={{ ...tableCellStyle, color: 'var(--color-text-muted)', maxWidth: 300 }}>
+                  {role.description || '--'}
+                </td>
+                <td style={tableCellStyle}>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 9,
+                      fontWeight: 600,
+                      letterSpacing: '1px',
+                      padding: '2px 8px',
+                      borderRadius: 'var(--radius)',
+                      backgroundColor: role.is_system
+                        ? 'rgba(77, 171, 247, 0.12)'
+                        : 'rgba(64, 192, 87, 0.12)',
+                      color: role.is_system ? 'var(--color-accent)' : 'var(--color-success)',
+                      border: role.is_system
+                        ? '1px solid rgba(77, 171, 247, 0.3)'
+                        : '1px solid rgba(64, 192, 87, 0.3)',
+                    }}
+                  >
+                    {role.is_system ? 'SYSTEM' : 'CUSTOM'}
+                  </span>
+                </td>
+                <td style={tableCellStyle}>
+                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>
+                    {role.permissions.length}
+                  </span>
+                </td>
+                <td style={{ ...tableCellStyle, textAlign: 'right' }}>
+                  <div
+                    style={{ display: 'flex', gap: 6, justifyContent: 'flex-end' }}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <button
+                      style={btnSecondaryStyle}
+                      onClick={() => openRole(role)}
+                      title={role.is_system ? 'View' : 'Edit'}
+                    >
+                      <Edit3 size={12} />
+                    </button>
+                    {!role.is_system && (
+                      <>
+                        {deleteConfirm === role.id ? (
+                          <div style={{ display: 'flex', gap: 4 }}>
+                            <button
+                              style={btnDangerStyle}
+                              onClick={() => handleDelete(role.id)}
+                            >
+                              CONFIRM
+                            </button>
+                            <button
+                              style={btnSecondaryStyle}
+                              onClick={() => setDeleteConfirm(null)}
+                            >
+                              <X size={12} />
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            style={btnDangerStyle}
+                            onClick={() => setDeleteConfirm(role.id)}
+                            title="Delete"
+                          >
+                            <Trash2 size={12} />
+                          </button>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
+
+      {/* Permission editor panel */}
+      {formOpen && (
+        <Card
+          title={
+            formMode === 'create'
+              ? 'CREATE NEW ROLE'
+              : formMode === 'edit'
+                ? `EDIT ROLE: ${selectedRole?.name}`
+                : `VIEW ROLE: ${selectedRole?.name}`
+          }
+          headerRight={
+            <button
+              style={btnSecondaryStyle}
+              onClick={() => setFormOpen(false)}
+            >
+              <X size={12} /> CLOSE
+            </button>
+          }
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16, padding: 4 }}>
+            {/* Name + description fields */}
+            <div style={{ display: 'flex', gap: 16 }}>
+              <div style={{ flex: 1 }}>
+                <label style={labelStyle}>ROLE NAME</label>
+                <input
+                  type="text"
+                  value={formName}
+                  onChange={(e) => setFormName(e.target.value)}
+                  placeholder="e.g. Supply Clerk"
+                  style={inputStyle}
+                  disabled={formMode === 'view'}
+                />
+              </div>
+              <div style={{ flex: 2 }}>
+                <label style={labelStyle}>DESCRIPTION</label>
+                <input
+                  type="text"
+                  value={formDescription}
+                  onChange={(e) => setFormDescription(e.target.value)}
+                  placeholder="Brief description of this role's responsibilities"
+                  style={inputStyle}
+                  disabled={formMode === 'view'}
+                />
+              </div>
+            </div>
+
+            {/* Permissions by category */}
+            <div>
+              <label style={labelStyle}>
+                PERMISSIONS ({formPermissionIds.size} / {permissions.length} SELECTED)
+              </label>
+              <div style={{ maxHeight: 400, overflowY: 'auto', paddingRight: 4 }}>
+                {Object.entries(permsByCategory).map(([cat, perms]) => (
+                  <PermissionCategory
+                    key={cat}
+                    category={cat}
+                    permissions={perms}
+                    selectedIds={formPermissionIds}
+                    onToggle={togglePermission}
+                    disabled={formMode === 'view'}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Actions */}
+            {formMode !== 'view' && (
+              <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+                <button style={btnSecondaryStyle} onClick={() => setFormOpen(false)}>
+                  CANCEL
+                </button>
+                <button
+                  style={{
+                    ...btnPrimaryStyle,
+                    opacity: saving || !formName.trim() ? 0.5 : 1,
+                    cursor: saving || !formName.trim() ? 'not-allowed' : 'pointer',
+                  }}
+                  onClick={handleSave}
+                  disabled={saving || !formName.trim()}
+                >
+                  <Save size={12} /> {saving ? 'SAVING...' : formMode === 'create' ? 'CREATE' : 'SAVE'}
+                </button>
+              </div>
+            )}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { NavLink } from 'react-router-dom';
+import type { LucideIcon } from 'lucide-react';
 import {
   LayoutDashboard,
   Package,
@@ -17,30 +18,43 @@ import {
   Settings,
   Shield,
   BookOpen,
+  Fuel,
+  ShieldCheck,
   X,
 } from 'lucide-react';
 import { useAuthStore } from '@/stores/authStore';
 import { useDashboardStore } from '@/stores/dashboardStore';
 import { isDemoMode } from '@/api/mockClient';
+import { usePermission } from '@/hooks/usePermission';
 import UnitSelector from '@/components/common/UnitSelector';
 
-const navItems = [
-  { to: '/dashboard', icon: LayoutDashboard, label: 'DASHBOARD' },
-  { to: '/map', icon: MapPin, label: 'MAP' },
-  { to: '/supply', icon: Package, label: 'SUPPLY' },
-  { to: '/equipment', icon: Wrench, label: 'EQUIPMENT' },
-  { to: '/maintenance', icon: Hammer, label: 'MAINTENANCE' },
-  { to: '/requisitions', icon: ClipboardList, label: 'REQUISITIONS' },
-  { to: '/personnel', icon: Users, label: 'PERSONNEL' },
-  { to: '/readiness', icon: Activity, label: 'READINESS' },
-  { to: '/medical', icon: Heart, label: 'MEDICAL' },
-  { to: '/transportation', icon: Truck, label: 'TRANSPORTATION' },
-  { to: '/ingestion', icon: Upload, label: 'INGESTION' },
-  { to: '/data-sources', icon: Database, label: 'DATA SOURCES' },
-  { to: '/reports', icon: FileText, label: 'REPORTS' },
-  { to: '/alerts', icon: AlertTriangle, label: 'ALERTS' },
-  { to: '/admin', icon: Settings, label: 'ADMIN' },
-  { to: '/docs', icon: BookOpen, label: 'DOCS' },
+interface NavItem {
+  to: string;
+  icon: LucideIcon;
+  label: string;
+  permission?: string;
+}
+
+const navItems: NavItem[] = [
+  { to: '/dashboard', icon: LayoutDashboard, label: 'DASHBOARD', permission: 'dashboard:view' },
+  { to: '/map', icon: MapPin, label: 'MAP', permission: 'map:view' },
+  { to: '/supply', icon: Package, label: 'SUPPLY', permission: 'supply:view' },
+  { to: '/equipment', icon: Wrench, label: 'EQUIPMENT', permission: 'equipment:view' },
+  { to: '/maintenance', icon: Hammer, label: 'MAINTENANCE', permission: 'maintenance:view' },
+  { to: '/requisitions', icon: ClipboardList, label: 'REQUISITIONS', permission: 'requisitions:view' },
+  { to: '/personnel', icon: Users, label: 'PERSONNEL', permission: 'personnel:view' },
+  { to: '/readiness', icon: Activity, label: 'READINESS', permission: 'readiness:view' },
+  { to: '/medical', icon: Heart, label: 'MEDICAL', permission: 'medical:view' },
+  { to: '/transportation', icon: Truck, label: 'TRANSPORTATION', permission: 'transportation:view' },
+  { to: '/fuel', icon: Fuel, label: 'FUEL', permission: 'fuel:view' },
+  { to: '/custody', icon: ShieldCheck, label: 'CUSTODY', permission: 'custody:view' },
+  { to: '/ingestion', icon: Upload, label: 'INGESTION', permission: 'ingestion:view' },
+  { to: '/data-sources', icon: Database, label: 'DATA SOURCES', permission: 'data_sources:view' },
+  { to: '/reports', icon: FileText, label: 'REPORTS', permission: 'reports:view' },
+  { to: '/alerts', icon: AlertTriangle, label: 'ALERTS', permission: 'alerts:view' },
+  { to: '/audit', icon: ClipboardList, label: 'AUDIT', permission: 'audit:view' },
+  { to: '/admin', icon: Settings, label: 'ADMIN', permission: 'admin:users' },
+  { to: '/docs', icon: BookOpen, label: 'DOCS', permission: 'docs:view' },
 ];
 
 interface SidebarProps {
@@ -51,6 +65,11 @@ interface SidebarProps {
 export default function Sidebar({ isMobileOpen, onClose }: SidebarProps) {
   const user = useAuthStore((s) => s.user);
   const { selectedUnitId, setSelectedUnitId } = useDashboardStore();
+  const { hasPermission } = usePermission();
+
+  const filteredNavItems = navItems.filter(
+    (item) => !item.permission || hasPermission(item.permission),
+  );
 
   return (
     <aside
@@ -143,7 +162,7 @@ export default function Sidebar({ isMobileOpen, onClose }: SidebarProps) {
 
       {/* Navigation */}
       <nav style={{ flex: 1, padding: '8px 0', overflowY: 'auto' }}>
-        {navItems.map((item) => (
+        {filteredNavItems.map((item) => (
           <NavLink
             key={item.to}
             to={item.to}

--- a/frontend/src/hooks/usePermission.ts
+++ b/frontend/src/hooks/usePermission.ts
@@ -1,0 +1,31 @@
+import { useAuthStore } from '../stores/authStore';
+
+export function usePermission() {
+  const user = useAuthStore((s) => s.user);
+  const permissions = useAuthStore((s) => s.permissions);
+
+  const hasPermission = (code: string): boolean => {
+    if (!user) return false;
+    const role = user.role?.toLowerCase();
+    if (role === 'admin') return true;
+    return permissions.includes(code);
+  };
+
+  const hasAnyPermission = (...codes: string[]): boolean => {
+    if (!user) return false;
+    const role = user.role?.toLowerCase();
+    if (role === 'admin') return true;
+    return codes.some((c) => permissions.includes(c));
+  };
+
+  const hasAllPermissions = (...codes: string[]): boolean => {
+    if (!user) return false;
+    const role = user.role?.toLowerCase();
+    if (role === 'admin') return true;
+    return codes.every((c) => permissions.includes(c));
+  };
+
+  const isAdmin = user?.role?.toLowerCase() === 'admin';
+
+  return { hasPermission, hasAnyPermission, hasAllPermissions, isAdmin };
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -134,6 +134,24 @@ export enum ScheduleFrequency {
 
 // Interfaces
 
+export interface Permission {
+  id: number;
+  code: string;
+  display_name: string;
+  category: string;
+  description?: string;
+}
+
+export interface CustomRole {
+  id: number;
+  name: string;
+  description?: string;
+  is_system: boolean;
+  permissions: Permission[];
+  created_at: string;
+  updated_at: string;
+}
+
 export interface User {
   id: number;
   username: string;
@@ -142,6 +160,8 @@ export interface User {
   unit_id: number | null;
   email: string;
   is_active: boolean;
+  permissions?: string[];
+  custom_role_id?: number;
   created_at?: string;
   updated_at?: string | null;
 }

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect } from 'react';
-import { Users, Settings, Shield, Layers, Plus, Edit3, Save, Check, X, Trash2, Crosshair } from 'lucide-react';
+import { Users, Settings, Shield, Layers, Plus, Edit3, Save, Check, X, Trash2, Crosshair, KeyRound } from 'lucide-react';
 import Card from '@/components/ui/Card';
 import StatusBadge from '@/components/ui/StatusBadge';
 import StatusDot from '@/components/ui/StatusDot';
 import UnitTreeView from '@/components/admin/UnitTreeView';
 import TileLayerSettings from '@/components/admin/TileLayerSettings';
 import ScenarioManager from '@/components/admin/ScenarioManager';
+import RoleManager from '@/components/admin/RoleManager';
 import { Role, Echelon, type User, type Unit } from '@/lib/types';
 import { ECHELON_ORDER, ECHELON_ALLOWED_CHILDREN } from '@/lib/constants';
 import { mockApi } from '@/api/mockClient';
@@ -180,7 +181,7 @@ const addButtonStyle: React.CSSProperties = {
 // ---------------------------------------------------------------------------
 
 export default function AdminPage() {
-  const [activeTab, setActiveTab] = useState<'users' | 'units' | 'classification' | 'tiles' | 'scenarios'>('users');
+  const [activeTab, setActiveTab] = useState<'users' | 'units' | 'classification' | 'tiles' | 'scenarios' | 'roles'>('users');
   const { classification, updateClassification } = useClassificationStore();
 
   // ── User management state ──
@@ -381,6 +382,7 @@ export default function AdminPage() {
           { key: 'classification' as const, label: 'CLASSIFICATION', icon: Shield },
           { key: 'tiles' as const, label: 'MAP TILES', icon: Layers },
           { key: 'scenarios' as const, label: 'SCENARIOS', icon: Crosshair },
+          { key: 'roles' as const, label: 'ROLES & PERMISSIONS', icon: KeyRound },
         ].map((tab) => (
           <button
             key={tab.key}
@@ -754,6 +756,9 @@ export default function AdminPage() {
 
       {/* ── Scenarios Tab ── */}
       {activeTab === 'scenarios' && <ScenarioManager />}
+
+      {/* ── Roles & Permissions Tab ── */}
+      {activeTab === 'roles' && <RoleManager />}
 
       {/* ── User Add/Edit Modal ── */}
       {userModalOpen && (

--- a/frontend/src/pages/DocsPage.tsx
+++ b/frontend/src/pages/DocsPage.tsx
@@ -12,6 +12,13 @@ import {
   Shield,
   Wrench,
   Settings,
+  Users,
+  Heart,
+  Fuel,
+  ShieldCheck,
+  Bell,
+  ClipboardList,
+  Truck,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
@@ -21,6 +28,14 @@ type Section =
   | 'features'
   | 'equipment'
   | 'reports'
+  | 'personnel'
+  | 'medical'
+  | 'fuel'
+  | 'custody'
+  | 'notifications'
+  | 'requisitions'
+  | 'readiness'
+  | 'transportation'
   | 'admin'
   | 'deployment'
   | 'api-reference'
@@ -39,6 +54,14 @@ const navItems: NavItem[] = [
   { id: 'architecture', label: 'Architecture', icon: Layers },
   { id: 'features', label: 'Features', icon: Activity },
   { id: 'equipment', label: 'Equipment & Maint.', icon: Wrench },
+  { id: 'personnel', label: 'Personnel', icon: Users },
+  { id: 'medical', label: 'Medical', icon: Heart },
+  { id: 'fuel', label: 'Fuel Management', icon: Fuel },
+  { id: 'custody', label: 'Chain of Custody', icon: ShieldCheck },
+  { id: 'requisitions', label: 'Requisitions', icon: ClipboardList },
+  { id: 'readiness', label: 'Readiness', icon: Activity },
+  { id: 'transportation', label: 'Transportation', icon: Truck },
+  { id: 'notifications', label: 'Notifications', icon: Bell },
   { id: 'reports', label: 'Reports', icon: Activity },
   { id: 'admin', label: 'Administration', icon: Settings },
   { id: 'deployment', label: 'Deployment', icon: Server },
@@ -1736,6 +1759,383 @@ docker compose up -d --build`}</CodeBlock>
 }
 
 // ---------------------------------------------------------------------------
+// SECTION: Personnel Management
+// ---------------------------------------------------------------------------
+
+function PersonnelSection() {
+  return (
+    <div>
+      <SectionHeading>Personnel Management</SectionHeading>
+
+      <Paragraph>
+        The Personnel module provides a comprehensive view of unit strength,
+        individual service member records, and personnel readiness. It supports
+        S-1 and S-3 staff in maintaining accurate accountability and planning.
+      </Paragraph>
+
+      <SubHeading>Key Features</SubHeading>
+      <BulletList
+        items={[
+          'Unit strength tracking with present-for-duty, TAD, leave, medical, and UA categories',
+          'Individual service member records with rank, MOS, clearance, and assignment history',
+          'EAS (End of Active Service) tracking with configurable advance warning periods',
+          'Security clearance expiration monitoring with automated alerts',
+          'Personnel status roll-ups by echelon through the unit hierarchy',
+          'Filterable and sortable personnel tables with search capabilities',
+          'Personnel summary dashboard with strength percentages and trend data',
+        ]}
+      />
+
+      <SubHeading>Usage</SubHeading>
+      <Paragraph>
+        Navigate to the PERSONNEL page from the sidebar. The summary view shows
+        overall unit strength metrics. Click on individual records to view
+        detailed service member information. Use the unit selector in the sidebar
+        to scope personnel data to a specific echelon.
+      </Paragraph>
+
+      <InfoBox title="Data Sources">
+        Personnel data can be ingested from mIRC chat logs, Excel templates,
+        or entered manually. The system monitors EAS dates and security clearance
+        expirations, generating alerts when thresholds are crossed.
+      </InfoBox>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SECTION: Medical Tracking
+// ---------------------------------------------------------------------------
+
+function MedicalSection() {
+  return (
+    <div>
+      <SectionHeading>Medical Tracking</SectionHeading>
+
+      <Paragraph>
+        The Medical module supports tracking of casualty events, blood product
+        inventory, medical readiness status, and MEDEVAC coordination. It
+        provides S-3 and medical staff with real-time visibility into the
+        medical posture of their units.
+      </Paragraph>
+
+      <SubHeading>Key Features</SubHeading>
+      <BulletList
+        items={[
+          'Casualty tracking with category classification (KIA, WIA, DOW, NBI, disease)',
+          'Blood product inventory management with expiration date monitoring',
+          'Medical readiness status tracking by unit',
+          'MEDEVAC request coordination and status tracking',
+          'Automated alerts for blood product expiration and casualty events',
+          'Medical status roll-ups by echelon',
+          'Integration with personnel records for individual medical histories',
+        ]}
+      />
+
+      <SubHeading>Usage</SubHeading>
+      <Paragraph>
+        Access the MEDICAL page from the sidebar. The dashboard view shows
+        medical readiness metrics and recent casualty events. Blood product
+        inventory displays current stock levels with color-coded expiration
+        warnings. Casualty events are logged with timestamps and linked to
+        personnel records.
+      </Paragraph>
+
+      <WarningBox title="Classification">
+        Medical data may contain sensitive PII and PHI. Ensure appropriate
+        classification markings are applied and access is restricted to
+        authorized medical and command staff.
+      </WarningBox>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SECTION: Fuel Management
+// ---------------------------------------------------------------------------
+
+function FuelSection() {
+  return (
+    <div>
+      <SectionHeading>Fuel Management</SectionHeading>
+
+      <Paragraph>
+        The Fuel module tracks bulk fuel (Class III) inventory, consumption
+        rates, distribution operations, and storage facility status. It provides
+        S-4 staff with the data needed to maintain fuel supply continuity across
+        the force.
+      </Paragraph>
+
+      <SubHeading>Key Features</SubHeading>
+      <BulletList
+        items={[
+          'Bulk fuel inventory tracking (JP-8, DF-2, MOGAS) by storage location',
+          'Real-time consumption rate monitoring with days-of-supply calculations',
+          'Fuel distribution operation tracking from source to destination',
+          'Storage facility status monitoring (capacity, condition, security)',
+          'Automated alerts when fuel levels drop below configurable thresholds',
+          'Fuel consumption trend charts with historical data',
+          'Integration with transportation module for fuel convoy tracking',
+        ]}
+      />
+
+      <SubHeading>Usage</SubHeading>
+      <Paragraph>
+        Navigate to the FUEL page from the sidebar. The overview shows current
+        fuel levels across all storage points with traffic-light status
+        indicators. Use the detailed view to track individual distribution
+        operations and consumption trends by fuel type and location.
+      </Paragraph>
+
+      <InfoBox title="Thresholds">
+        Fuel alert thresholds are configurable in the Admin settings. Default
+        thresholds follow USMC planning factors: RED below 2 days of supply,
+        AMBER below 4 days, GREEN at 4+ days.
+      </InfoBox>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SECTION: Chain of Custody
+// ---------------------------------------------------------------------------
+
+function CustodySection() {
+  return (
+    <div>
+      <SectionHeading>Chain of Custody</SectionHeading>
+
+      <Paragraph>
+        The Chain of Custody module tracks the transfer and accountability of
+        sensitive items, equipment, and materials that require documented
+        hand-off records. It ensures compliance with property accountability
+        regulations and provides an auditable trail.
+      </Paragraph>
+
+      <SubHeading>Key Features</SubHeading>
+      <BulletList
+        items={[
+          'Digital chain of custody records with timestamp and location tracking',
+          'Transfer initiation and acceptance workflow with signature capture',
+          'Sensitive item tracking (weapons, COMSEC, crypto, NVDs, optics)',
+          'Custody history audit trail with full provenance tracking',
+          'Automated notifications for pending custody transfers',
+          'Integration with equipment module for serial number and TAMCN linkage',
+          'Overdue transfer alerts when items are not receipted within SLA',
+        ]}
+      />
+
+      <SubHeading>Usage</SubHeading>
+      <Paragraph>
+        Access the CUSTODY page from the sidebar. The dashboard shows active
+        custody records, pending transfers, and recent transfer history.
+        Initiate a new transfer by selecting an item and specifying the
+        receiving party. The receiving party must acknowledge receipt to
+        complete the transfer.
+      </Paragraph>
+
+      <WarningBox title="Accountability">
+        Chain of custody records are immutable once completed. All transfers
+        are logged in the audit trail and cannot be modified or deleted. This
+        ensures regulatory compliance for sensitive item accountability.
+      </WarningBox>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SECTION: Notifications
+// ---------------------------------------------------------------------------
+
+function NotificationsSection() {
+  return (
+    <div>
+      <SectionHeading>Notifications</SectionHeading>
+
+      <Paragraph>
+        The Notification system delivers real-time alerts and updates to users
+        based on their role, unit assignment, and notification preferences. It
+        ensures critical logistics events are communicated promptly to the
+        appropriate personnel.
+      </Paragraph>
+
+      <SubHeading>Key Features</SubHeading>
+      <BulletList
+        items={[
+          'Real-time push notifications via WebSocket (Socket.IO)',
+          'Role-based notification routing (commanders see critical alerts, operators see task assignments)',
+          'Notification categories: supply alerts, equipment status, personnel changes, system events',
+          'Read/unread tracking with bulk actions',
+          'Notification preferences per user (email, in-app, or both)',
+          'Alert escalation for unacknowledged critical notifications',
+          'Integration with the Alerts module for threshold-based notifications',
+        ]}
+      />
+
+      <SubHeading>Usage</SubHeading>
+      <Paragraph>
+        Notifications appear in the header notification bell. Click to view
+        recent notifications and mark them as read. Critical notifications
+        also appear as banner alerts at the top of the page. Configure
+        notification preferences in the Admin settings.
+      </Paragraph>
+
+      <InfoBox title="Alert Integration">
+        The notification system works in conjunction with the Alerts module.
+        When an alert fires (e.g., supply drops below threshold), a notification
+        is generated and routed to users based on their role and unit assignment.
+      </InfoBox>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SECTION: Requisitions
+// ---------------------------------------------------------------------------
+
+function RequisitionsSection() {
+  return (
+    <div>
+      <SectionHeading>Requisitions</SectionHeading>
+
+      <Paragraph>
+        The Requisitions module manages the request, approval, and fulfillment
+        workflow for supply and equipment orders. It supports the full lifecycle
+        from initial request through commander approval to receipt of materials.
+      </Paragraph>
+
+      <SubHeading>Key Features</SubHeading>
+      <BulletList
+        items={[
+          'Create requisitions for supply items across all NATO supply classes',
+          'Multi-level approval workflow (requester > S-4 > commander)',
+          'Priority classification (routine, priority, immediate, flash)',
+          'Requisition status tracking (draft, submitted, approved, ordered, received, cancelled)',
+          'Linked to supply catalog for standardized item selection (NSN/NIIN lookup)',
+          'Requisition history with full audit trail',
+          'Automated alerts for pending approvals and overdue requisitions',
+          'Bulk requisition creation from supply shortfall analysis',
+        ]}
+      />
+
+      <SubHeading>Usage</SubHeading>
+      <Paragraph>
+        Navigate to the REQUISITIONS page from the sidebar. Click "New
+        Requisition" to create a request. Select items from the supply catalog,
+        specify quantities and priority, then submit for approval. Track
+        requisition status in the list view. Approvers will see pending
+        requisitions in their notification queue.
+      </Paragraph>
+
+      <InfoBox title="Permissions">
+        Creating requisitions requires the <InlineCode>requisitions:create</InlineCode>{' '}
+        permission. Approving requisitions requires <InlineCode>requisitions:approve</InlineCode>.
+        Viewers can see requisition status but cannot create or approve.
+      </InfoBox>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SECTION: Readiness Reporting
+// ---------------------------------------------------------------------------
+
+function ReadinessSection() {
+  return (
+    <div>
+      <SectionHeading>Readiness Reporting</SectionHeading>
+
+      <Paragraph>
+        The Readiness module provides a comprehensive view of unit combat
+        readiness across personnel, equipment, supply, and training dimensions.
+        It aggregates data from multiple modules to produce a holistic readiness
+        assessment conforming to DRRS-MC reporting standards.
+      </Paragraph>
+
+      <SubHeading>Key Features</SubHeading>
+      <BulletList
+        items={[
+          'Unit readiness ratings (C1-C5) based on personnel, equipment, supply, and training',
+          'Readiness roll-up tree showing ratings from company to MEF level',
+          'Trend charts showing readiness changes over time',
+          'Personnel strength tables with present-for-duty percentages',
+          'Equipment MC/NMC rates by TAMCN with mission-capable breakdowns',
+          'Supply days-of-supply metrics by class with status indicators',
+          'Configurable readiness thresholds per echelon and category',
+          'Readiness gauge visualizations with color-coded status',
+        ]}
+      />
+
+      <SubHeading>Usage</SubHeading>
+      <Paragraph>
+        Navigate to the READINESS page from the sidebar. The overview displays
+        the current readiness rating for the selected unit with breakdowns by
+        category. Use the roll-up tree to see how subordinate unit ratings
+        aggregate to higher echelons. Trend charts show readiness progression
+        over the past 30 days.
+      </Paragraph>
+
+      <InfoBox title="Rating Calculation">
+        Readiness ratings are calculated using weighted averages across
+        personnel strength, equipment availability, supply levels, and training
+        currency. The lowest-rated category determines the overall unit rating
+        per USMC readiness reporting standards.
+      </InfoBox>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SECTION: Transportation
+// ---------------------------------------------------------------------------
+
+function TransportationSection() {
+  return (
+    <div>
+      <SectionHeading>Transportation</SectionHeading>
+
+      <Paragraph>
+        The Transportation module manages convoy operations, route planning,
+        movement tracking, and vehicle allocation. It provides logistics staff
+        with real-time visibility into all transportation assets and ongoing
+        movements.
+      </Paragraph>
+
+      <SubHeading>Key Features</SubHeading>
+      <BulletList
+        items={[
+          'Convoy management with status tracking (planned, en route, delayed, arrived, cancelled)',
+          'Interactive route planning with GeoJSON/GPX/KML/KMZ import support',
+          'Real-time movement tracking with map overlay',
+          'Vehicle and personnel allocation per convoy',
+          'Cargo manifest management with weight and cube calculations',
+          'Throughput charts showing movement volume over time',
+          'Route distance and estimated travel time calculations',
+          'Integration with map module for route visualization and convoy positions',
+          'Movement detail modals with full manifest, vehicle, and timeline information',
+        ]}
+      />
+
+      <SubHeading>Usage</SubHeading>
+      <Paragraph>
+        Navigate to the TRANSPORTATION page from the sidebar. The movement
+        tracker shows all active and planned convoys with status indicators.
+        Use the route planner to create new convoy routes by importing route
+        files or drawing directly on the map. The convoy map provides a
+        real-time view of all convoy positions and routes.
+      </Paragraph>
+
+      <InfoBox title="Route Files">
+        KEYSTONE supports importing routes in GeoJSON, GPX, KML, and KMZ
+        formats. Routes can also be drawn directly on the interactive map
+        using the route drawing tool. All routes are stored and can be
+        reused for future convoy operations.
+      </InfoBox>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Shared table styles
 // ---------------------------------------------------------------------------
 
@@ -1768,6 +2168,14 @@ const sectionComponents: Record<Section, () => JSX.Element> = {
   architecture: ArchitectureSection,
   features: FeaturesSection,
   equipment: EquipmentSection,
+  personnel: PersonnelSection,
+  medical: MedicalSection,
+  fuel: FuelSection,
+  custody: CustodySection,
+  requisitions: RequisitionsSection,
+  readiness: ReadinessSection,
+  transportation: TransportationSection,
+  notifications: NotificationsSection,
   reports: ReportsSection,
   admin: AdminSection,
   deployment: DeploymentSection,

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -2,17 +2,140 @@ import { create } from 'zustand';
 import type { User } from '@/lib/types';
 import * as authApi from '@/api/auth';
 
+// ---------------------------------------------------------------------------
+// Default permission sets per role — used when server doesn't provide them
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = {
+  admin: ['*'],
+  commander: [
+    'dashboard:view',
+    'map:view',
+    'supply:view',
+    'equipment:view',
+    'maintenance:view',
+    'requisitions:view',
+    'requisitions:approve',
+    'personnel:view',
+    'readiness:view',
+    'medical:view',
+    'fuel:view',
+    'custody:view',
+    'audit:view',
+    'transportation:view',
+    'ingestion:view',
+    'ingestion:upload',
+    'reports:view',
+    'reports:generate',
+    'alerts:view',
+    'alerts:acknowledge',
+    'docs:view',
+  ],
+  s4: [
+    'dashboard:view',
+    'map:view',
+    'supply:view',
+    'supply:edit',
+    'equipment:view',
+    'equipment:edit',
+    'maintenance:view',
+    'maintenance:create',
+    'maintenance:edit',
+    'requisitions:view',
+    'requisitions:create',
+    'requisitions:edit',
+    'requisitions:approve',
+    'readiness:view',
+    'fuel:view',
+    'fuel:edit',
+    'custody:view',
+    'custody:edit',
+    'transportation:view',
+    'transportation:edit',
+    'ingestion:view',
+    'ingestion:upload',
+    'reports:view',
+    'reports:generate',
+    'alerts:view',
+    'alerts:acknowledge',
+    'docs:view',
+  ],
+  s3: [
+    'dashboard:view',
+    'map:view',
+    'personnel:view',
+    'personnel:edit',
+    'medical:view',
+    'readiness:view',
+    'readiness:edit',
+    'equipment:view',
+    'transportation:view',
+    'transportation:edit',
+    'reports:view',
+    'reports:generate',
+    'alerts:view',
+    'alerts:acknowledge',
+    'docs:view',
+  ],
+  operator: [
+    'dashboard:view',
+    'map:view',
+    'supply:view',
+    'equipment:view',
+    'maintenance:view',
+    'requisitions:view',
+    'requisitions:create',
+    'requisitions:edit',
+    'personnel:view',
+    'readiness:view',
+    'medical:view',
+    'fuel:view',
+    'custody:view',
+    'transportation:view',
+    'ingestion:view',
+    'ingestion:upload',
+    'reports:view',
+    'alerts:view',
+    'docs:view',
+  ],
+  viewer: [
+    'dashboard:view',
+    'map:view',
+    'supply:view',
+    'equipment:view',
+    'readiness:view',
+    'alerts:view',
+    'reports:view',
+    'personnel:view',
+    'docs:view',
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Auth Store
+// ---------------------------------------------------------------------------
+
 interface AuthState {
   user: User | null;
   token: string | null;
+  permissions: string[];
   isLoading: boolean;
   error: string | null;
   isAuthenticated: boolean;
   login: (username: string, password: string) => Promise<void>;
   logout: () => void;
   setUser: (user: User) => void;
+  setPermissions: (perms: string[]) => void;
   checkAuth: () => boolean;
   clearError: () => void;
+}
+
+function resolvePermissions(user: User): string[] {
+  if (user.permissions && user.permissions.length > 0) {
+    return user.permissions;
+  }
+  const role = (user.role || '').toLowerCase();
+  return DEFAULT_ROLE_PERMISSIONS[role] || [];
 }
 
 export const useAuthStore = create<AuthState>((set, get) => ({
@@ -25,6 +148,14 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
   })(),
   token: localStorage.getItem('keystone_token'),
+  permissions: (() => {
+    try {
+      const stored = localStorage.getItem('keystone_permissions');
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  })(),
   isLoading: false,
   error: null,
 
@@ -36,11 +167,14 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     set({ isLoading: true, error: null });
     try {
       const response = await authApi.login(username, password);
+      const perms = resolvePermissions(response.user);
       localStorage.setItem('keystone_token', response.token);
       localStorage.setItem('keystone_user', JSON.stringify(response.user));
+      localStorage.setItem('keystone_permissions', JSON.stringify(perms));
       set({
         user: response.user,
         token: response.token,
+        permissions: perms,
         isLoading: false,
         error: null,
       });
@@ -56,12 +190,18 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   logout: () => {
     localStorage.removeItem('keystone_token');
     localStorage.removeItem('keystone_user');
-    set({ user: null, token: null, error: null });
+    localStorage.removeItem('keystone_permissions');
+    set({ user: null, token: null, permissions: [], error: null });
   },
 
   setUser: (user: User) => {
     localStorage.setItem('keystone_user', JSON.stringify(user));
     set({ user });
+  },
+
+  setPermissions: (perms: string[]) => {
+    localStorage.setItem('keystone_permissions', JSON.stringify(perms));
+    set({ permissions: perms });
   },
 
   checkAuth: () => {
@@ -70,7 +210,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     if (token && userStr) {
       try {
         const user = JSON.parse(userStr);
-        set({ token, user });
+        const permsStr = localStorage.getItem('keystone_permissions');
+        const permissions = permsStr ? JSON.parse(permsStr) : resolvePermissions(user);
+        set({ token, user, permissions });
         return true;
       } catch {
         return false;


### PR DESCRIPTION
## Summary
- **62 granular permissions** across 16 categories replace hardcoded role checks
- Admins can create **custom roles** with discrete access to tabs, actions, and data via new Roles & Permissions admin tab
- **Sidebar, routes, and write endpoints** all enforce permissions — a Viewer now only sees Dashboard, Map, Supply, Equipment, Readiness, Alerts, Reports, Personnel, Docs
- Adds **3 missing nav items** (Fuel, Custody, Audit) and **8 missing doc sections** (Personnel, Medical, Fuel, Custody, Notifications, Requisitions, Readiness, Transportation)
- Login/me API responses now include effective permission codes
- Backend `require_permission()` guards on supply, equipment, readiness write endpoints

## Test plan
- [x] `ruff check .` — PASS
- [x] `ruff format --check .` — PASS (193 files)
- [x] `mypy app/` — PASS (0 issues, 144 files)
- [x] `pytest tests/` — PASS (123 passed)
- [x] `tsc -b` — PASS (0 errors)
- [x] `vitest run` — PASS (4 tests)
- [ ] Login as `viewer` → only sees Dashboard, Map, Supply, Equipment, Readiness, Alerts, Reports, Personnel, Docs in sidebar
- [ ] Login as `admin` → sees all items including Admin
- [ ] Navigate to `/admin` as viewer → 403 ACCESS DENIED page
- [ ] Admin > Roles & Permissions tab → create custom role, assign permissions, assign to user
- [ ] DevSecOps review completed — no CRITICAL/HIGH findings in new code (pre-existing items documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)