### PR TITLE
fix: requisition persistence, lifecycle actions & analytics

### DIFF
--- a/frontend/src/api/requisitions.ts
+++ b/frontend/src/api/requisitions.ts
@@ -38,588 +38,621 @@ const mockDelay = (ms = 150 + Math.random() * 150): Promise<void> =>
   new Promise((r) => setTimeout(r, ms));
 
 // ---------------------------------------------------------------------------
-// Mock Requisition Data
+// sessionStorage-backed Requisition Store
 // ---------------------------------------------------------------------------
 
-const MOCK_REQUISITIONS: Requisition[] = [
-  {
-    id: 1,
-    requisition_number: 'REQ-2026-0001',
-    unit_id: 4,
-    requested_by_id: 10,
-    requested_by_name: 'SSgt Martinez',
-    approved_by_id: null,
-    supply_catalog_item_id: 1,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '8970-00-149-1094',
-    dodic: null,
-    nomenclature: 'MEAL, READY-TO-EAT (MRE), CASE',
-    quantity_requested: 120,
-    quantity_approved: null,
-    quantity_issued: null,
-    unit_of_issue: 'CS',
-    priority: '06' as RequisitionPriority,
-    status: 'DRAFT',
-    justification: 'Resupply for upcoming field exercise, 3-day FEX support',
-    denial_reason: null,
-    document_number: null,
-    created_at: isoStr(1),
-    updated_at: isoStr(1),
-    submitted_at: null,
-    approved_at: null,
-    shipped_at: null,
-    received_at: null,
-    estimated_delivery_date: null,
-    actual_delivery_date: null,
-    approvals: [],
-    status_history: [
-      { id: 1, old_status: null, new_status: 'DRAFT', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(1), notes: 'Requisition created' },
-    ],
-  },
-  {
-    id: 2,
-    requisition_number: 'REQ-2026-0002',
-    unit_id: 4,
-    requested_by_id: 12,
-    requested_by_name: 'Cpl Johnson',
-    approved_by_id: null,
-    supply_catalog_item_id: 2,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '9150-01-197-7688',
-    dodic: null,
-    nomenclature: 'LUBRICANT, WEAPONS (CLP)',
-    quantity_requested: 48,
-    quantity_approved: null,
-    quantity_issued: null,
-    unit_of_issue: 'BT',
-    priority: '06' as RequisitionPriority,
-    status: 'SUBMITTED',
-    justification: 'Weapons maintenance prior to range week',
-    denial_reason: null,
-    document_number: 'W81K4026R0002',
-    created_at: isoStr(5),
-    updated_at: isoStr(4),
-    submitted_at: isoStr(4),
-    approved_at: null,
-    shipped_at: null,
-    received_at: null,
-    estimated_delivery_date: null,
-    actual_delivery_date: null,
-    approvals: [],
-    status_history: [
-      { id: 2, old_status: null, new_status: 'DRAFT', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(5), notes: 'Requisition created' },
-      { id: 3, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(4), notes: 'Submitted for approval' },
-    ],
-  },
-  {
-    id: 3,
-    requisition_number: 'REQ-2026-0003',
-    unit_id: 5,
-    requested_by_id: 15,
-    requested_by_name: 'Sgt Williams',
-    approved_by_id: null,
-    supply_catalog_item_id: null,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '6515-01-532-8056',
-    dodic: null,
-    nomenclature: 'FIRST AID KIT, INDIVIDUAL (IFAK)',
-    quantity_requested: 30,
-    quantity_approved: null,
-    quantity_issued: null,
-    unit_of_issue: 'KT',
-    priority: '03' as RequisitionPriority,
-    status: 'SUBMITTED',
-    justification: 'EMERGENCY: IFAKs expired, need replacement before deployment',
-    denial_reason: null,
-    document_number: 'W81K4026R0003',
-    created_at: isoStr(3),
-    updated_at: isoStr(2),
-    submitted_at: isoStr(2),
-    approved_at: null,
-    shipped_at: null,
-    received_at: null,
-    estimated_delivery_date: null,
-    actual_delivery_date: null,
-    approvals: [],
-    status_history: [
-      { id: 4, old_status: null, new_status: 'DRAFT', changed_by_id: 15, changed_by_name: 'Sgt Williams', changed_at: isoStr(3), notes: 'Requisition created' },
-      { id: 5, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 15, changed_by_name: 'Sgt Williams', changed_at: isoStr(2), notes: 'Submitted - EMERGENCY priority' },
-    ],
-  },
-  {
-    id: 4,
-    requisition_number: 'REQ-2026-0004',
-    unit_id: 4,
-    requested_by_id: 10,
-    requested_by_name: 'SSgt Martinez',
-    approved_by_id: 5,
-    supply_catalog_item_id: 3,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '8405-01-547-2558',
-    dodic: null,
-    nomenclature: 'GLOVES, COLD WEATHER, INTERMEDIATE',
-    quantity_requested: 60,
-    quantity_approved: 60,
-    quantity_issued: null,
-    unit_of_issue: 'PR',
-    priority: '06' as RequisitionPriority,
-    status: 'APPROVED',
-    justification: 'Mountain Warfare Training Center cold weather package',
-    denial_reason: null,
-    document_number: 'W81K4026R0004',
-    created_at: isoStr(10),
-    updated_at: isoStr(7),
-    submitted_at: isoStr(9),
-    approved_at: isoStr(7),
-    shipped_at: null,
-    received_at: null,
-    estimated_delivery_date: dateStr(-5),
-    actual_delivery_date: null,
-    approvals: [
-      { id: 1, approver_id: 5, approver_name: 'Capt Davis', action: 'APPROVE', comments: 'Approved per MWTC packing list', action_date: isoStr(7) },
-    ],
-    status_history: [
-      { id: 6, old_status: null, new_status: 'DRAFT', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(10), notes: null },
-      { id: 7, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(9), notes: null },
-      { id: 8, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 5, changed_by_name: 'Capt Davis', changed_at: isoStr(7), notes: 'Approved per MWTC packing list' },
-    ],
-  },
-  {
-    id: 5,
-    requisition_number: 'REQ-2026-0005',
-    unit_id: 4,
-    requested_by_id: 12,
-    requested_by_name: 'Cpl Johnson',
-    approved_by_id: 5,
-    supply_catalog_item_id: null,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '9130-00-160-1818',
-    dodic: null,
-    nomenclature: 'FUEL, DIESEL, DF-2',
-    quantity_requested: 500,
-    quantity_approved: 500,
-    quantity_issued: null,
-    unit_of_issue: 'GL',
-    priority: '02' as RequisitionPriority,
-    status: 'SOURCING',
-    justification: 'URGENT: Convoy resupply for Operation Iron Hawk',
-    denial_reason: null,
-    document_number: 'W81K4026R0005',
-    created_at: isoStr(8),
-    updated_at: isoStr(5),
-    submitted_at: isoStr(7),
-    approved_at: isoStr(6),
-    shipped_at: null,
-    received_at: null,
-    estimated_delivery_date: dateStr(-2),
-    actual_delivery_date: null,
-    approvals: [
-      { id: 2, approver_id: 5, approver_name: 'Capt Davis', action: 'APPROVE', comments: 'Approved - coordinate with MLG for bulk delivery', action_date: isoStr(6) },
-    ],
-    status_history: [
-      { id: 9, old_status: null, new_status: 'DRAFT', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(8), notes: null },
-      { id: 10, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(7), notes: null },
-      { id: 11, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 5, changed_by_name: 'Capt Davis', changed_at: isoStr(6), notes: null },
-      { id: 12, old_status: 'APPROVED', new_status: 'SOURCING', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(5), notes: 'Coordinating with 1st MLG' },
-    ],
-  },
-  {
-    id: 6,
-    requisition_number: 'REQ-2026-0006',
-    unit_id: 5,
-    requested_by_id: 18,
-    requested_by_name: 'LCpl Ramirez',
-    approved_by_id: 8,
-    supply_catalog_item_id: null,
-    ammo_catalog_item_id: 1,
-    equipment_catalog_item_id: null,
-    nsn: '1305-01-480-6989',
-    dodic: 'A059',
-    nomenclature: 'CARTRIDGE, 5.56MM, BALL, M855',
-    quantity_requested: 10000,
-    quantity_approved: 8000,
-    quantity_issued: 8000,
-    unit_of_issue: 'RD',
-    priority: '02' as RequisitionPriority,
-    status: 'SHIPPED',
-    justification: 'Range week qualification ammo',
-    denial_reason: null,
-    document_number: 'W81K4026R0006',
-    created_at: isoStr(14),
-    updated_at: isoStr(3),
-    submitted_at: isoStr(13),
-    approved_at: isoStr(11),
-    shipped_at: isoStr(3),
-    received_at: null,
-    estimated_delivery_date: dateStr(-1),
-    actual_delivery_date: null,
-    approvals: [
-      { id: 3, approver_id: 8, approver_name: 'Maj Reynolds', action: 'APPROVE', comments: 'Approved 8000 rounds (reduced from 10000 per ammo allotment)', action_date: isoStr(11) },
-    ],
-    status_history: [
-      { id: 13, old_status: null, new_status: 'DRAFT', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(14), notes: null },
-      { id: 14, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(13), notes: null },
-      { id: 15, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 8, changed_by_name: 'Maj Reynolds', changed_at: isoStr(11), notes: 'Qty reduced to 8000' },
-      { id: 16, old_status: 'APPROVED', new_status: 'SOURCING', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(7), notes: null },
-      { id: 17, old_status: 'SOURCING', new_status: 'SHIPPED', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(3), notes: 'Shipped via LSA convoy' },
-    ],
-  },
-  {
-    id: 7,
-    requisition_number: 'REQ-2026-0007',
-    unit_id: 4,
-    requested_by_id: 10,
-    requested_by_name: 'SSgt Martinez',
-    approved_by_id: 5,
-    supply_catalog_item_id: null,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '6545-01-539-6439',
-    dodic: null,
-    nomenclature: 'COMBAT GAUZE, HEMOSTATIC',
-    quantity_requested: 100,
-    quantity_approved: 100,
-    quantity_issued: 100,
-    unit_of_issue: 'EA',
-    priority: '03' as RequisitionPriority,
-    status: 'RECEIVED',
-    justification: 'EMERGENCY: Restock after live fire exercise casualties treated',
-    denial_reason: null,
-    document_number: 'W81K4026R0007',
-    created_at: isoStr(20),
-    updated_at: isoStr(2),
-    submitted_at: isoStr(19),
-    approved_at: isoStr(18),
-    shipped_at: isoStr(5),
-    received_at: isoStr(2),
-    estimated_delivery_date: dateStr(3),
-    actual_delivery_date: dateStr(2),
-    approvals: [
-      { id: 4, approver_id: 5, approver_name: 'Capt Davis', action: 'APPROVE', comments: 'EMERGENCY approved - expedite', action_date: isoStr(18) },
-    ],
-    status_history: [
-      { id: 18, old_status: null, new_status: 'DRAFT', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(20), notes: null },
-      { id: 19, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(19), notes: null },
-      { id: 20, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 5, changed_by_name: 'Capt Davis', changed_at: isoStr(18), notes: 'EMERGENCY approved' },
-      { id: 21, old_status: 'APPROVED', new_status: 'SOURCING', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(15), notes: null },
-      { id: 22, old_status: 'SOURCING', new_status: 'SHIPPED', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(5), notes: 'Express shipment via Class VIII push' },
-      { id: 23, old_status: 'SHIPPED', new_status: 'RECEIVED', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(2), notes: 'Received at BAS, qty verified' },
-    ],
-  },
-  {
-    id: 8,
-    requisition_number: 'REQ-2026-0008',
-    unit_id: 5,
-    requested_by_id: 15,
-    requested_by_name: 'Sgt Williams',
-    approved_by_id: 8,
-    supply_catalog_item_id: null,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '2540-01-560-4518',
-    dodic: null,
-    nomenclature: 'TIRE, PNEUMATIC, HMMWV',
-    quantity_requested: 8,
-    quantity_approved: null,
-    quantity_issued: null,
-    unit_of_issue: 'EA',
-    priority: '02' as RequisitionPriority,
-    status: 'DENIED',
-    justification: 'Replace worn tires on 4x HMMWV fleet',
-    denial_reason: 'Use DLA direct order per MCSF 4400 policy; not a unit-level requisition',
-    document_number: 'W81K4026R0008',
-    created_at: isoStr(12),
-    updated_at: isoStr(9),
-    submitted_at: isoStr(11),
-    approved_at: null,
-    shipped_at: null,
-    received_at: null,
-    estimated_delivery_date: null,
-    actual_delivery_date: null,
-    approvals: [
-      { id: 5, approver_id: 8, approver_name: 'Maj Reynolds', action: 'DENY', comments: 'Use DLA direct order per MCSF 4400 policy', action_date: isoStr(9) },
-    ],
-    status_history: [
-      { id: 24, old_status: null, new_status: 'DRAFT', changed_by_id: 15, changed_by_name: 'Sgt Williams', changed_at: isoStr(12), notes: null },
-      { id: 25, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 15, changed_by_name: 'Sgt Williams', changed_at: isoStr(11), notes: null },
-      { id: 26, old_status: 'SUBMITTED', new_status: 'DENIED', changed_by_id: 8, changed_by_name: 'Maj Reynolds', changed_at: isoStr(9), notes: 'DLA direct order required' },
-    ],
-  },
-  {
-    id: 9,
-    requisition_number: 'REQ-2026-0009',
-    unit_id: 4,
-    requested_by_id: 12,
-    requested_by_name: 'Cpl Johnson',
-    approved_by_id: null,
-    supply_catalog_item_id: null,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '8340-01-475-8850',
-    dodic: null,
-    nomenclature: 'TENT, COMBAT, 2-MAN (LITEFIGHTER)',
-    quantity_requested: 15,
-    quantity_approved: null,
-    quantity_issued: null,
-    unit_of_issue: 'EA',
-    priority: '06' as RequisitionPriority,
-    status: 'SUBMITTED',
-    justification: 'Replacement shelters for worn inventory prior to deployment',
-    denial_reason: null,
-    document_number: 'W81K4026R0009',
-    created_at: isoStr(2),
-    updated_at: isoStr(1),
-    submitted_at: isoStr(1),
-    approved_at: null,
-    shipped_at: null,
-    received_at: null,
-    estimated_delivery_date: null,
-    actual_delivery_date: null,
-    approvals: [],
-    status_history: [
-      { id: 27, old_status: null, new_status: 'DRAFT', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(2), notes: null },
-      { id: 28, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(1), notes: null },
-    ],
-  },
-  {
-    id: 10,
-    requisition_number: 'REQ-2026-0010',
-    unit_id: 5,
-    requested_by_id: 18,
-    requested_by_name: 'LCpl Ramirez',
-    approved_by_id: 8,
-    supply_catalog_item_id: null,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '7530-01-454-7220',
-    dodic: null,
-    nomenclature: 'MAP CASE, WATERPROOF',
-    quantity_requested: 20,
-    quantity_approved: 20,
-    quantity_issued: 20,
-    unit_of_issue: 'EA',
-    priority: '06' as RequisitionPriority,
-    status: 'RECEIVED',
-    justification: 'Standard issue for platoon leadership',
-    denial_reason: null,
-    document_number: 'W81K4026R0010',
-    created_at: isoStr(30),
-    updated_at: isoStr(10),
-    submitted_at: isoStr(28),
-    approved_at: isoStr(25),
-    shipped_at: isoStr(15),
-    received_at: isoStr(10),
-    estimated_delivery_date: dateStr(12),
-    actual_delivery_date: dateStr(10),
-    approvals: [
-      { id: 6, approver_id: 8, approver_name: 'Maj Reynolds', action: 'APPROVE', comments: null, action_date: isoStr(25) },
-    ],
-    status_history: [
-      { id: 29, old_status: null, new_status: 'DRAFT', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(30), notes: null },
-      { id: 30, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(28), notes: null },
-      { id: 31, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 8, changed_by_name: 'Maj Reynolds', changed_at: isoStr(25), notes: null },
-      { id: 32, old_status: 'APPROVED', new_status: 'SOURCING', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(20), notes: null },
-      { id: 33, old_status: 'SOURCING', new_status: 'SHIPPED', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(15), notes: null },
-      { id: 34, old_status: 'SHIPPED', new_status: 'RECEIVED', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(10), notes: 'All 20 received, condition serviceable' },
-    ],
-  },
-  {
-    id: 11,
-    requisition_number: 'REQ-2026-0011',
-    unit_id: 4,
-    requested_by_id: 10,
-    requested_by_name: 'SSgt Martinez',
-    approved_by_id: null,
-    supply_catalog_item_id: null,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '8465-01-604-6541',
-    dodic: null,
-    nomenclature: 'PACK, FILBE MAIN (ILBE REPLACEMENT)',
-    quantity_requested: 25,
-    quantity_approved: null,
-    quantity_issued: null,
-    unit_of_issue: 'EA',
-    priority: '06' as RequisitionPriority,
-    status: 'CANCELED',
-    justification: 'Replace damaged packs from last deployment',
-    denial_reason: null,
-    document_number: 'W81K4026R0011',
-    created_at: isoStr(15),
-    updated_at: isoStr(13),
-    submitted_at: null,
-    approved_at: null,
-    shipped_at: null,
-    received_at: null,
-    estimated_delivery_date: null,
-    actual_delivery_date: null,
-    approvals: [],
-    status_history: [
-      { id: 35, old_status: null, new_status: 'DRAFT', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(15), notes: null },
-      { id: 36, old_status: 'DRAFT', new_status: 'CANCELED', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(13), notes: 'Duplicate requisition — consolidated with REQ-2026-0015' },
-    ],
-  },
-  {
-    id: 12,
-    requisition_number: 'REQ-2026-0012',
-    unit_id: 5,
-    requested_by_id: 15,
-    requested_by_name: 'Sgt Williams',
-    approved_by_id: 8,
-    supply_catalog_item_id: null,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '6850-00-281-1985',
-    dodic: null,
-    nomenclature: 'WATER PURIFICATION TABLETS',
-    quantity_requested: 200,
-    quantity_approved: 200,
-    quantity_issued: null,
-    unit_of_issue: 'BX',
-    priority: '02' as RequisitionPriority,
-    status: 'BACKORDERED',
-    justification: 'URGENT: Water purification for field op, no potable water source',
-    denial_reason: null,
-    document_number: 'W81K4026R0012',
-    created_at: isoStr(9),
-    updated_at: isoStr(4),
-    submitted_at: isoStr(8),
-    approved_at: isoStr(7),
-    shipped_at: null,
-    received_at: null,
-    estimated_delivery_date: dateStr(-7),
-    actual_delivery_date: null,
-    approvals: [
-      { id: 7, approver_id: 8, approver_name: 'Maj Reynolds', action: 'APPROVE', comments: 'Approved, coordinate with BnAid for push package', action_date: isoStr(7) },
-    ],
-    status_history: [
-      { id: 37, old_status: null, new_status: 'DRAFT', changed_by_id: 15, changed_by_name: 'Sgt Williams', changed_at: isoStr(9), notes: null },
-      { id: 38, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 15, changed_by_name: 'Sgt Williams', changed_at: isoStr(8), notes: null },
-      { id: 39, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 8, changed_by_name: 'Maj Reynolds', changed_at: isoStr(7), notes: null },
-      { id: 40, old_status: 'APPROVED', new_status: 'SOURCING', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(6), notes: null },
-      { id: 41, old_status: 'SOURCING', new_status: 'BACKORDERED', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(4), notes: 'Supply depot out of stock, ETA 7 days' },
-    ],
-  },
-  {
-    id: 13,
-    requisition_number: 'REQ-2026-0013',
-    unit_id: 4,
-    requested_by_id: 10,
-    requested_by_name: 'SSgt Martinez',
-    approved_by_id: null,
-    supply_catalog_item_id: null,
-    ammo_catalog_item_id: 2,
-    equipment_catalog_item_id: null,
-    nsn: '1315-01-482-4963',
-    dodic: 'B519',
-    nomenclature: 'GRENADE, HAND, SMOKE, GREEN (M18)',
-    quantity_requested: 40,
-    quantity_approved: null,
-    quantity_issued: null,
-    unit_of_issue: 'EA',
-    priority: '06' as RequisitionPriority,
-    status: 'SUBMITTED',
-    justification: 'Training grenades for squad leader course',
-    denial_reason: null,
-    document_number: 'W81K4026R0013',
-    created_at: isoStr(3),
-    updated_at: isoStr(2),
-    submitted_at: isoStr(2),
-    approved_at: null,
-    shipped_at: null,
-    received_at: null,
-    estimated_delivery_date: null,
-    actual_delivery_date: null,
-    approvals: [],
-    status_history: [
-      { id: 42, old_status: null, new_status: 'DRAFT', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(3), notes: null },
-      { id: 43, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(2), notes: null },
-    ],
-  },
-  {
-    id: 14,
-    requisition_number: 'REQ-2026-0014',
-    unit_id: 5,
-    requested_by_id: 18,
-    requested_by_name: 'LCpl Ramirez',
-    approved_by_id: 8,
-    supply_catalog_item_id: null,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '4240-01-516-4559',
-    dodic: null,
-    nomenclature: 'BALLISTIC EYEWEAR, ESS',
-    quantity_requested: 45,
-    quantity_approved: 45,
-    quantity_issued: 45,
-    unit_of_issue: 'EA',
-    priority: '06' as RequisitionPriority,
-    status: 'RECEIVED',
-    justification: 'PPE issue for new joins',
-    denial_reason: null,
-    document_number: 'W81K4026R0014',
-    created_at: isoStr(25),
-    updated_at: isoStr(8),
-    submitted_at: isoStr(24),
-    approved_at: isoStr(22),
-    shipped_at: isoStr(12),
-    received_at: isoStr(8),
-    estimated_delivery_date: dateStr(10),
-    actual_delivery_date: dateStr(8),
-    approvals: [
-      { id: 8, approver_id: 8, approver_name: 'Maj Reynolds', action: 'APPROVE', comments: null, action_date: isoStr(22) },
-    ],
-    status_history: [
-      { id: 44, old_status: null, new_status: 'DRAFT', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(25), notes: null },
-      { id: 45, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(24), notes: null },
-      { id: 46, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 8, changed_by_name: 'Maj Reynolds', changed_at: isoStr(22), notes: null },
-      { id: 47, old_status: 'APPROVED', new_status: 'SOURCING', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(18), notes: null },
-      { id: 48, old_status: 'SOURCING', new_status: 'SHIPPED', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(12), notes: null },
-      { id: 49, old_status: 'SHIPPED', new_status: 'RECEIVED', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(8), notes: 'All 45 pair received' },
-    ],
-  },
-  {
-    id: 15,
-    requisition_number: 'REQ-2026-0015',
-    unit_id: 4,
-    requested_by_id: 12,
-    requested_by_name: 'Cpl Johnson',
-    approved_by_id: null,
-    supply_catalog_item_id: null,
-    ammo_catalog_item_id: null,
-    equipment_catalog_item_id: null,
-    nsn: '8465-01-604-6541',
-    dodic: null,
-    nomenclature: 'PACK, FILBE MAIN (ILBE REPLACEMENT)',
-    quantity_requested: 40,
-    quantity_approved: null,
-    quantity_issued: null,
-    unit_of_issue: 'EA',
-    priority: '02' as RequisitionPriority,
-    status: 'SUBMITTED',
-    justification: 'URGENT: Consolidated replacement request for damaged packs across Bn',
-    denial_reason: null,
-    document_number: 'W81K4026R0015',
-    created_at: isoStr(4),
-    updated_at: isoStr(3),
-    submitted_at: isoStr(3),
-    approved_at: null,
-    shipped_at: null,
-    received_at: null,
-    estimated_delivery_date: null,
-    actual_delivery_date: null,
-    approvals: [],
-    status_history: [
-      { id: 50, old_status: null, new_status: 'DRAFT', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(4), notes: null },
-      { id: 51, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(3), notes: 'Consolidated from REQ-2026-0011' },
-    ],
-  },
-];
+const STORAGE_KEY = 'KEYSTONE_REQUISITIONS';
+
+function buildInitialRequisitions(): Requisition[] {
+  return [
+    {
+      id: 1,
+      requisition_number: 'REQ-2026-0001',
+      unit_id: 4,
+      requested_by_id: 10,
+      requested_by_name: 'SSgt Martinez',
+      approved_by_id: null,
+      supply_catalog_item_id: 1,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '8970-00-149-1094',
+      dodic: null,
+      nomenclature: 'MEAL, READY-TO-EAT (MRE), CASE',
+      quantity_requested: 120,
+      quantity_approved: null,
+      quantity_issued: null,
+      unit_of_issue: 'CS',
+      priority: '06' as RequisitionPriority,
+      status: 'DRAFT',
+      justification: 'Resupply for upcoming field exercise, 3-day FEX support',
+      denial_reason: null,
+      document_number: null,
+      created_at: isoStr(1),
+      updated_at: isoStr(1),
+      submitted_at: null,
+      approved_at: null,
+      shipped_at: null,
+      received_at: null,
+      estimated_delivery_date: null,
+      actual_delivery_date: null,
+      approvals: [],
+      status_history: [
+        { id: 1, old_status: null, new_status: 'DRAFT', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(1), notes: 'Requisition created' },
+      ],
+    },
+    {
+      id: 2,
+      requisition_number: 'REQ-2026-0002',
+      unit_id: 4,
+      requested_by_id: 12,
+      requested_by_name: 'Cpl Johnson',
+      approved_by_id: null,
+      supply_catalog_item_id: 2,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '9150-01-197-7688',
+      dodic: null,
+      nomenclature: 'LUBRICANT, WEAPONS (CLP)',
+      quantity_requested: 48,
+      quantity_approved: null,
+      quantity_issued: null,
+      unit_of_issue: 'BT',
+      priority: '06' as RequisitionPriority,
+      status: 'SUBMITTED',
+      justification: 'Weapons maintenance prior to range week',
+      denial_reason: null,
+      document_number: 'W81K4026R0002',
+      created_at: isoStr(5),
+      updated_at: isoStr(4),
+      submitted_at: isoStr(4),
+      approved_at: null,
+      shipped_at: null,
+      received_at: null,
+      estimated_delivery_date: null,
+      actual_delivery_date: null,
+      approvals: [],
+      status_history: [
+        { id: 2, old_status: null, new_status: 'DRAFT', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(5), notes: 'Requisition created' },
+        { id: 3, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(4), notes: 'Submitted for approval' },
+      ],
+    },
+    {
+      id: 3,
+      requisition_number: 'REQ-2026-0003',
+      unit_id: 5,
+      requested_by_id: 15,
+      requested_by_name: 'Sgt Williams',
+      approved_by_id: null,
+      supply_catalog_item_id: null,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '6515-01-532-8056',
+      dodic: null,
+      nomenclature: 'FIRST AID KIT, INDIVIDUAL (IFAK)',
+      quantity_requested: 30,
+      quantity_approved: null,
+      quantity_issued: null,
+      unit_of_issue: 'KT',
+      priority: '03' as RequisitionPriority,
+      status: 'SUBMITTED',
+      justification: 'EMERGENCY: IFAKs expired, need replacement before deployment',
+      denial_reason: null,
+      document_number: 'W81K4026R0003',
+      created_at: isoStr(3),
+      updated_at: isoStr(2),
+      submitted_at: isoStr(2),
+      approved_at: null,
+      shipped_at: null,
+      received_at: null,
+      estimated_delivery_date: null,
+      actual_delivery_date: null,
+      approvals: [],
+      status_history: [
+        { id: 4, old_status: null, new_status: 'DRAFT', changed_by_id: 15, changed_by_name: 'Sgt Williams', changed_at: isoStr(3), notes: 'Requisition created' },
+        { id: 5, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 15, changed_by_name: 'Sgt Williams', changed_at: isoStr(2), notes: 'Submitted - EMERGENCY priority' },
+      ],
+    },
+    {
+      id: 4,
+      requisition_number: 'REQ-2026-0004',
+      unit_id: 4,
+      requested_by_id: 10,
+      requested_by_name: 'SSgt Martinez',
+      approved_by_id: 5,
+      supply_catalog_item_id: 3,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '8405-01-547-2558',
+      dodic: null,
+      nomenclature: 'GLOVES, COLD WEATHER, INTERMEDIATE',
+      quantity_requested: 60,
+      quantity_approved: 60,
+      quantity_issued: null,
+      unit_of_issue: 'PR',
+      priority: '06' as RequisitionPriority,
+      status: 'APPROVED',
+      justification: 'Mountain Warfare Training Center cold weather package',
+      denial_reason: null,
+      document_number: 'W81K4026R0004',
+      created_at: isoStr(10),
+      updated_at: isoStr(7),
+      submitted_at: isoStr(9),
+      approved_at: isoStr(7),
+      shipped_at: null,
+      received_at: null,
+      estimated_delivery_date: dateStr(-5),
+      actual_delivery_date: null,
+      approvals: [
+        { id: 1, approver_id: 5, approver_name: 'Capt Davis', action: 'APPROVE', comments: 'Approved per MWTC packing list', action_date: isoStr(7) },
+      ],
+      status_history: [
+        { id: 6, old_status: null, new_status: 'DRAFT', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(10), notes: null },
+        { id: 7, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(9), notes: null },
+        { id: 8, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 5, changed_by_name: 'Capt Davis', changed_at: isoStr(7), notes: 'Approved per MWTC packing list' },
+      ],
+    },
+    {
+      id: 5,
+      requisition_number: 'REQ-2026-0005',
+      unit_id: 4,
+      requested_by_id: 12,
+      requested_by_name: 'Cpl Johnson',
+      approved_by_id: 5,
+      supply_catalog_item_id: null,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '9130-00-160-1818',
+      dodic: null,
+      nomenclature: 'FUEL, DIESEL, DF-2',
+      quantity_requested: 500,
+      quantity_approved: 500,
+      quantity_issued: null,
+      unit_of_issue: 'GL',
+      priority: '02' as RequisitionPriority,
+      status: 'SOURCING',
+      justification: 'URGENT: Convoy resupply for Operation Iron Hawk',
+      denial_reason: null,
+      document_number: 'W81K4026R0005',
+      created_at: isoStr(8),
+      updated_at: isoStr(5),
+      submitted_at: isoStr(7),
+      approved_at: isoStr(6),
+      shipped_at: null,
+      received_at: null,
+      estimated_delivery_date: dateStr(-2),
+      actual_delivery_date: null,
+      approvals: [
+        { id: 2, approver_id: 5, approver_name: 'Capt Davis', action: 'APPROVE', comments: 'Approved - coordinate with MLG for bulk delivery', action_date: isoStr(6) },
+      ],
+      status_history: [
+        { id: 9, old_status: null, new_status: 'DRAFT', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(8), notes: null },
+        { id: 10, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(7), notes: null },
+        { id: 11, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 5, changed_by_name: 'Capt Davis', changed_at: isoStr(6), notes: null },
+        { id: 12, old_status: 'APPROVED', new_status: 'SOURCING', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(5), notes: 'Coordinating with 1st MLG' },
+      ],
+    },
+    {
+      id: 6,
+      requisition_number: 'REQ-2026-0006',
+      unit_id: 5,
+      requested_by_id: 18,
+      requested_by_name: 'LCpl Ramirez',
+      approved_by_id: 8,
+      supply_catalog_item_id: null,
+      ammo_catalog_item_id: 1,
+      equipment_catalog_item_id: null,
+      nsn: '1305-01-480-6989',
+      dodic: 'A059',
+      nomenclature: 'CARTRIDGE, 5.56MM, BALL, M855',
+      quantity_requested: 10000,
+      quantity_approved: 8000,
+      quantity_issued: 8000,
+      unit_of_issue: 'RD',
+      priority: '02' as RequisitionPriority,
+      status: 'SHIPPED',
+      justification: 'Range week qualification ammo',
+      denial_reason: null,
+      document_number: 'W81K4026R0006',
+      created_at: isoStr(14),
+      updated_at: isoStr(3),
+      submitted_at: isoStr(13),
+      approved_at: isoStr(11),
+      shipped_at: isoStr(3),
+      received_at: null,
+      estimated_delivery_date: dateStr(-1),
+      actual_delivery_date: null,
+      approvals: [
+        { id: 3, approver_id: 8, approver_name: 'Maj Reynolds', action: 'APPROVE', comments: 'Approved 8000 rounds (reduced from 10000 per ammo allotment)', action_date: isoStr(11) },
+      ],
+      status_history: [
+        { id: 13, old_status: null, new_status: 'DRAFT', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(14), notes: null },
+        { id: 14, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(13), notes: null },
+        { id: 15, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 8, changed_by_name: 'Maj Reynolds', changed_at: isoStr(11), notes: 'Qty reduced to 8000' },
+        { id: 16, old_status: 'APPROVED', new_status: 'SOURCING', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(7), notes: null },
+        { id: 17, old_status: 'SOURCING', new_status: 'SHIPPED', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(3), notes: 'Shipped via LSA convoy' },
+      ],
+    },
+    {
+      id: 7,
+      requisition_number: 'REQ-2026-0007',
+      unit_id: 4,
+      requested_by_id: 10,
+      requested_by_name: 'SSgt Martinez',
+      approved_by_id: 5,
+      supply_catalog_item_id: null,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '6545-01-539-6439',
+      dodic: null,
+      nomenclature: 'COMBAT GAUZE, HEMOSTATIC',
+      quantity_requested: 100,
+      quantity_approved: 100,
+      quantity_issued: 100,
+      unit_of_issue: 'EA',
+      priority: '03' as RequisitionPriority,
+      status: 'RECEIVED',
+      justification: 'EMERGENCY: Restock after live fire exercise casualties treated',
+      denial_reason: null,
+      document_number: 'W81K4026R0007',
+      created_at: isoStr(20),
+      updated_at: isoStr(2),
+      submitted_at: isoStr(19),
+      approved_at: isoStr(18),
+      shipped_at: isoStr(5),
+      received_at: isoStr(2),
+      estimated_delivery_date: dateStr(3),
+      actual_delivery_date: dateStr(2),
+      approvals: [
+        { id: 4, approver_id: 5, approver_name: 'Capt Davis', action: 'APPROVE', comments: 'EMERGENCY approved - expedite', action_date: isoStr(18) },
+      ],
+      status_history: [
+        { id: 18, old_status: null, new_status: 'DRAFT', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(20), notes: null },
+        { id: 19, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(19), notes: null },
+        { id: 20, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 5, changed_by_name: 'Capt Davis', changed_at: isoStr(18), notes: 'EMERGENCY approved' },
+        { id: 21, old_status: 'APPROVED', new_status: 'SOURCING', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(15), notes: null },
+        { id: 22, old_status: 'SOURCING', new_status: 'SHIPPED', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(5), notes: 'Express shipment via Class VIII push' },
+        { id: 23, old_status: 'SHIPPED', new_status: 'RECEIVED', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(2), notes: 'Received at BAS, qty verified' },
+      ],
+    },
+    {
+      id: 8,
+      requisition_number: 'REQ-2026-0008',
+      unit_id: 5,
+      requested_by_id: 15,
+      requested_by_name: 'Sgt Williams',
+      approved_by_id: 8,
+      supply_catalog_item_id: null,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '2540-01-560-4518',
+      dodic: null,
+      nomenclature: 'TIRE, PNEUMATIC, HMMWV',
+      quantity_requested: 8,
+      quantity_approved: null,
+      quantity_issued: null,
+      unit_of_issue: 'EA',
+      priority: '02' as RequisitionPriority,
+      status: 'DENIED',
+      justification: 'Replace worn tires on 4x HMMWV fleet',
+      denial_reason: 'Use DLA direct order per MCSF 4400 policy; not a unit-level requisition',
+      document_number: 'W81K4026R0008',
+      created_at: isoStr(12),
+      updated_at: isoStr(9),
+      submitted_at: isoStr(11),
+      approved_at: null,
+      shipped_at: null,
+      received_at: null,
+      estimated_delivery_date: null,
+      actual_delivery_date: null,
+      approvals: [
+        { id: 5, approver_id: 8, approver_name: 'Maj Reynolds', action: 'DENY', comments: 'Use DLA direct order per MCSF 4400 policy', action_date: isoStr(9) },
+      ],
+      status_history: [
+        { id: 24, old_status: null, new_status: 'DRAFT', changed_by_id: 15, changed_by_name: 'Sgt Williams', changed_at: isoStr(12), notes: null },
+        { id: 25, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 15, changed_by_name: 'Sgt Williams', changed_at: isoStr(11), notes: null },
+        { id: 26, old_status: 'SUBMITTED', new_status: 'DENIED', changed_by_id: 8, changed_by_name: 'Maj Reynolds', changed_at: isoStr(9), notes: 'DLA direct order required' },
+      ],
+    },
+    {
+      id: 9,
+      requisition_number: 'REQ-2026-0009',
+      unit_id: 4,
+      requested_by_id: 12,
+      requested_by_name: 'Cpl Johnson',
+      approved_by_id: null,
+      supply_catalog_item_id: null,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '8340-01-475-8850',
+      dodic: null,
+      nomenclature: 'TENT, COMBAT, 2-MAN (LITEFIGHTER)',
+      quantity_requested: 15,
+      quantity_approved: null,
+      quantity_issued: null,
+      unit_of_issue: 'EA',
+      priority: '06' as RequisitionPriority,
+      status: 'SUBMITTED',
+      justification: 'Replacement shelters for worn inventory prior to deployment',
+      denial_reason: null,
+      document_number: 'W81K4026R0009',
+      created_at: isoStr(2),
+      updated_at: isoStr(1),
+      submitted_at: isoStr(1),
+      approved_at: null,
+      shipped_at: null,
+      received_at: null,
+      estimated_delivery_date: null,
+      actual_delivery_date: null,
+      approvals: [],
+      status_history: [
+        { id: 27, old_status: null, new_status: 'DRAFT', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(2), notes: null },
+        { id: 28, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(1), notes: null },
+      ],
+    },
+    {
+      id: 10,
+      requisition_number: 'REQ-2026-0010',
+      unit_id: 5,
+      requested_by_id: 18,
+      requested_by_name: 'LCpl Ramirez',
+      approved_by_id: 8,
+      supply_catalog_item_id: null,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '7530-01-454-7220',
+      dodic: null,
+      nomenclature: 'MAP CASE, WATERPROOF',
+      quantity_requested: 20,
+      quantity_approved: 20,
+      quantity_issued: 20,
+      unit_of_issue: 'EA',
+      priority: '06' as RequisitionPriority,
+      status: 'RECEIVED',
+      justification: 'Standard issue for platoon leadership',
+      denial_reason: null,
+      document_number: 'W81K4026R0010',
+      created_at: isoStr(30),
+      updated_at: isoStr(10),
+      submitted_at: isoStr(28),
+      approved_at: isoStr(25),
+      shipped_at: isoStr(15),
+      received_at: isoStr(10),
+      estimated_delivery_date: dateStr(12),
+      actual_delivery_date: dateStr(10),
+      approvals: [
+        { id: 6, approver_id: 8, approver_name: 'Maj Reynolds', action: 'APPROVE', comments: null, action_date: isoStr(25) },
+      ],
+      status_history: [
+        { id: 29, old_status: null, new_status: 'DRAFT', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(30), notes: null },
+        { id: 30, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(28), notes: null },
+        { id: 31, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 8, changed_by_name: 'Maj Reynolds', changed_at: isoStr(25), notes: null },
+        { id: 32, old_status: 'APPROVED', new_status: 'SOURCING', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(20), notes: null },
+        { id: 33, old_status: 'SOURCING', new_status: 'SHIPPED', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(15), notes: null },
+        { id: 34, old_status: 'SHIPPED', new_status: 'RECEIVED', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(10), notes: 'All 20 received, condition serviceable' },
+      ],
+    },
+    {
+      id: 11,
+      requisition_number: 'REQ-2026-0011',
+      unit_id: 4,
+      requested_by_id: 10,
+      requested_by_name: 'SSgt Martinez',
+      approved_by_id: null,
+      supply_catalog_item_id: null,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '8465-01-604-6541',
+      dodic: null,
+      nomenclature: 'PACK, FILBE MAIN (ILBE REPLACEMENT)',
+      quantity_requested: 25,
+      quantity_approved: null,
+      quantity_issued: null,
+      unit_of_issue: 'EA',
+      priority: '06' as RequisitionPriority,
+      status: 'CANCELED',
+      justification: 'Replace damaged packs from last deployment',
+      denial_reason: null,
+      document_number: 'W81K4026R0011',
+      created_at: isoStr(15),
+      updated_at: isoStr(13),
+      submitted_at: null,
+      approved_at: null,
+      shipped_at: null,
+      received_at: null,
+      estimated_delivery_date: null,
+      actual_delivery_date: null,
+      approvals: [],
+      status_history: [
+        { id: 35, old_status: null, new_status: 'DRAFT', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(15), notes: null },
+        { id: 36, old_status: 'DRAFT', new_status: 'CANCELED', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(13), notes: 'Duplicate requisition — consolidated with REQ-2026-0015' },
+      ],
+    },
+    {
+      id: 12,
+      requisition_number: 'REQ-2026-0012',
+      unit_id: 5,
+      requested_by_id: 15,
+      requested_by_name: 'Sgt Williams',
+      approved_by_id: 8,
+      supply_catalog_item_id: null,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '6850-00-281-1985',
+      dodic: null,
+      nomenclature: 'WATER PURIFICATION TABLETS',
+      quantity_requested: 200,
+      quantity_approved: 200,
+      quantity_issued: null,
+      unit_of_issue: 'BX',
+      priority: '02' as RequisitionPriority,
+      status: 'BACKORDERED',
+      justification: 'URGENT: Water purification for field op, no potable water source',
+      denial_reason: null,
+      document_number: 'W81K4026R0012',
+      created_at: isoStr(9),
+      updated_at: isoStr(4),
+      submitted_at: isoStr(8),
+      approved_at: isoStr(7),
+      shipped_at: null,
+      received_at: null,
+      estimated_delivery_date: dateStr(-7),
+      actual_delivery_date: null,
+      approvals: [
+        { id: 7, approver_id: 8, approver_name: 'Maj Reynolds', action: 'APPROVE', comments: 'Approved, coordinate with BnAid for push package', action_date: isoStr(7) },
+      ],
+      status_history: [
+        { id: 37, old_status: null, new_status: 'DRAFT', changed_by_id: 15, changed_by_name: 'Sgt Williams', changed_at: isoStr(9), notes: null },
+        { id: 38, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 15, changed_by_name: 'Sgt Williams', changed_at: isoStr(8), notes: null },
+        { id: 39, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 8, changed_by_name: 'Maj Reynolds', changed_at: isoStr(7), notes: null },
+        { id: 40, old_status: 'APPROVED', new_status: 'SOURCING', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(6), notes: null },
+        { id: 41, old_status: 'SOURCING', new_status: 'BACKORDERED', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(4), notes: 'Supply depot out of stock, ETA 7 days' },
+      ],
+    },
+    {
+      id: 13,
+      requisition_number: 'REQ-2026-0013',
+      unit_id: 4,
+      requested_by_id: 10,
+      requested_by_name: 'SSgt Martinez',
+      approved_by_id: null,
+      supply_catalog_item_id: null,
+      ammo_catalog_item_id: 2,
+      equipment_catalog_item_id: null,
+      nsn: '1315-01-482-4963',
+      dodic: 'B519',
+      nomenclature: 'GRENADE, HAND, SMOKE, GREEN (M18)',
+      quantity_requested: 40,
+      quantity_approved: null,
+      quantity_issued: null,
+      unit_of_issue: 'EA',
+      priority: '06' as RequisitionPriority,
+      status: 'SUBMITTED',
+      justification: 'Training grenades for squad leader course',
+      denial_reason: null,
+      document_number: 'W81K4026R0013',
+      created_at: isoStr(3),
+      updated_at: isoStr(2),
+      submitted_at: isoStr(2),
+      approved_at: null,
+      shipped_at: null,
+      received_at: null,
+      estimated_delivery_date: null,
+      actual_delivery_date: null,
+      approvals: [],
+      status_history: [
+        { id: 42, old_status: null, new_status: 'DRAFT', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(3), notes: null },
+        { id: 43, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 10, changed_by_name: 'SSgt Martinez', changed_at: isoStr(2), notes: null },
+      ],
+    },
+    {
+      id: 14,
+      requisition_number: 'REQ-2026-0014',
+      unit_id: 5,
+      requested_by_id: 18,
+      requested_by_name: 'LCpl Ramirez',
+      approved_by_id: 8,
+      supply_catalog_item_id: null,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '4240-01-516-4559',
+      dodic: null,
+      nomenclature: 'BALLISTIC EYEWEAR, ESS',
+      quantity_requested: 45,
+      quantity_approved: 45,
+      quantity_issued: 45,
+      unit_of_issue: 'EA',
+      priority: '06' as RequisitionPriority,
+      status: 'RECEIVED',
+      justification: 'PPE issue for new joins',
+      denial_reason: null,
+      document_number: 'W81K4026R0014',
+      created_at: isoStr(25),
+      updated_at: isoStr(8),
+      submitted_at: isoStr(24),
+      approved_at: isoStr(22),
+      shipped_at: isoStr(12),
+      received_at: isoStr(8),
+      estimated_delivery_date: dateStr(10),
+      actual_delivery_date: dateStr(8),
+      approvals: [
+        { id: 8, approver_id: 8, approver_name: 'Maj Reynolds', action: 'APPROVE', comments: null, action_date: isoStr(22) },
+      ],
+      status_history: [
+        { id: 44, old_status: null, new_status: 'DRAFT', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(25), notes: null },
+        { id: 45, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(24), notes: null },
+        { id: 46, old_status: 'SUBMITTED', new_status: 'APPROVED', changed_by_id: 8, changed_by_name: 'Maj Reynolds', changed_at: isoStr(22), notes: null },
+        { id: 47, old_status: 'APPROVED', new_status: 'SOURCING', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(18), notes: null },
+        { id: 48, old_status: 'SOURCING', new_status: 'SHIPPED', changed_by_id: 3, changed_by_name: 'GySgt Thompson', changed_at: isoStr(12), notes: null },
+        { id: 49, old_status: 'SHIPPED', new_status: 'RECEIVED', changed_by_id: 18, changed_by_name: 'LCpl Ramirez', changed_at: isoStr(8), notes: 'All 45 pair received' },
+      ],
+    },
+    {
+      id: 15,
+      requisition_number: 'REQ-2026-0015',
+      unit_id: 4,
+      requested_by_id: 12,
+      requested_by_name: 'Cpl Johnson',
+      approved_by_id: null,
+      supply_catalog_item_id: null,
+      ammo_catalog_item_id: null,
+      equipment_catalog_item_id: null,
+      nsn: '8465-01-604-6541',
+      dodic: null,
+      nomenclature: 'PACK, FILBE MAIN (ILBE REPLACEMENT)',
+      quantity_requested: 40,
+      quantity_approved: null,
+      quantity_issued: null,
+      unit_of_issue: 'EA',
+      priority: '02' as RequisitionPriority,
+      status: 'SUBMITTED',
+      justification: 'URGENT: Consolidated replacement request for damaged packs across Bn',
+      denial_reason: null,
+      document_number: 'W81K4026R0015',
+      created_at: isoStr(4),
+      updated_at: isoStr(3),
+      submitted_at: isoStr(3),
+      approved_at: null,
+      shipped_at: null,
+      received_at: null,
+      estimated_delivery_date: null,
+      actual_delivery_date: null,
+      approvals: [],
+      status_history: [
+        { id: 50, old_status: null, new_status: 'DRAFT', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(4), notes: null },
+        { id: 51, old_status: 'DRAFT', new_status: 'SUBMITTED', changed_by_id: 12, changed_by_name: 'Cpl Johnson', changed_at: isoStr(3), notes: 'Consolidated from REQ-2026-0011' },
+      ],
+    },
+  ];
+}
+
+function loadRequisitions(): Requisition[] {
+  if (typeof window === 'undefined') return [];
+  const stored = sessionStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    return JSON.parse(stored);
+  }
+  // First load: store initial data
+  const initial = buildInitialRequisitions();
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(initial));
+  return initial;
+}
+
+function saveRequisitions(reqs: Requisition[]): void {
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(reqs));
+}
+
+function getRequisitionsStore(): Requisition[] {
+  return loadRequisitions();
+}
+
+function updateRequisition(id: number, updater: (req: Requisition) => Requisition): Requisition {
+  const all = loadRequisitions();
+  const idx = all.findIndex((r) => r.id === id);
+  if (idx === -1) throw new Error(`Requisition ${id} not found`);
+  all[idx] = updater(all[idx]);
+  saveRequisitions(all);
+  return all[idx];
+}
 
 // ---------------------------------------------------------------------------
 // Mock Inventory Data
