### PR TITLE
feat: shared Modal component + EmptyState across all data tables

### DIFF
--- a/frontend/src/components/custody/AuditLogTable.tsx
+++ b/frontend/src/components/custody/AuditLogTable.tsx
@@ -4,6 +4,7 @@
 
 import { FileText } from 'lucide-react';
 import type { AuditLogEntry } from '@/lib/types';
+import EmptyState from '@/components/ui/EmptyState';
 
 interface AuditLogTableProps {
   logs: AuditLogEntry[];
@@ -64,18 +65,11 @@ export default function AuditLogTable({ logs, loading }: AuditLogTableProps) {
 
   if (logs.length === 0) {
     return (
-      <div
-        style={{
-          padding: 40,
-          textAlign: 'center',
-          color: 'var(--color-text-muted)',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-        }}
-      >
-        <FileText size={24} style={{ opacity: 0.4, marginBottom: 8 }} />
-        <div>No audit log entries found</div>
-      </div>
+      <EmptyState
+        icon={<FileText size={32} />}
+        title="NO AUDIT LOGS"
+        message="Audit log entries will appear here"
+      />
     );
   }
 

--- a/frontend/src/components/custody/CustodyChainTimeline.tsx
+++ b/frontend/src/components/custody/CustodyChainTimeline.tsx
@@ -2,8 +2,9 @@
 // CustodyChainTimeline — Vertical timeline of custody transfers
 // =============================================================================
 
-import { ArrowRight, User } from 'lucide-react';
+import { ArrowRight, GitBranch, User } from 'lucide-react';
 import type { CustodyTransfer } from '@/lib/types';
+import EmptyState from '@/components/ui/EmptyState';
 
 interface CustodyChainTimelineProps {
   transfers: CustodyTransfer[];
@@ -71,17 +72,11 @@ export default function CustodyChainTimeline({
 
       {/* Timeline entries */}
       {transfers.length === 0 ? (
-        <div
-          style={{
-            padding: 24,
-            textAlign: 'center',
-            color: 'var(--color-text-muted)',
-            fontFamily: 'var(--font-mono)',
-            fontSize: 11,
-          }}
-        >
-          No transfer history
-        </div>
+        <EmptyState
+          icon={<GitBranch size={32} />}
+          title="NO TRANSFER HISTORY"
+          message="Custody transfer records will appear here"
+        />
       ) : (
         transfers.map((transfer, idx) => {
           const color = TRANSFER_TYPE_COLORS[transfer.transfer_type] ?? '#6b7280';

--- a/frontend/src/components/custody/InventoryPanel.tsx
+++ b/frontend/src/components/custody/InventoryPanel.tsx
@@ -4,6 +4,7 @@
 
 import { ClipboardCheck } from 'lucide-react';
 import type { InventoryEvent } from '@/lib/types';
+import EmptyState from '@/components/ui/EmptyState';
 
 interface InventoryPanelProps {
   events: InventoryEvent[];
@@ -35,18 +36,11 @@ export default function InventoryPanel({ events, loading }: InventoryPanelProps)
 
   if (events.length === 0) {
     return (
-      <div
-        style={{
-          padding: 40,
-          textAlign: 'center',
-          color: 'var(--color-text-muted)',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-        }}
-      >
-        <ClipboardCheck size={24} style={{ opacity: 0.4, marginBottom: 8 }} />
-        <div>No inventory events found</div>
-      </div>
+      <EmptyState
+        icon={<ClipboardCheck size={32} />}
+        title="NO INVENTORY EVENTS"
+        message="Inventory events will appear here"
+      />
     );
   }
 

--- a/frontend/src/components/custody/SensitiveItemsTable.tsx
+++ b/frontend/src/components/custody/SensitiveItemsTable.tsx
@@ -4,6 +4,7 @@
 
 import { Shield } from 'lucide-react';
 import type { SensitiveItem } from '@/lib/types';
+import EmptyState from '@/components/ui/EmptyState';
 
 interface SensitiveItemsTableProps {
   items: SensitiveItem[];
@@ -77,18 +78,11 @@ export default function SensitiveItemsTable({
 
   if (items.length === 0) {
     return (
-      <div
-        style={{
-          padding: 40,
-          textAlign: 'center',
-          color: 'var(--color-text-muted)',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-        }}
-      >
-        <Shield size={24} style={{ opacity: 0.4, marginBottom: 8 }} />
-        <div>No sensitive items found</div>
-      </div>
+      <EmptyState
+        icon={<Shield size={32} />}
+        title="NO SENSITIVE ITEMS"
+        message="Registered sensitive items will appear here"
+      />
     );
   }
 

--- a/frontend/src/components/equipment/MaintenanceHistoryTab.tsx
+++ b/frontend/src/components/equipment/MaintenanceHistoryTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ChevronDown, ChevronRight, Wrench, Package, Clock, User, ExternalLink, Plus } from 'lucide-react';
 import type { MaintenanceWorkOrder } from '@/lib/types';
+import EmptyState from '@/components/ui/EmptyState';
 import { WorkOrderStatus } from '@/lib/types';
 import { formatDate, formatRelativeTime } from '@/lib/utils';
 import WorkOrderDetailModal from './WorkOrderDetailModal';
@@ -642,19 +643,13 @@ export default function MaintenanceHistoryTab({ workOrders, equipmentId, onRefre
 
       {/* Work Order List */}
       {sorted.length === 0 ? (
-        <div
-          style={{
-            padding: 32,
-            textAlign: 'center',
-            color: 'var(--color-text-muted)',
-            fontSize: 12,
-            backgroundColor: 'var(--color-bg-elevated)',
-            border: '1px solid var(--color-border)',
-            borderRadius: 'var(--radius)',
-          }}
-        >
-          No maintenance work orders found for this equipment.
-        </div>
+        <EmptyState
+          icon={<Wrench size={32} />}
+          title="NO WORK ORDERS"
+          message="No maintenance work orders found for this equipment"
+          actionLabel="+ NEW WORK ORDER"
+          onAction={() => setShowCreate(true)}
+        />
       ) : (
         sorted.map((wo) => (
           <WorkOrderRow key={wo.id} wo={wo} onViewDetails={setModalWO} />

--- a/frontend/src/components/equipment/MaintenanceQueue.tsx
+++ b/frontend/src/components/equipment/MaintenanceQueue.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Wrench, Clock, Package, Plus } from 'lucide-react';
 import Card from '@/components/ui/Card';
+import EmptyState from '@/components/ui/EmptyState';
 import StatusDot from '@/components/ui/StatusDot';
 import { formatRelativeTime } from '@/lib/utils';
 import type { MaintenanceWorkOrder } from '@/lib/types';
@@ -110,6 +111,15 @@ export default function MaintenanceQueue() {
       }
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {workOrders.length === 0 && (
+          <EmptyState
+            icon={<Wrench size={32} />}
+            title="NO WORK ORDERS"
+            message="Create a work order to track maintenance tasks"
+            actionLabel="+ NEW WORK ORDER"
+            onAction={() => setShowCreate(true)}
+          />
+        )}
         {workOrders.map((wo) => {
           const totalLabor = wo.laborEntries.reduce((sum, l) => sum + l.hours, 0);
           return (

--- a/frontend/src/components/fuel/FuelTransactionTable.tsx
+++ b/frontend/src/components/fuel/FuelTransactionTable.tsx
@@ -2,7 +2,9 @@
 // FuelTransactionTable — Transaction history table with type badges
 // =============================================================================
 
+import { Fuel } from 'lucide-react';
 import type { FuelTransaction } from '@/lib/types';
+import EmptyState from '@/components/ui/EmptyState';
 
 interface FuelTransactionTableProps {
   transactions: FuelTransaction[];
@@ -64,17 +66,11 @@ export default function FuelTransactionTable({ transactions }: FuelTransactionTa
 
   if (sorted.length === 0) {
     return (
-      <div
-        style={{
-          padding: 32,
-          textAlign: 'center',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 12,
-          color: 'var(--color-text-muted)',
-        }}
-      >
-        No transactions found.
-      </div>
+      <EmptyState
+        icon={<Fuel size={32} />}
+        title="NO TRANSACTIONS"
+        message="Fuel transactions will appear here"
+      />
     );
   }
 

--- a/frontend/src/components/maintenance/DeadlineBoard.tsx
+++ b/frontend/src/components/maintenance/DeadlineBoard.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, CheckCircle } from 'lucide-react';
 import type { MaintenanceDeadline, DeadlineReason } from '@/lib/types';
+import EmptyState from '@/components/ui/EmptyState';
 
 interface DeadlineBoardProps {
   deadlines: MaintenanceDeadline[];
@@ -54,22 +55,11 @@ export default function DeadlineBoard({ deadlines, onLift }: DeadlineBoardProps)
 
   if (groups.length === 0) {
     return (
-      <div
-        style={{
-          padding: 40,
-          textAlign: 'center',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          color: 'var(--color-text-muted)',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: 8,
-        }}
-      >
-        <CheckCircle size={24} style={{ color: 'var(--color-success)' }} />
-        No deadlined equipment
-      </div>
+      <EmptyState
+        icon={<CheckCircle size={32} />}
+        title="NO DEADLINE EQUIPMENT"
+        message="All equipment is operationally ready"
+      />
     );
   }
 

--- a/frontend/src/components/maintenance/PMScheduleTable.tsx
+++ b/frontend/src/components/maintenance/PMScheduleTable.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
-import { AlertTriangle, CheckCircle, Clock } from 'lucide-react';
+import { AlertTriangle, Calendar, CheckCircle, Clock } from 'lucide-react';
+import EmptyState from '@/components/ui/EmptyState';
 import type { PMScheduleItem, PMType } from '@/lib/types';
 import { formatDate } from '@/lib/utils';
 
@@ -47,17 +48,11 @@ export default function PMScheduleTable({ schedule }: PMScheduleTableProps) {
 
   if (sortedSchedule.length === 0) {
     return (
-      <div
-        style={{
-          padding: 40,
-          textAlign: 'center',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          color: 'var(--color-text-muted)',
-        }}
-      >
-        No PM schedule items found
-      </div>
+      <EmptyState
+        icon={<Calendar size={32} />}
+        title="NO PM SCHEDULES"
+        message="Preventive maintenance schedules will appear here"
+      />
     );
   }
 

--- a/frontend/src/components/medical/BurnRateTable.tsx
+++ b/frontend/src/components/medical/BurnRateTable.tsx
@@ -3,8 +3,9 @@
 // =============================================================================
 
 import { useState, useMemo } from 'react';
-import { AlertTriangle } from 'lucide-react';
+import { Activity, AlertTriangle } from 'lucide-react';
 import type { MedicalBurnRate } from '@/lib/types';
+import EmptyState from '@/components/ui/EmptyState';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -111,17 +112,11 @@ export default function BurnRateTable({ burnRates }: BurnRateTableProps) {
 
   if (burnRates.length === 0) {
     return (
-      <div
-        style={{
-          padding: 40,
-          textAlign: 'center',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          color: 'var(--color-text-muted)',
-        }}
-      >
-        No burn rate data available
-      </div>
+      <EmptyState
+        icon={<Activity size={32} />}
+        title="NO BURN RATE DATA"
+        message="Medical supply burn rate data will appear here"
+      />
     );
   }
 

--- a/frontend/src/components/medical/CasualtyTable.tsx
+++ b/frontend/src/components/medical/CasualtyTable.tsx
@@ -3,8 +3,9 @@
 // =============================================================================
 
 import { useState, useMemo } from 'react';
-import { Clock, MapPin, Users } from 'lucide-react';
+import { Clock, Heart, MapPin, Users } from 'lucide-react';
 import type { CasualtyReport } from '@/lib/types';
+import EmptyState from '@/components/ui/EmptyState';
 import { CASEVACPrecedence, CasualtyReportStatus, EvacuationStatus, TriageCategory } from '@/lib/types';
 
 // ---------------------------------------------------------------------------
@@ -164,17 +165,11 @@ export default function CasualtyTable({ casualties }: CasualtyTableProps) {
 
   if (casualties.length === 0) {
     return (
-      <div
-        style={{
-          padding: 40,
-          textAlign: 'center',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          color: 'var(--color-text-muted)',
-        }}
-      >
-        No active casualty reports
-      </div>
+      <EmptyState
+        icon={<Heart size={32} />}
+        title="NO CASUALTY REPORTS"
+        message="Active casualty reports will appear here"
+      />
     );
   }
 

--- a/frontend/src/components/personnel/AlphaRosterTable.tsx
+++ b/frontend/src/components/personnel/AlphaRosterTable.tsx
@@ -3,8 +3,9 @@
 // =============================================================================
 
 import { useState, useMemo } from 'react';
-import { Search } from 'lucide-react';
+import { Search, Users } from 'lucide-react';
 import type { PersonnelRecord, RifleQual, DutyStatusType } from '@/lib/types';
+import EmptyState from '@/components/ui/EmptyState';
 
 interface AlphaRosterTableProps {
   personnel: PersonnelRecord[];
@@ -198,6 +199,13 @@ export default function AlphaRosterTable({ personnel }: AlphaRosterTableProps) {
       </div>
 
       {/* Table */}
+      {filtered.length === 0 ? (
+        <EmptyState
+          icon={<Users size={32} />}
+          title="NO PERSONNEL"
+          message="Personnel assigned to this unit will appear here"
+        />
+      ) : (
       <div style={{ overflowX: 'auto' }}>
         <table
           style={{
@@ -294,6 +302,7 @@ export default function AlphaRosterTable({ personnel }: AlphaRosterTableProps) {
           </tbody>
         </table>
       </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/requisitions/ApprovalQueue.tsx
+++ b/frontend/src/components/requisitions/ApprovalQueue.tsx
@@ -4,8 +4,9 @@
 
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Check, XCircle, Clock, AlertTriangle } from 'lucide-react';
+import { Check, XCircle, Clock, AlertTriangle, ClipboardCheck } from 'lucide-react';
 import type { Requisition, RequisitionPriority } from '@/lib/types';
+import EmptyState from '@/components/ui/EmptyState';
 import { approveRequisition, denyRequisition } from '@/api/requisitions';
 
 // ---------------------------------------------------------------------------
@@ -327,17 +328,11 @@ export default function ApprovalQueue({ requisitions, onRefresh }: ApprovalQueue
 
   if (pending.length === 0) {
     return (
-      <div
-        style={{
-          padding: 40,
-          textAlign: 'center',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          color: 'var(--color-text-muted)',
-        }}
-      >
-        No requisitions pending approval
-      </div>
+      <EmptyState
+        icon={<ClipboardCheck size={32} />}
+        title="NO PENDING APPROVALS"
+        message="Requisitions pending approval will appear here"
+      />
     );
   }
 

--- a/frontend/src/components/requisitions/InventoryPanel.tsx
+++ b/frontend/src/components/requisitions/InventoryPanel.tsx
@@ -3,8 +3,9 @@
 // =============================================================================
 
 import { useQuery } from '@tanstack/react-query';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Package } from 'lucide-react';
 import Card from '@/components/ui/Card';
+import EmptyState from '@/components/ui/EmptyState';
 import { getInventory, getLowStockAlerts } from '@/api/requisitions';
 
 // ---------------------------------------------------------------------------
@@ -228,17 +229,11 @@ export default function InventoryPanel({ unitId }: InventoryPanelProps) {
             </table>
           </div>
         ) : (
-          <div
-            style={{
-              padding: 40,
-              textAlign: 'center',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 11,
-              color: 'var(--color-text-muted)',
-            }}
-          >
-            No inventory records found
-          </div>
+          <EmptyState
+            icon={<Package size={32} />}
+            title="NO INVENTORY RECORDS"
+            message="Inventory records will appear here"
+          />
         )}
       </Card>
     </div>

--- a/frontend/src/components/requisitions/RequisitionTable.tsx
+++ b/frontend/src/components/requisitions/RequisitionTable.tsx
@@ -3,8 +3,9 @@
 // =============================================================================
 
 import { useState, useMemo } from 'react';
-import { ChevronDown, ChevronUp, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronUp, ChevronRight, ClipboardList } from 'lucide-react';
 import type { Requisition, RequisitionStatus, RequisitionPriority } from '@/lib/types';
+import EmptyState from '@/components/ui/EmptyState';
 import RequisitionDetail from './RequisitionDetail';
 
 // ---------------------------------------------------------------------------
@@ -119,17 +120,11 @@ export default function RequisitionTable({ requisitions, onRefresh }: Requisitio
 
   if (requisitions.length === 0) {
     return (
-      <div
-        style={{
-          padding: 40,
-          textAlign: 'center',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          color: 'var(--color-text-muted)',
-        }}
-      >
-        No requisitions found
-      </div>
+      <EmptyState
+        icon={<ClipboardList size={32} />}
+        title="NO REQUISITIONS"
+        message="Requisitions will appear here"
+      />
     );
   }
 

--- a/frontend/src/components/transportation/MovementHistoryTable.tsx
+++ b/frontend/src/components/transportation/MovementHistoryTable.tsx
@@ -3,9 +3,10 @@
 // =============================================================================
 
 import { useState, useMemo } from 'react';
-import { Check, X } from 'lucide-react';
+import { Check, Truck, X } from 'lucide-react';
 import type { MovementHistoryRecord } from '@/lib/types';
 import Card from '@/components/ui/Card';
+import EmptyState from '@/components/ui/EmptyState';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -177,17 +178,11 @@ export default function MovementHistoryTable({
         }
       >
         {filteredRecords.length === 0 ? (
-          <div
-            style={{
-              padding: 40,
-              textAlign: 'center',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 11,
-              color: 'var(--color-text-muted)',
-            }}
-          >
-            No movement records found
-          </div>
+          <EmptyState
+            icon={<Truck size={32} />}
+            title="NO MOVEMENT RECORDS"
+            message="Completed movement records will appear here"
+          />
         ) : (
           <div style={{ overflowX: 'auto' }}>
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -5,9 +5,11 @@ interface EmptyStateProps {
   icon?: ReactNode;
   title: string;
   message?: string;
+  actionLabel?: string;
+  onAction?: () => void;
 }
 
-export default function EmptyState({ icon, title, message }: EmptyStateProps) {
+export default function EmptyState({ icon, title, message, actionLabel, onAction }: EmptyStateProps) {
   return (
     <div
       style={{
@@ -36,6 +38,27 @@ export default function EmptyState({ icon, title, message }: EmptyStateProps) {
       </div>
       {message && (
         <div style={{ fontSize: 13, opacity: 0.7 }}>{message}</div>
+      )}
+      {actionLabel && onAction && (
+        <button
+          onClick={onAction}
+          style={{
+            marginTop: 16,
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10,
+            fontWeight: 600,
+            letterSpacing: '1px',
+            textTransform: 'uppercase',
+            padding: '8px 16px',
+            backgroundColor: 'var(--color-accent)',
+            color: 'var(--color-bg)',
+            border: 'none',
+            borderRadius: 'var(--radius)',
+            cursor: 'pointer',
+          }}
+        >
+          {actionLabel}
+        </button>
       )}
     </div>
   );

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,123 @@
+import { useEffect } from 'react';
+import { X } from 'lucide-react';
+
+interface ModalProps {
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+  maxWidth?: number;
+  footer?: React.ReactNode;
+}
+
+export default function Modal({ title, onClose, children, maxWidth = 600, footer }: ModalProps) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 3000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0, 0, 0, 0.85)',
+        animation: 'modalFadeIn 0.15s ease-out',
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <style>{`
+        @keyframes modalFadeIn {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+      `}</style>
+      <div
+        style={{
+          width: '90%',
+          maxWidth,
+          maxHeight: '90vh',
+          backgroundColor: 'var(--color-bg-card)',
+          border: '1px solid var(--color-border-strong)',
+          borderRadius: 'var(--radius)',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '14px 16px',
+            borderBottom: '1px solid var(--color-border)',
+          }}
+        >
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 12,
+              fontWeight: 700,
+              letterSpacing: '1.5px',
+              color: 'var(--color-text-bright)',
+              textTransform: 'uppercase',
+            }}
+          >
+            {title}
+          </span>
+          <button
+            onClick={onClose}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'none',
+              border: 'none',
+              color: 'var(--color-text-muted)',
+              cursor: 'pointer',
+              padding: 4,
+            }}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            padding: 16,
+          }}
+        >
+          {children}
+        </div>
+
+        {/* Footer */}
+        {footer && (
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: 8,
+              padding: '12px 16px',
+              borderTop: '1px solid var(--color-border)',
+            }}
+          >
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **New `Modal.tsx`** — Shared reusable modal component with centered overlay, ESC key close, backdrop click close, internal scrolling, and fade-in animation. Follows existing KEYSTONE styling conventions.
- **Enhanced `EmptyState.tsx`** — Added `actionLabel` and `onAction` props to support call-to-action buttons in empty states.
- **EmptyState adopted across 16 components** — Consistent empty-data UX with contextual Lucide icons across maintenance, equipment, personnel, custody, fuel, requisitions, medical, and transportation tables.

### Components updated with EmptyState:
| Component | Icon | Title |
|-----------|------|-------|
| PMScheduleTable | Calendar | NO PM SCHEDULES |
| DeadlineBoard | CheckCircle | NO DEADLINE EQUIPMENT |
| MaintenanceQueue | Wrench | NO WORK ORDERS (+ action button) |
| MaintenanceHistoryTab | Wrench | NO WORK ORDERS (+ action button) |
| AlphaRosterTable | Users | NO PERSONNEL |
| SensitiveItemsTable | Shield | NO SENSITIVE ITEMS |
| FuelTransactionTable | Fuel | NO TRANSACTIONS |
| RequisitionTable | ClipboardList | NO REQUISITIONS |
| ApprovalQueue | ClipboardCheck | NO PENDING APPROVALS |
| InventoryPanel (requisitions) | Package | NO INVENTORY RECORDS |
| CasualtyTable | Heart | NO CASUALTY REPORTS |
| BurnRateTable | Activity | NO BURN RATE DATA |
| MovementHistoryTable | Truck | NO MOVEMENT RECORDS |
| AuditLogTable | FileText | NO AUDIT LOGS |
| CustodyChainTimeline | GitBranch | NO TRANSFER HISTORY |
| InventoryPanel (custody) | ClipboardCheck | NO INVENTORY EVENTS |

### Pre-existing (no changes needed):
- Sidebar already had Fuel, Custody, Audit nav links
- All modals already properly centered
- All mutations already had `onSuccess` query invalidation

## Test plan

- [x] `npx tsc -b` — zero TypeScript errors
- [x] `npx vitest run` — 4/4 tests pass
- [x] DevSecOps review — 0 critical/high/medium findings (3 LOW hardening recommendations)
- [ ] Smoke test — Docker unavailable in CI env; verify manually if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)