@@ -657,7 +690,7 @@ export async function getRequisitions(
 ): Promise<Requisition[]> {
   if (isDemoMode) {
     await mockDelay();
-    let results = [...MOCK_REQUISITIONS];
+    let results = [...getRequisitionsStore()];
     if (filters?.status) {
       results = results.filter((r) => r.status === filters.status);
     }
@@ -678,9 +711,9 @@ export async function getRequisitions(
 export async function getRequisition(id: number): Promise<Requisition> {
   if (isDemoMode) {
     await mockDelay();
-    const req = MOCK_REQUISITIONS.find((r) => r.id === id);
+    const req = getRequisitionsStore().find((r) => r.id === id);
     if (!req) throw new Error(`Requisition ${id} not found`);
-    return req;
+    return { ...req };
   }
   const response = await apiClient.get<{ data: Requisition }>(`/requisitions/${id}`);
   return response.data.data;
@@ -692,9 +725,10 @@ export async function createRequisition(
 ): Promise<Requisition> {
   if (isDemoMode) {
     await mockDelay();
+    const all = loadRequisitions();
     const newReq: Requisition = {
-      id: MOCK_REQUISITIONS.length + 1,
-      requisition_number: `REQ-2026-${String(MOCK_REQUISITIONS.length + 1).padStart(4, '0')}`,
+      id: all.length + 1,
+      requisition_number: `REQ-2026-${String(all.length + 1).padStart(4, '0')}`,
       unit_id: _unitId,
       requested_by_id: 10,
       requested_by_name: 'SSgt Martinez',
@@ -725,7 +759,7 @@ export async function createRequisition(
       approvals: [],
       status_history: [
         {
-          id: 100 + MOCK_REQUISITIONS.length,
+          id: Date.now(),
           old_status: null,
           new_status: 'DRAFT',
           changed_by_id: 10,
@@ -735,8 +769,9 @@ export async function createRequisition(
         },
       ],
     };
-    MOCK_REQUISITIONS.push(newReq);
-    return newReq;
+    all.push(newReq);
+    saveRequisitions(all);
+    return { ...newReq };
   }
   const response = await apiClient.post<{ data: Requisition }>(
     `/units/${_unitId}/requisitions`,
@@ -748,13 +783,25 @@ export async function createRequisition(
 export async function submitRequisition(id: number): Promise<Requisition> {
   if (isDemoMode) {
     await mockDelay();
-    const req = MOCK_REQUISITIONS.find((r) => r.id === id);
-    if (!req) throw new Error(`Requisition ${id} not found`);
-    req.status = 'SUBMITTED';
-    req.submitted_at = new Date().toISOString();
-    req.updated_at = new Date().toISOString();
-    req.document_number = `W81K4026R${String(id).padStart(4, '0')}`;
-    return { ...req };
+    return updateRequisition(id, (req) => ({
+      ...req,
+      status: 'SUBMITTED' as RequisitionStatus,
+      submitted_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      document_number: `W81K4026R${String(id).padStart(4, '0')}`,
+      status_history: [
+        ...(req.status_history ?? []),
+        {
+          id: Date.now(),
+          old_status: req.status,
+          new_status: 'SUBMITTED' as RequisitionStatus,
+          changed_by_id: req.requested_by_id,
+          changed_by_name: req.requested_by_name,
+          changed_at: new Date().toISOString(),
+          notes: 'Submitted for approval',
+        },
+      ],
+    }));
   }
   const response = await apiClient.post<{ data: Requisition }>(
     `/requisitions/${id}/submit`,
@@ -768,14 +815,37 @@ export async function approveRequisition(
 ): Promise<Requisition> {
   if (isDemoMode) {
     await mockDelay();
-    const req = MOCK_REQUISITIONS.find((r) => r.id === id);
-    if (!req) throw new Error(`Requisition ${id} not found`);
-    req.status = 'APPROVED';
-    req.quantity_approved = data.quantity_approved ?? req.quantity_requested;
-    req.approved_at = new Date().toISOString();
-    req.approved_by_id = 5;
-    req.updated_at = new Date().toISOString();
-    return { ...req };
+    return updateRequisition(id, (req) => ({
+      ...req,
+      status: 'APPROVED' as RequisitionStatus,
+      quantity_approved: data.quantity_approved ?? req.quantity_requested,
+      approved_at: new Date().toISOString(),
+      approved_by_id: 5,
+      updated_at: new Date().toISOString(),
+      approvals: [
+        ...(req.approvals ?? []),
+        {
+          id: Date.now(),
+          approver_id: 5,
+          approver_name: 'Capt Davis',
+          action: 'APPROVE' as const,
+          comments: data.comments ?? 'Approved',
+          action_date: new Date().toISOString(),
+        },
+      ],
+      status_history: [
+        ...(req.status_history ?? []),
+        {
+          id: Date.now(),
+          old_status: req.status,
+          new_status: 'APPROVED' as RequisitionStatus,
+          changed_by_id: 5,
+          changed_by_name: 'Capt Davis',
+          changed_at: new Date().toISOString(),
+          notes: data.comments ?? 'Approved',
+        },
+      ],
+    }));
   }
   const response = await apiClient.post<{ data: Requisition }>(
     `/requisitions/${id}/approve`,
@@ -790,17 +860,92 @@ export async function denyRequisition(
 ): Promise<Requisition> {
   if (isDemoMode) {
     await mockDelay();
-    const req = MOCK_REQUISITIONS.find((r) => r.id === id);
-    if (!req) throw new Error(`Requisition ${id} not found`);
-    req.status = 'DENIED';
-    req.denial_reason = data.reason;
-    req.updated_at = new Date().toISOString();
-    return { ...req };
+    return updateRequisition(id, (req) => ({
+      ...req,
+      status: 'DENIED' as RequisitionStatus,
+      denial_reason: data.reason,
+      updated_at: new Date().toISOString(),
+      approvals: [
+        ...(req.approvals ?? []),
+        {
+          id: Date.now(),
+          approver_id: 5,
+          approver_name: 'Capt Davis',
+          action: 'DENY' as const,
+          comments: data.reason,
+          action_date: new Date().toISOString(),
+        },
+      ],
+      status_history: [
+        ...(req.status_history ?? []),
+        {
+          id: Date.now(),
+          old_status: req.status,
+          new_status: 'DENIED' as RequisitionStatus,
+          changed_by_id: 5,
+          changed_by_name: 'Capt Davis',
+          changed_at: new Date().toISOString(),
+          notes: data.reason,
+        },
+      ],
+    }));
   }
   const response = await apiClient.post<{ data: Requisition }>(
     `/requisitions/${id}/deny`,
     data,
   );
+  return response.data.data;
+}
+
+export async function processRequisition(id: number, notes?: string): Promise<Requisition> {
+  if (isDemoMode) {
+    await mockDelay();
+    return updateRequisition(id, (req) => ({
+      ...req,
+      status: 'SOURCING' as RequisitionStatus,
+      updated_at: new Date().toISOString(),
+      status_history: [
+        ...(req.status_history ?? []),
+        {
+          id: Date.now(),
+          old_status: req.status,
+          new_status: 'SOURCING' as RequisitionStatus,
+          changed_by_id: 3,
+          changed_by_name: 'GySgt Thompson',
+          changed_at: new Date().toISOString(),
+          notes: notes ?? 'Processing - sourcing materials',
+        },
+      ],
+    }));
+  }
+  const response = await apiClient.put<{ data: Requisition }>(`/requisitions/${id}/process`);
+  return response.data.data;
+}
+
+export async function shipRequisition(id: number, notes?: string): Promise<Requisition> {
+  if (isDemoMode) {
+    await mockDelay();
+    return updateRequisition(id, (req) => ({
+      ...req,
+      status: 'SHIPPED' as RequisitionStatus,
+      shipped_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      estimated_delivery_date: dateStr(-3),
+      status_history: [
+        ...(req.status_history ?? []),
+        {
+          id: Date.now(),
+          old_status: req.status,
+          new_status: 'SHIPPED' as RequisitionStatus,
+          changed_by_id: 3,
+          changed_by_name: 'GySgt Thompson',
+          changed_at: new Date().toISOString(),
+          notes: notes ?? 'Shipped',
+        },
+      ],
+    }));
+  }
+  const response = await apiClient.put<{ data: Requisition }>(`/requisitions/${id}/ship`);
   return response.data.data;
 }
 
@@ -810,14 +955,26 @@ export async function receiveRequisition(
 ): Promise<Requisition> {
   if (isDemoMode) {
     await mockDelay();
-    const req = MOCK_REQUISITIONS.find((r) => r.id === id);
-    if (!req) throw new Error(`Requisition ${id} not found`);
-    req.status = 'RECEIVED';
-    req.received_at = new Date().toISOString();
-    req.actual_delivery_date = new Date().toISOString().split('T')[0];
-    req.quantity_issued = data.quantity_received ?? req.quantity_approved ?? req.quantity_requested;
-    req.updated_at = new Date().toISOString();
-    return { ...req };
+    return updateRequisition(id, (req) => ({
+      ...req,
+      status: 'RECEIVED' as RequisitionStatus,
+      received_at: new Date().toISOString(),
+      actual_delivery_date: new Date().toISOString().split('T')[0],
+      quantity_issued: data.quantity_received ?? req.quantity_approved ?? req.quantity_requested,
+      updated_at: new Date().toISOString(),
+      status_history: [
+        ...(req.status_history ?? []),
+        {
+          id: Date.now(),
+          old_status: req.status,
+          new_status: 'RECEIVED' as RequisitionStatus,
+          changed_by_id: req.requested_by_id,
+          changed_by_name: req.requested_by_name,
+          changed_at: new Date().toISOString(),
+          notes: data.notes ?? 'Received and verified',
+        },
+      ],
+    }));
   }
   const response = await apiClient.post<{ data: Requisition }>(
     `/requisitions/${id}/receive`,
@@ -832,17 +989,94 @@ export async function cancelRequisition(
 ): Promise<Requisition> {
   if (isDemoMode) {
     await mockDelay();
-    const req = MOCK_REQUISITIONS.find((r) => r.id === id);
-    if (!req) throw new Error(`Requisition ${id} not found`);
-    req.status = 'CANCELED';
-    req.updated_at = new Date().toISOString();
-    if (reason) req.denial_reason = reason;
-    return { ...req };
+    return updateRequisition(id, (req) => ({
+      ...req,
+      status: 'CANCELED' as RequisitionStatus,
+      updated_at: new Date().toISOString(),
+      denial_reason: reason ?? req.denial_reason,
+      status_history: [
+        ...(req.status_history ?? []),
+        {
+          id: Date.now(),
+          old_status: req.status,
+          new_status: 'CANCELED' as RequisitionStatus,
+          changed_by_id: req.requested_by_id,
+          changed_by_name: req.requested_by_name,
+          changed_at: new Date().toISOString(),
+          notes: reason ?? 'Canceled',
+        },
+      ],
+    }));
   }
   const response = await apiClient.post<{ data: Requisition }>(
     `/requisitions/${id}/cancel`,
     { reason },
   );
+  return response.data.data;
+}
+
+// ---------------------------------------------------------------------------
+// API Functions — Requisition Analytics
+// ---------------------------------------------------------------------------
+
+export async function getRequisitionAnalytics(): Promise<{
+  summary: { total: number; active: number; fulfilled: number; denied: number; canceled: number; approvalRate: number };
+  byStatus: Record<string, number>;
+  byPriority: Record<string, number>;
+  bySupplyClass: Array<{ supplyClass: string; count: number; fulfilled: number }>;
+  avgFulfillmentDays: number;
+  recentTrend: Array<{ date: string; submitted: number; fulfilled: number }>;
+}> {
+  if (isDemoMode) {
+    await mockDelay();
+    const all = getRequisitionsStore();
+    const byStatus: Record<string, number> = {};
+    const byPriority: Record<string, number> = {};
+    for (const r of all) {
+      byStatus[r.status] = (byStatus[r.status] ?? 0) + 1;
+      byPriority[r.priority] = (byPriority[r.priority] ?? 0) + 1;
+    }
+    const fulfilled = all.filter((r) => r.status === 'RECEIVED').length;
+    const denied = all.filter((r) => r.status === 'DENIED').length;
+    const canceled = all.filter((r) => r.status === 'CANCELED').length;
+    const active = all.filter((r) => !['RECEIVED', 'DENIED', 'CANCELED'].includes(r.status)).length;
+    const total = all.length;
+
+    // Generate trend data for last 30 days
+    const recentTrend = [];
+    for (let i = 29; i >= 0; i--) {
+      const d = new Date();
+      d.setDate(d.getDate() - i);
+      const ds = d.toISOString().split('T')[0];
+      // Seeded values for consistency
+      const seed = (i * 7 + 13) % 5;
+      recentTrend.push({ date: ds, submitted: seed + 1, fulfilled: Math.max(0, seed - 1) });
+    }
+
+    return {
+      summary: {
+        total,
+        active,
+        fulfilled,
+        denied,
+        canceled,
+        approvalRate: total > 0 ? Math.round(((total - denied - canceled) / total) * 100) : 0,
+      },
+      byStatus,
+      byPriority,
+      bySupplyClass: [
+        { supplyClass: 'CL I', count: 3, fulfilled: 1 },
+        { supplyClass: 'CL II', count: 4, fulfilled: 2 },
+        { supplyClass: 'CL III', count: 2, fulfilled: 1 },
+        { supplyClass: 'CL V', count: 3, fulfilled: 1 },
+        { supplyClass: 'CL VIII', count: 2, fulfilled: 2 },
+        { supplyClass: 'CL IX', count: 1, fulfilled: 0 },
+      ],
+      avgFulfillmentDays: 12.3,
+      recentTrend,
+    };
+  }
+  const response = await apiClient.get<{ data: any }>('/requisitions/analytics/summary');
   return response.data.data;
 }
 

--- a/frontend/src/components/requisitions/RequisitionDetail.tsx
+++ b/frontend/src/components/requisitions/RequisitionDetail.tsx
@@ -2,13 +2,15 @@
 // RequisitionDetail — Detail panel for a single requisition
 // =============================================================================
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   Send,
   Check,
   XCircle,
   PackageCheck,
+  Package,
+  Truck,
   Ban,
   Clock,
 } from 'lucide-react';
@@ -17,6 +19,8 @@ import {
   submitRequisition,
   approveRequisition,
   denyRequisition,
+  processRequisition,
+  shipRequisition,
   receiveRequisition,
   cancelRequisition,
 } from '@/api/requisitions';
@@ -81,6 +85,9 @@ export default function RequisitionDetail({ requisition, onRefresh }: Requisitio
     mutationFn: () => denyRequisition(requisition.id, { reason: denyReason }),
     onSuccess: () => { setShowDenyInput(false); invalidateAll(); },
   });
+
+  const processMut = useMutation({ mutationFn: () => processRequisition(requisition.id), onSuccess: invalidateAll });
+  const shipMut = useMutation({ mutationFn: () => shipRequisition(requisition.id), onSuccess: invalidateAll });
   const receiveMut = useMutation({ mutationFn: () => receiveRequisition(requisition.id, {}), onSuccess: invalidateAll });
   const cancelMut = useMutation({ mutationFn: () => cancelRequisition(requisition.id), onSuccess: invalidateAll });
 
@@ -121,6 +128,8 @@ export default function RequisitionDetail({ requisition, onRefresh }: Requisitio
   const canSubmit = requisition.status === 'DRAFT';
   const canApprove = requisition.status === 'SUBMITTED';
   const canDeny = requisition.status === 'SUBMITTED';
+  const canProcess = requisition.status === 'APPROVED';
+  const canShip = requisition.status === 'SOURCING';
   const canReceive = requisition.status === 'SHIPPED';
   const canCancel = ['DRAFT', 'SUBMITTED', 'APPROVED'].includes(requisition.status);
 
@@ -156,6 +165,65 @@ export default function RequisitionDetail({ requisition, onRefresh }: Requisitio
           {requisition.status}
         </span>
       </div>
+
+      {/* Status Stepper */}
+      {requisition.status !== 'DENIED' && requisition.status !== 'CANCELED' ? (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 0, padding: '4px 0' }}>
+          {(['SUBMITTED', 'APPROVED', 'SOURCING', 'SHIPPED', 'RECEIVED'] as const).map((step, idx) => {
+            const STATUS_ORDER: Record<string, number> = {
+              DRAFT: 0, SUBMITTED: 1, APPROVED: 2, SOURCING: 3, BACKORDERED: 3, SHIPPED: 4, RECEIVED: 5, DENIED: -1, CANCELED: -1,
+            };
+            const currentIdx = STATUS_ORDER[requisition.status] ?? 0;
+            const stepIdx = STATUS_ORDER[step];
+            const isCompleted = currentIdx > stepIdx;
+            const isCurrent = currentIdx === stepIdx;
+            return (
+              <React.Fragment key={step}>
+                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', minWidth: 70 }}>
+                  <div
+                    style={{
+                      width: 24, height: 24, borderRadius: '50%',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 700,
+                      backgroundColor: isCompleted ? 'var(--color-success)' : isCurrent ? 'var(--color-accent)' : 'var(--color-bg-elevated)',
+                      color: isCompleted || isCurrent ? '#fff' : 'var(--color-text-muted)',
+                      border: isCurrent ? '2px solid rgba(77, 171, 247, 0.5)' : '1px solid var(--color-border)',
+                      transition: 'all var(--transition)',
+                    }}
+                  >
+                    {isCompleted ? '✓' : idx + 1}
+                  </div>
+                  <span style={{
+                    fontFamily: 'var(--font-mono)', fontSize: 8, fontWeight: 600,
+                    letterSpacing: '0.5px', marginTop: 4,
+                    color: isCompleted || isCurrent ? 'var(--color-text-bright)' : 'var(--color-text-muted)',
+                  }}>
+                    {step}
+                  </span>
+                </div>
+                {idx < 4 && (
+                  <div style={{
+                    flex: 1, height: 2, minWidth: 20,
+                    backgroundColor: isCompleted ? 'var(--color-success)' : 'var(--color-border)',
+                    marginBottom: 16,
+                    transition: 'background-color var(--transition)',
+                  }} />
+                )}
+              </React.Fragment>
+            );
+          })}
+        </div>
+      ) : (
+        <div style={{
+          padding: '6px 12px', borderRadius: 'var(--radius)',
+          backgroundColor: requisition.status === 'DENIED' ? 'rgba(255, 107, 107, 0.1)' : 'rgba(148, 163, 184, 0.1)',
+          border: `1px solid ${requisition.status === 'DENIED' ? 'rgba(255, 107, 107, 0.2)' : 'rgba(148, 163, 184, 0.2)'}`,
+          fontFamily: 'var(--font-mono)', fontSize: 11, fontWeight: 700,
+          color: requisition.status === 'DENIED' ? 'var(--color-danger)' : 'var(--color-text-muted)',
+        }}>
+          {requisition.status === 'DENIED' ? '✗ DENIED' : '⊗ CANCELED'}
+        </div>
+      )}
 
       {/* Info grid */}
       <div
@@ -563,6 +631,24 @@ export default function RequisitionDetail({ requisition, onRefresh }: Requisitio
               CANCEL
             </button>
           </div>
+        )}
+        {canProcess && (
+          <button
+            style={btnStyle('var(--color-warning)')}
+            onClick={() => processMut.mutate()}
+            disabled={processMut.isPending}
+          >
+            <Package size={12} /> PROCESS
+          </button>
+        )}
+        {canShip && (
+          <button
+            style={btnStyle('#a78bfa')}
+            onClick={() => shipMut.mutate()}
+            disabled={shipMut.isPending}
+          >
+            <Truck size={12} /> SHIP
+          </button>
         )}
         {canReceive && (
           <button

--- a/frontend/src/pages/RequisitionsPage.tsx
+++ b/frontend/src/pages/RequisitionsPage.tsx
@@ -11,7 +11,7 @@ import RequisitionTable from '@/components/requisitions/RequisitionTable';
 import ApprovalQueue from '@/components/requisitions/ApprovalQueue';
 import InventoryPanel from '@/components/requisitions/InventoryPanel';
 import CreateRequisitionModal from '@/components/requisitions/CreateRequisitionModal';
-import { getRequisitions } from '@/api/requisitions';
+import { getRequisitions, getRequisitionAnalytics } from '@/api/requisitions';
 
 // ---------------------------------------------------------------------------
 // Tab definitions
@@ -20,8 +20,12 @@ import { getRequisitions } from '@/api/requisitions';
 const TABS = [
   { key: 'all' as const, label: 'ALL REQUISITIONS' },
   { key: 'pending' as const, label: 'PENDING APPROVAL' },
+  { key: 'analytics' as const, label: 'ANALYTICS' },
   { key: 'inventory' as const, label: 'INVENTORY' },
 ];
+
+const ACTIVE_STATUSES = ['DRAFT', 'SUBMITTED', 'APPROVED', 'SOURCING', 'BACKORDERED', 'SHIPPED'];
+const ARCHIVED_STATUSES = ['RECEIVED', 'DENIED', 'CANCELED'];
 
 type TabKey = (typeof TABS)[number]['key'];
 
@@ -32,6 +36,7 @@ type TabKey = (typeof TABS)[number]['key'];
 export default function RequisitionsPage() {
   const [activeTab, setActiveTab] = useState<TabKey>('all');
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [viewMode, setViewMode] = useState<'ACTIVE' | 'ARCHIVED' | 'ALL'>('ACTIVE');
 
   const selectedUnitId = useDashboardStore((s) => s.selectedUnitId);
 
@@ -53,6 +58,19 @@ export default function RequisitionsPage() {
     queryKey: ['requisitions'],
     queryFn: () => getRequisitions(),
   });
+
+  const { data: analytics } = useQuery({
+    queryKey: ['requisition-analytics'],
+    queryFn: () => getRequisitionAnalytics(),
+    enabled: activeTab === 'analytics',
+  });
+
+  const filteredRequisitions = useMemo(() => {
+    if (!requisitions) return [];
+    if (viewMode === 'ACTIVE') return requisitions.filter(r => ACTIVE_STATUSES.includes(r.status));
+    if (viewMode === 'ARCHIVED') return requisitions.filter(r => ARCHIVED_STATUSES.includes(r.status));
+    return requisitions;
+  }, [requisitions, viewMode]);
 
   // -------------------------------------------------------------------------
   // ESC handler
@@ -187,6 +205,41 @@ export default function RequisitionsPage() {
         </button>
       </div>
 
+      {/* View mode toggle */}
+      <div style={{ display: 'flex', gap: 2 }}>
+        {(['ACTIVE', 'ARCHIVED', 'ALL'] as const).map((mode) => (
+          <button
+            key={mode}
+            onClick={() => setViewMode(mode)}
+            style={{
+              padding: '5px 12px',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 9,
+              fontWeight: viewMode === mode ? 600 : 400,
+              letterSpacing: '1px',
+              border: 'none',
+              borderBottom: viewMode === mode ? '2px solid var(--color-accent)' : '2px solid transparent',
+              backgroundColor: 'transparent',
+              color: viewMode === mode ? 'var(--color-accent)' : 'var(--color-text-muted)',
+              cursor: 'pointer',
+              transition: 'all var(--transition)',
+            }}
+          >
+            {mode}
+            {mode === 'ACTIVE' && (
+              <span style={{ marginLeft: 6, fontSize: 8, fontWeight: 700, color: 'var(--color-success)' }}>
+                {requisitions?.filter(r => ACTIVE_STATUSES.includes(r.status)).length ?? 0}
+              </span>
+            )}
+            {mode === 'ARCHIVED' && (
+              <span style={{ marginLeft: 6, fontSize: 8, fontWeight: 700, color: 'var(--color-text-muted)' }}>
+                {requisitions?.filter(r => ARCHIVED_STATUSES.includes(r.status)).length ?? 0}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
       {/* Tabs */}
       <div
         style={{
@@ -251,7 +304,7 @@ export default function RequisitionsPage() {
             renderLoadingSkeleton()
           ) : (
             <RequisitionTable
-              requisitions={requisitions ?? []}
+              requisitions={filteredRequisitions}
               onRefresh={() => refetch()}
             />
           )}
@@ -264,9 +317,66 @@ export default function RequisitionsPage() {
             renderLoadingSkeleton()
           ) : (
             <ApprovalQueue
-              requisitions={requisitions ?? []}
+              requisitions={filteredRequisitions}
               onRefresh={() => refetch()}
             />
+          )}
+        </div>
+      )}
+
+      {activeTab === 'analytics' && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          {analytics && (
+            <>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: 12 }}>
+                {[
+                  { label: 'TOTAL', value: analytics.summary.total, color: 'var(--color-text-bright)' },
+                  { label: 'ACTIVE', value: analytics.summary.active, color: 'var(--color-accent)' },
+                  { label: 'FULFILLED', value: analytics.summary.fulfilled, color: 'var(--color-success)' },
+                  { label: 'DENIED', value: analytics.summary.denied, color: 'var(--color-danger)' },
+                  { label: 'CANCELED', value: analytics.summary.canceled, color: 'var(--color-text-muted)' },
+                  { label: 'APPROVAL RATE', value: `${analytics.summary.approvalRate}%`, color: 'var(--color-warning)' },
+                ].map((kpi) => (
+                  <Card key={kpi.label} title={kpi.label}>
+                    <div style={{ fontFamily: 'var(--font-mono)', fontSize: 28, fontWeight: 700, color: kpi.color, textAlign: 'center', padding: '8px 0' }}>
+                      {kpi.value}
+                    </div>
+                  </Card>
+                ))}
+              </div>
+
+              <Card title="STATUS BREAKDOWN">
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '8px 0' }}>
+                  {Object.entries(analytics.byStatus).map(([status, count]) => {
+                    const maxCount = Math.max(...Object.values(analytics.byStatus));
+                    const pct = maxCount > 0 ? ((count as number) / maxCount) * 100 : 0;
+                    return (
+                      <div key={status} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 600, width: 100, textAlign: 'right', color: 'var(--color-text-muted)' }}>{status}</span>
+                        <div style={{ flex: 1, height: 16, backgroundColor: 'var(--color-bg)', borderRadius: 2, overflow: 'hidden' }}>
+                          <div style={{ width: `${pct}%`, height: '100%', backgroundColor: 'var(--color-accent)', borderRadius: 2, transition: 'width 0.3s ease' }} />
+                        </div>
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, fontWeight: 700, width: 30, color: 'var(--color-text-bright)' }}>{count as number}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </Card>
+
+              <Card title="FULFILLMENT METRICS">
+                <div style={{ display: 'flex', alignItems: 'center', gap: 16, padding: '8px 0' }}>
+                  <div style={{ textAlign: 'center' }}>
+                    <div style={{ fontFamily: 'var(--font-mono)', fontSize: 9, fontWeight: 600, letterSpacing: '1.5px', color: 'var(--color-text-muted)', textTransform: 'uppercase' as const }}>AVG FULFILLMENT TIME</div>
+                    <div style={{ fontFamily: 'var(--font-mono)', fontSize: 28, fontWeight: 700, color: 'var(--color-accent)' }}>{analytics.avgFulfillmentDays}d</div>
+                  </div>
+                </div>
+              </Card>
+            </>
+          )}
+          {!analytics && (
+            <div style={{ padding: 40, textAlign: 'center', fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-text-muted)' }}>
+              Loading analytics...
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- **Bug 1 (CRITICAL)**: Requisition approval changes now persist across page refreshes via sessionStorage-backed store instead of module-scoped arrays that reset on reload
- **Bug 2**: Added PROCESS (APPROVED→SOURCING) and SHIP (SOURCING→SHIPPED) lifecycle buttons with visual 5-step status stepper and history timeline entries
- **Bug 3**: Added ACTIVE/ARCHIVED/ALL view mode toggle with count badges, plus ANALYTICS tab with KPI cards (total, active, fulfilled, denied, canceled, approval rate), status breakdown bar chart, and fulfillment metrics

## Files Changed
- `frontend/src/api/requisitions.ts` — sessionStorage persistence, `processRequisition()`, `shipRequisition()`, `getRequisitionAnalytics()`, 15 realistic mock requisitions
- `frontend/src/components/requisitions/RequisitionDetail.tsx` — status stepper, PROCESS/SHIP buttons
- `frontend/src/pages/RequisitionsPage.tsx` — ACTIVE/ARCHIVED/ALL toggle, ANALYTICS tab

## Test Plan
- [x] Approve requisition → refresh page → approval persists (sessionStorage)
- [x] SUBMITTED → APPROVED → SOURCING (PROCESS btn) → SHIPPED (SHIP btn) → RECEIVE btn appears
- [x] Status stepper shows ✓ for completed steps, current step highlighted
- [x] Status history timeline appends entries for each transition
- [x] ACTIVE/ARCHIVED/ALL toggle filters correctly with count badges
- [x] ANALYTICS tab renders KPI cards, status breakdown chart, fulfillment metrics
- [x] TypeScript compiles clean (`npx tsc -b`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)