### PR TITLE
feat: transportation personnel assignment & live tracking

### DIFF
--- a/backend/app/api/personnel.py
+++ b/backend/app/api/personnel.py
@@ -1,6 +1,7 @@
 """Personnel directory CRUD endpoints."""
 
 import json
+from datetime import date
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
@@ -13,7 +14,15 @@ from app.core.exceptions import ConflictError, NotFoundError
 from app.core.permissions import check_unit_access, get_accessible_units, require_role
 from app.database import get_db
 from app.models.manning import Qualification
-from app.models.personnel import AmmoLoad, Personnel, PersonnelStatus, Weapon
+from app.models.personnel import (
+    AmmoLoad,
+    ConvoyPersonnel,
+    PayGrade,
+    Personnel,
+    PersonnelStatus,
+    Weapon,
+)
+from app.models.transportation import VEHICLE_LICENSE_REQUIREMENTS
 from app.models.user import Role, User
 from app.schemas.manning import (
     MOSFillReport,
@@ -35,6 +44,10 @@ from app.schemas.personnel import (
     WeaponCreate,
     WeaponResponse,
     WeaponUpdate,
+)
+from app.schemas.transportation import (
+    QualifiedPersonnelItem,
+    QualifiedPersonnelResponse,
 )
 from app.services.personnel_analytics import PersonnelAnalyticsService
 
@@ -105,6 +118,150 @@ async def search_personnel(
     )
     result = await db.execute(query)
     return result.scalars().all()
+
+
+@router.get("/qualified", response_model=QualifiedPersonnelResponse)
+async def get_qualified_personnel(
+    role: str = Query(...),
+    vehicle_tamcn: str = Query(...),
+    unit_id: Optional[int] = Query(None),
+    exclude_movement_id: Optional[int] = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return personnel qualified for a given convoy role and vehicle type."""
+    accessible = await get_accessible_units(db, current_user)
+
+    # Build base query for active personnel
+    query = (
+        select(Personnel)
+        .where(
+            Personnel.unit_id.in_(accessible),
+            Personnel.status == PersonnelStatus.ACTIVE,
+        )
+        .options(selectinload(Personnel.qualifications))
+    )
+
+    if unit_id and unit_id in accessible:
+        query = query.where(Personnel.unit_id == unit_id)
+
+    result = await db.execute(query)
+    all_personnel = result.scalars().all()
+
+    # Determine required qualifications based on role
+    role_upper = role.upper()
+    vehicle_license = VEHICLE_LICENSE_REQUIREMENTS.get(vehicle_tamcn)
+    required_qualifications: list[str] = []
+    today = date.today()
+
+    # E5+ pay grades
+    e5_plus = {
+        PayGrade.E5, PayGrade.E6, PayGrade.E7, PayGrade.E8, PayGrade.E9,
+    }
+    # E6+ pay grades
+    e6_plus = {
+        PayGrade.E6, PayGrade.E7, PayGrade.E8, PayGrade.E9,
+    }
+    # Officer / warrant pay grades
+    officer_grades = {
+        PayGrade.W1, PayGrade.W2, PayGrade.W3, PayGrade.W4, PayGrade.W5,
+        PayGrade.O1, PayGrade.O2, PayGrade.O3, PayGrade.O4, PayGrade.O5,
+        PayGrade.O6, PayGrade.O7, PayGrade.O8, PayGrade.O9, PayGrade.O10,
+    }
+
+    def has_current_qual(person: Personnel, qual_name: str) -> bool:
+        """Check if personnel has a current, non-expired qualification."""
+        for q in person.qualifications:
+            if (
+                q.qualification_name == qual_name
+                and q.is_current
+                and (q.expiration_date is None or q.expiration_date >= today)
+            ):
+                return True
+        return False
+
+    # Determine which personnel are already assigned to the given movement
+    assigned_personnel_ids: set[int] = set()
+    if exclude_movement_id:
+        cp_result = await db.execute(
+            select(ConvoyPersonnel.personnel_id).where(
+                ConvoyPersonnel.movement_id == exclude_movement_id
+            )
+        )
+        assigned_personnel_ids = {row[0] for row in cp_result.all()}
+
+    qualified: list[QualifiedPersonnelItem] = []
+
+    for person in all_personnel:
+        is_qualified = False
+
+        if role_upper in ("DRIVER", "A_DRIVER"):
+            required_qualifications = ["MILITARY_DRIVER"]
+            if vehicle_license:
+                required_qualifications.append(vehicle_license)
+            is_qualified = has_current_qual(person, "MILITARY_DRIVER") and (
+                vehicle_license is None or has_current_qual(person, vehicle_license)
+            )
+
+        elif role_upper == "TC":
+            required_qualifications = ["MILITARY_DRIVER"]
+            if vehicle_license:
+                required_qualifications.append(vehicle_license)
+            is_qualified = (
+                person.pay_grade in e5_plus
+                and has_current_qual(person, "MILITARY_DRIVER")
+                and (
+                    vehicle_license is None
+                    or has_current_qual(person, vehicle_license)
+                )
+            )
+
+        elif role_upper == "VC":
+            required_qualifications = ["E6+ or Officer"]
+            is_qualified = person.pay_grade in (e6_plus | officer_grades)
+
+        elif role_upper == "GUNNER":
+            required_qualifications = ["WEAPONS_QUAL"]
+            is_qualified = has_current_qual(person, "WEAPONS_QUAL")
+
+        elif role_upper == "MEDIC":
+            required_qualifications = ["MOS 8404 or TCCC"]
+            is_qualified = person.mos == "8404" or has_current_qual(person, "TCCC")
+
+        elif role_upper == "PAX":
+            required_qualifications = []
+            is_qualified = True
+
+        if is_qualified:
+            qual_dicts = [
+                {
+                    "id": q.id,
+                    "qualification_name": q.qualification_name,
+                    "qualification_type": q.qualification_type,
+                    "is_current": q.is_current,
+                    "expiration_date": str(q.expiration_date) if q.expiration_date else None,
+                }
+                for q in person.qualifications
+            ]
+            qualified.append(
+                QualifiedPersonnelItem(
+                    id=person.id,
+                    edipi=person.edipi,
+                    rank=person.rank,
+                    first_name=person.first_name,
+                    last_name=person.last_name,
+                    mos=person.mos,
+                    pay_grade=person.pay_grade.value if person.pay_grade else None,
+                    is_assigned_to_movement=person.id in assigned_personnel_ids,
+                    qualifications=qual_dicts,
+                )
+            )
+
+    return QualifiedPersonnelResponse(
+        personnel=qualified,
+        total=len(qualified),
+        required_qualifications=required_qualifications,
+    )
 
 
 @router.get("/{person_id}", response_model=PersonnelResponse)

--- a/backend/app/api/transportation.py
+++ b/backend/app/api/transportation.py
@@ -1,19 +1,38 @@
 """Transportation / movement CRUD endpoints."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.core.auth import get_current_user
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import BadRequestError, NotFoundError
 from app.core.permissions import check_unit_access, get_accessible_units, require_role
 from app.database import get_db
-from app.models.transportation import Movement, MovementStatus
+from app.models.personnel import (
+    ConvoyPersonnel,
+    ConvoyVehicle,
+    Personnel,
+)
+from app.models.transportation import (
+    ConvoyCargo,
+    Movement,
+    MovementStatus,
+    VEHICLE_LICENSE_REQUIREMENTS,
+)
 from app.models.user import Role, User
-from app.schemas.transportation import MovementCreate, MovementResponse, MovementUpdate
+from app.schemas.transportation import (
+    ConvoyCargoCreate,
+    ConvoyCargoResponse,
+    MovementCreate,
+    MovementResponse,
+    MovementUpdate,
+    ValidateAssignmentRequest,
+    ValidateAssignmentResponse,
+)
 
 router = APIRouter()
 
@@ -155,9 +174,219 @@ async def update_movement(
     if "unit_id" in update_data and update_data["unit_id"] != record.unit_id:
         await check_unit_access(current_user, update_data["unit_id"], db)
 
+    old_status = record.status
     for field, value in update_data.items():
         setattr(record, field, value)
+
+    # Personnel tracking: propagate status changes to assigned personnel
+    new_status = record.status
+    if old_status != new_status:
+        if new_status == MovementStatus.EN_ROUTE:
+            # Set current_movement_id for all assigned personnel
+            cp_result = await db.execute(
+                select(ConvoyPersonnel.personnel_id).where(
+                    ConvoyPersonnel.movement_id == record_id
+                )
+            )
+            personnel_ids = [row[0] for row in cp_result.all()]
+            if personnel_ids:
+                await db.execute(
+                    update(Personnel)
+                    .where(Personnel.id.in_(personnel_ids))
+                    .values(current_movement_id=record_id)
+                )
+
+        elif new_status == MovementStatus.COMPLETE:
+            # Clear current_movement_id for all personnel on this movement
+            await db.execute(
+                update(Personnel)
+                .where(Personnel.current_movement_id == record_id)
+                .values(current_movement_id=None)
+            )
 
     await db.flush()
     await db.refresh(record)
     return record
+
+
+# --- Assignment validation ---
+
+
+@router.post(
+    "/validate-assignment",
+    response_model=ValidateAssignmentResponse,
+)
+async def validate_assignment(
+    data: ValidateAssignmentRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Validate if a personnel can be assigned to a role on a vehicle."""
+    # Load personnel with qualifications
+    result = await db.execute(
+        select(Personnel)
+        .where(Personnel.id == data.personnel_id)
+        .options(selectinload(Personnel.qualifications))
+    )
+    person = result.scalar_one_or_none()
+    if not person:
+        raise NotFoundError("Personnel", data.personnel_id)
+
+    # Verify user has access to the personnel's unit
+    accessible = await get_accessible_units(db, current_user)
+    if person.unit_id not in accessible:
+        raise NotFoundError("Personnel", data.personnel_id)
+
+    # Validate role against ConvoyRole enum
+    valid_roles = {"DRIVER", "A_DRIVER", "GUNNER", "TC", "VC", "MEDIC", "PAX"}
+    if data.role.upper() not in valid_roles:
+        raise BadRequestError(f"Invalid role: {data.role}. Must be one of {', '.join(sorted(valid_roles))}")
+
+    # Check if already assigned to another vehicle in this movement
+    cp_result = await db.execute(
+        select(ConvoyPersonnel).where(
+            ConvoyPersonnel.movement_id == data.movement_id,
+            ConvoyPersonnel.personnel_id == data.personnel_id,
+        )
+    )
+    existing = cp_result.scalar_one_or_none()
+    assigned_to_other = existing is not None
+
+    today = date.today()
+    missing: list[str] = []
+    role_upper = data.role.upper()
+    vehicle_license = VEHICLE_LICENSE_REQUIREMENTS.get(data.vehicle_tamcn)
+
+    def has_qual(qual_name: str) -> bool:
+        for q in person.qualifications:
+            if (
+                q.qualification_name == qual_name
+                and q.is_current
+                and (q.expiration_date is None or q.expiration_date >= today)
+            ):
+                return True
+        return False
+
+    from app.models.personnel import PayGrade
+
+    e5_plus = {
+        PayGrade.E5, PayGrade.E6, PayGrade.E7, PayGrade.E8, PayGrade.E9,
+    }
+    e6_plus = {
+        PayGrade.E6, PayGrade.E7, PayGrade.E8, PayGrade.E9,
+    }
+    officer_grades = {
+        PayGrade.W1, PayGrade.W2, PayGrade.W3, PayGrade.W4, PayGrade.W5,
+        PayGrade.O1, PayGrade.O2, PayGrade.O3, PayGrade.O4, PayGrade.O5,
+        PayGrade.O6, PayGrade.O7, PayGrade.O8, PayGrade.O9, PayGrade.O10,
+    }
+
+    if role_upper in ("DRIVER", "A_DRIVER"):
+        if not has_qual("MILITARY_DRIVER"):
+            missing.append("MILITARY_DRIVER")
+        if vehicle_license and not has_qual(vehicle_license):
+            missing.append(vehicle_license)
+
+    elif role_upper == "TC":
+        if person.pay_grade not in e5_plus:
+            missing.append("E5+ pay grade required")
+        if not has_qual("MILITARY_DRIVER"):
+            missing.append("MILITARY_DRIVER")
+        if vehicle_license and not has_qual(vehicle_license):
+            missing.append(vehicle_license)
+
+    elif role_upper == "VC":
+        if person.pay_grade not in (e6_plus | officer_grades):
+            missing.append("E6+ or Officer pay grade required")
+
+    elif role_upper == "GUNNER":
+        if not has_qual("WEAPONS_QUAL"):
+            missing.append("WEAPONS_QUAL")
+
+    elif role_upper == "MEDIC":
+        if person.mos != "8404" and not has_qual("TCCC"):
+            missing.append("MOS 8404 or TCCC certification")
+
+    # PAX has no requirements
+
+    valid = len(missing) == 0
+    reason = "Qualified" if valid else f"Missing: {', '.join(missing)}"
+    if assigned_to_other and valid:
+        reason = "Qualified but already assigned to a vehicle in this movement"
+
+    return ValidateAssignmentResponse(
+        valid=valid,
+        reason=reason,
+        missing_qualifications=missing,
+        assigned_to_other_vehicle=assigned_to_other,
+    )
+
+
+# --- Convoy Cargo endpoints ---
+
+
+@router.get(
+    "/{movement_id}/cargo",
+    response_model=List[ConvoyCargoResponse],
+)
+async def list_movement_cargo(
+    movement_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List cargo for a movement."""
+    result = await db.execute(select(Movement).where(Movement.id == movement_id))
+    movement = result.scalar_one_or_none()
+    if not movement:
+        raise NotFoundError("Movement", movement_id)
+
+    await check_unit_access(current_user, movement.unit_id, db)
+
+    cargo_result = await db.execute(
+        select(ConvoyCargo)
+        .where(ConvoyCargo.movement_id == movement_id)
+        .order_by(ConvoyCargo.id)
+    )
+    return cargo_result.scalars().all()
+
+
+@router.post(
+    "/{movement_id}/cargo",
+    response_model=ConvoyCargoResponse,
+    status_code=201,
+    dependencies=[Depends(require_role(WRITE_ROLES))],
+)
+async def add_movement_cargo(
+    movement_id: int,
+    data: ConvoyCargoCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Add cargo to a movement."""
+    result = await db.execute(select(Movement).where(Movement.id == movement_id))
+    movement = result.scalar_one_or_none()
+    if not movement:
+        raise NotFoundError("Movement", movement_id)
+
+    await check_unit_access(current_user, movement.unit_id, db)
+
+    # Verify convoy vehicle belongs to this movement
+    cv_result = await db.execute(
+        select(ConvoyVehicle).where(
+            ConvoyVehicle.id == data.convoy_vehicle_id,
+            ConvoyVehicle.movement_id == movement_id,
+        )
+    )
+    if not cv_result.scalar_one_or_none():
+        raise BadRequestError(
+            f"Convoy vehicle {data.convoy_vehicle_id} not found in movement {movement_id}"
+        )
+
+    cargo = ConvoyCargo(
+        movement_id=movement_id,
+        **data.model_dump(),
+    )
+    db.add(cargo)
+    await db.flush()
+    await db.refresh(cargo)
+    return cargo

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,7 +11,7 @@ from app.models.equipment import (
     FaultSeverity,
     EquipmentDriverAssignment,
 )
-from app.models.transportation import Movement, MovementStatus
+from app.models.transportation import Movement, MovementStatus, ConvoyCargo, VEHICLE_LICENSE_REQUIREMENTS
 from app.models.convoy_planning import (
     ConvoyPlan,
     ConvoySerial,
@@ -350,4 +350,6 @@ __all__ = [
     "RecommendationType",
     "LogisticsRecommendation",
     "RecommendationStatus",
+    "ConvoyCargo",
+    "VEHICLE_LICENSE_REQUIREMENTS",
 ]

--- a/backend/app/models/personnel.py
+++ b/backend/app/models/personnel.py
@@ -135,12 +135,17 @@ class Personnel(Base):
     drivers_license_military = Column(Boolean, default=False)
     duty_status = Column(SQLEnum(DutyStatus), nullable=True, default=DutyStatus.PRESENT)
 
+    current_movement_id = Column(
+        Integer, ForeignKey("movements.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
 
     unit = relationship("Unit", back_populates="personnel")
+    current_movement = relationship("Movement", foreign_keys=[current_movement_id])
     weapons = relationship(
         "Weapon", back_populates="personnel", cascade="all, delete-orphan"
     )
@@ -213,6 +218,9 @@ class ConvoyVehicle(Base):
     )
     assigned_personnel = relationship(
         "ConvoyPersonnel", back_populates="convoy_vehicle", cascade="all, delete-orphan"
+    )
+    cargo = relationship(
+        "ConvoyCargo", back_populates="convoy_vehicle", cascade="all, delete-orphan"
     )
 
 

--- a/backend/app/models/transportation.py
+++ b/backend/app/models/transportation.py
@@ -3,6 +3,7 @@
 import enum
 
 from sqlalchemy import (
+    Boolean,
     Column,
     DateTime,
     Enum as SQLEnum,
@@ -67,5 +68,56 @@ class Movement(Base):
     convoy_personnel = relationship(
         "ConvoyPersonnel", back_populates="movement", cascade="all, delete-orphan"
     )
+    convoy_cargo = relationship(
+        "ConvoyCargo", back_populates="movement", cascade="all, delete-orphan"
+    )
     convoy_plan = relationship("ConvoyPlan")
     convoy_serial = relationship("ConvoySerial")
+
+
+VEHICLE_LICENSE_REQUIREMENTS = {
+    "D1100": "HMMWV_LICENSE",
+    "D1149": "HMMWV_LICENSE",
+    "D0090": "MTVR_LICENSE",
+    "D0091": "MTVR_LICENSE",
+    "E0846": "JLTV_LICENSE",
+    "E0847": "JLTV_LICENSE",
+    "E0811": "LVSR_LICENSE",
+    "L0071": "LAV_LICENSE",
+    "P0072": "ACV_LICENSE",
+}
+
+
+class ConvoyCargo(Base):
+    __tablename__ = "convoy_cargo"
+
+    id = Column(Integer, primary_key=True, index=True)
+    movement_id = Column(
+        Integer,
+        ForeignKey("movements.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    convoy_vehicle_id = Column(
+        Integer,
+        ForeignKey("convoy_vehicles.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    supply_catalog_item_id = Column(
+        Integer, ForeignKey("supply_catalog.id"), nullable=True
+    )
+    equipment_catalog_item_id = Column(
+        Integer, ForeignKey("equipment_catalog.id"), nullable=True
+    )
+    description = Column(String(200), nullable=True)
+    quantity = Column(Integer, nullable=False, default=1)
+    weight_lbs = Column(Float, nullable=True)
+    is_hazmat = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    movement = relationship("Movement", back_populates="convoy_cargo")
+    convoy_vehicle = relationship("ConvoyVehicle", back_populates="cargo")
+    supply_catalog_item = relationship("SupplyCatalogItem")
+    equipment_catalog_item = relationship("EquipmentCatalogItem")

--- a/backend/app/schemas/transportation.py
+++ b/backend/app/schemas/transportation.py
@@ -49,3 +49,71 @@ class MovementResponse(MovementBase):
     march_table_data: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+# --- Convoy Cargo schemas ---
+
+
+class ConvoyCargoCreate(BaseModel):
+    convoy_vehicle_id: int
+    description: Optional[str] = None
+    quantity: int = Field(1, ge=1)
+    weight_lbs: Optional[float] = Field(None, ge=0)
+    is_hazmat: bool = False
+    supply_catalog_item_id: Optional[int] = None
+    equipment_catalog_item_id: Optional[int] = None
+
+
+class ConvoyCargoResponse(BaseModel):
+    id: int
+    movement_id: int
+    convoy_vehicle_id: int
+    description: Optional[str] = None
+    quantity: int
+    weight_lbs: Optional[float] = None
+    is_hazmat: bool
+    supply_catalog_item_id: Optional[int] = None
+    equipment_catalog_item_id: Optional[int] = None
+    created_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# --- Assignment validation schemas ---
+
+
+class ValidateAssignmentRequest(BaseModel):
+    personnel_id: int
+    role: str
+    vehicle_tamcn: str
+    movement_id: int
+
+
+class ValidateAssignmentResponse(BaseModel):
+    valid: bool
+    reason: str
+    missing_qualifications: list[str] = []
+    assigned_to_other_vehicle: bool = False
+
+
+# --- Qualified personnel schemas ---
+
+
+class QualifiedPersonnelItem(BaseModel):
+    id: int
+    edipi: str
+    rank: Optional[str] = None
+    first_name: str
+    last_name: str
+    mos: Optional[str] = None
+    pay_grade: Optional[str] = None
+    is_assigned_to_movement: bool = False
+    qualifications: list[dict] = []
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class QualifiedPersonnelResponse(BaseModel):
+    personnel: list[QualifiedPersonnelItem]
+    total: int
+    required_qualifications: list[str] = []

--- a/frontend/src/api/personnel.ts
+++ b/frontend/src/api/personnel.ts
@@ -14,6 +14,10 @@ import type {
   QualStatusData,
   PersonnelReadinessData,
   EASRecord,
+  QualifiedPersonnelItem,
+  QualifiedPersonnelResponse,
+  ValidateAssignmentRequest,
+  ValidateAssignmentResponse,
 } from '@/lib/types';
 
 // ---------------------------------------------------------------------------
@@ -438,4 +442,253 @@ export async function deleteQualification(id: number): Promise<void> {
     return;
   }
   await apiClient.delete(`/personnel/qualifications/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// Transportation Personnel Assignment & Certification Verification
+// ---------------------------------------------------------------------------
+
+// Mock qualification records keyed to MOCK_PERSONNEL ids
+const MOCK_QUALIFICATIONS: {
+  personnel_id: number;
+  qualification_type: string;
+  qualification_name: string;
+  is_current: boolean;
+  expiration_date: string | null;
+}[] = [
+  // Officers/SNCOs (ids 1-5): MILITARY_DRIVER + HMMWV_LICENSE + MTVR_LICENSE
+  { personnel_id: 1, qualification_type: 'MILITARY_DRIVER', qualification_name: 'Military Driver License', is_current: true, expiration_date: dateStr(365) },
+  { personnel_id: 1, qualification_type: 'HMMWV_LICENSE', qualification_name: 'HMMWV Operator License', is_current: true, expiration_date: dateStr(365) },
+  { personnel_id: 1, qualification_type: 'MTVR_LICENSE', qualification_name: 'MTVR Operator License', is_current: true, expiration_date: dateStr(300) },
+
+  { personnel_id: 2, qualification_type: 'MILITARY_DRIVER', qualification_name: 'Military Driver License', is_current: true, expiration_date: dateStr(400) },
+  { personnel_id: 2, qualification_type: 'HMMWV_LICENSE', qualification_name: 'HMMWV Operator License', is_current: true, expiration_date: dateStr(400) },
+  { personnel_id: 2, qualification_type: 'MTVR_LICENSE', qualification_name: 'MTVR Operator License', is_current: true, expiration_date: dateStr(350) },
+
+  { personnel_id: 3, qualification_type: 'MILITARY_DRIVER', qualification_name: 'Military Driver License', is_current: true, expiration_date: dateStr(320) },
+  { personnel_id: 3, qualification_type: 'HMMWV_LICENSE', qualification_name: 'HMMWV Operator License', is_current: true, expiration_date: dateStr(320) },
+  { personnel_id: 3, qualification_type: 'MTVR_LICENSE', qualification_name: 'MTVR Operator License', is_current: true, expiration_date: dateStr(280) },
+
+  { personnel_id: 4, qualification_type: 'MILITARY_DRIVER', qualification_name: 'Military Driver License', is_current: true, expiration_date: dateStr(350) },
+  { personnel_id: 4, qualification_type: 'HMMWV_LICENSE', qualification_name: 'HMMWV Operator License', is_current: true, expiration_date: dateStr(350) },
+  { personnel_id: 4, qualification_type: 'MTVR_LICENSE', qualification_name: 'MTVR Operator License', is_current: true, expiration_date: dateStr(310) },
+
+  { personnel_id: 5, qualification_type: 'MILITARY_DRIVER', qualification_name: 'Military Driver License', is_current: true, expiration_date: dateStr(380) },
+  { personnel_id: 5, qualification_type: 'HMMWV_LICENSE', qualification_name: 'HMMWV Operator License', is_current: true, expiration_date: dateStr(380) },
+  { personnel_id: 5, qualification_type: 'MTVR_LICENSE', qualification_name: 'MTVR Operator License', is_current: true, expiration_date: dateStr(340) },
+
+  // NCOs with drivers_license_military: true (ids 8, 9, 10, 11, 13, 16, 22): MILITARY_DRIVER + HMMWV_LICENSE
+  { personnel_id: 8, qualification_type: 'MILITARY_DRIVER', qualification_name: 'Military Driver License', is_current: true, expiration_date: dateStr(290) },
+  { personnel_id: 8, qualification_type: 'HMMWV_LICENSE', qualification_name: 'HMMWV Operator License', is_current: true, expiration_date: dateStr(290) },
+
+  { personnel_id: 9, qualification_type: 'MILITARY_DRIVER', qualification_name: 'Military Driver License', is_current: true, expiration_date: dateStr(260) },
+  { personnel_id: 9, qualification_type: 'HMMWV_LICENSE', qualification_name: 'HMMWV Operator License', is_current: true, expiration_date: dateStr(260) },
+
+  { personnel_id: 10, qualification_type: 'MILITARY_DRIVER', qualification_name: 'Military Driver License', is_current: true, expiration_date: dateStr(270) },
+  { personnel_id: 10, qualification_type: 'HMMWV_LICENSE', qualification_name: 'HMMWV Operator License', is_current: true, expiration_date: dateStr(270) },
+
+  { personnel_id: 11, qualification_type: 'MILITARY_DRIVER', qualification_name: 'Military Driver License', is_current: true, expiration_date: dateStr(240) },
+  { personnel_id: 11, qualification_type: 'HMMWV_LICENSE', qualification_name: 'HMMWV Operator License', is_current: true, expiration_date: dateStr(240) },
+
+  { personnel_id: 13, qualification_type: 'MILITARY_DRIVER', qualification_name: 'Military Driver License', is_current: true, expiration_date: dateStr(250) },
+  { personnel_id: 13, qualification_type: 'HMMWV_LICENSE', qualification_name: 'HMMWV Operator License', is_current: true, expiration_date: dateStr(250) },
+
+  { personnel_id: 16, qualification_type: 'MILITARY_DRIVER', qualification_name: 'Military Driver License', is_current: true, expiration_date: dateStr(230) },
+  { personnel_id: 16, qualification_type: 'HMMWV_LICENSE', qualification_name: 'HMMWV Operator License', is_current: true, expiration_date: dateStr(230) },
+
+  { personnel_id: 22, qualification_type: 'MILITARY_DRIVER', qualification_name: 'Military Driver License', is_current: true, expiration_date: dateStr(275) },
+  { personnel_id: 22, qualification_type: 'HMMWV_LICENSE', qualification_name: 'HMMWV Operator License', is_current: true, expiration_date: dateStr(275) },
+
+  // WEAPONS_QUAL for E5-E7 (ids 8, 9, 10, 11, 12) and id 13 (FDC Chief)
+  { personnel_id: 8, qualification_type: 'WEAPONS_QUAL', qualification_name: 'Crew-Served Weapons Qualification', is_current: true, expiration_date: dateStr(180) },
+  { personnel_id: 9, qualification_type: 'WEAPONS_QUAL', qualification_name: 'Crew-Served Weapons Qualification', is_current: true, expiration_date: dateStr(200) },
+  { personnel_id: 10, qualification_type: 'WEAPONS_QUAL', qualification_name: 'Crew-Served Weapons Qualification', is_current: true, expiration_date: dateStr(190) },
+  { personnel_id: 11, qualification_type: 'WEAPONS_QUAL', qualification_name: 'Crew-Served Weapons Qualification', is_current: true, expiration_date: dateStr(210) },
+  { personnel_id: 12, qualification_type: 'WEAPONS_QUAL', qualification_name: 'Crew-Served Weapons Qualification', is_current: true, expiration_date: dateStr(195) },
+  { personnel_id: 13, qualification_type: 'WEAPONS_QUAL', qualification_name: 'Crew-Served Weapons Qualification', is_current: true, expiration_date: dateStr(185) },
+
+  // TCCC for personnel 14 (Cpl Clark)
+  { personnel_id: 14, qualification_type: 'TCCC', qualification_name: 'Tactical Combat Casualty Care', is_current: true, expiration_date: dateStr(150) },
+];
+
+// Vehicle license requirements by TAMCN
+const VEHICLE_LICENSE_REQUIREMENTS: Record<string, string> = {
+  'D1100': 'HMMWV_LICENSE', 'D1149': 'HMMWV_LICENSE',
+  'D0090': 'MTVR_LICENSE', 'D0091': 'MTVR_LICENSE',
+  'E0846': 'JLTV_LICENSE', 'E0847': 'JLTV_LICENSE',
+  'E0811': 'LVSR_LICENSE',
+  'L0071': 'LAV_LICENSE',
+  'P0072': 'ACV_LICENSE',
+};
+
+// Pay grade sets for role eligibility
+const E5_PLUS = ['E5', 'E6', 'E7', 'E8', 'E9', 'W1', 'W2', 'W3', 'W4', 'W5'];
+const E6_PLUS_OR_OFFICER = ['E6', 'E7', 'E8', 'E9', 'W1', 'W2', 'W3', 'W4', 'W5', 'O1', 'O2', 'O3', 'O4', 'O5', 'O6', 'O7', 'O8', 'O9', 'O10'];
+
+function getPersonnelQuals(personnelId: number) {
+  return MOCK_QUALIFICATIONS.filter((q) => q.personnel_id === personnelId);
+}
+
+function hasCurrentQual(personnelId: number, qualType: string): boolean {
+  const now = new Date();
+  return MOCK_QUALIFICATIONS.some(
+    (q) =>
+      q.personnel_id === personnelId &&
+      q.qualification_type === qualType &&
+      q.is_current &&
+      (!q.expiration_date || new Date(q.expiration_date) > now),
+  );
+}
+
+export async function getQualifiedPersonnel(
+  role: string,
+  vehicleTamcn: string,
+  excludeMovementId?: number,
+): Promise<QualifiedPersonnelResponse> {
+  if (isDemoMode) {
+    await mockDelay();
+
+    const requiredLicense = VEHICLE_LICENSE_REQUIREMENTS[vehicleTamcn];
+    const requiredQualifications: string[] = [];
+    const activePers = MOCK_PERSONNEL.filter((p) => p.status === 'ACTIVE');
+
+    let filtered: typeof MOCK_PERSONNEL;
+
+    switch (role) {
+      case 'DRIVER':
+      case 'A_DRIVER':
+        requiredQualifications.push('MILITARY_DRIVER');
+        if (requiredLicense) requiredQualifications.push(requiredLicense);
+        filtered = activePers.filter(
+          (p) =>
+            hasCurrentQual(p.id, 'MILITARY_DRIVER') &&
+            (!requiredLicense || hasCurrentQual(p.id, requiredLicense)),
+        );
+        break;
+      case 'TC':
+        requiredQualifications.push('MILITARY_DRIVER');
+        if (requiredLicense) requiredQualifications.push(requiredLicense);
+        filtered = activePers.filter(
+          (p) =>
+            p.pay_grade !== null &&
+            E5_PLUS.includes(p.pay_grade) &&
+            hasCurrentQual(p.id, 'MILITARY_DRIVER') &&
+            (!requiredLicense || hasCurrentQual(p.id, requiredLicense)),
+        );
+        break;
+      case 'VC':
+        filtered = activePers.filter(
+          (p) => p.pay_grade !== null && E6_PLUS_OR_OFFICER.includes(p.pay_grade),
+        );
+        break;
+      case 'GUNNER':
+        requiredQualifications.push('WEAPONS_QUAL');
+        filtered = activePers.filter((p) => hasCurrentQual(p.id, 'WEAPONS_QUAL'));
+        break;
+      case 'MEDIC':
+        requiredQualifications.push('TCCC');
+        filtered = activePers.filter(
+          (p) => p.mos === '8404' || hasCurrentQual(p.id, 'TCCC'),
+        );
+        break;
+      case 'PAX':
+      default:
+        filtered = [...activePers];
+        break;
+    }
+
+    const personnel: QualifiedPersonnelItem[] = filtered.map((p) => ({
+      id: p.id,
+      edipi: p.edipi,
+      rank: p.rank,
+      first_name: p.first_name,
+      last_name: p.last_name,
+      mos: p.mos,
+      pay_grade: p.pay_grade,
+      is_assigned_to_movement: false,
+      qualifications: getPersonnelQuals(p.id).map((q) => ({
+        qualification_type: q.qualification_type,
+        qualification_name: q.qualification_name,
+        is_current: q.is_current,
+        expiration_date: q.expiration_date,
+      })),
+    }));
+
+    return {
+      personnel,
+      total: personnel.length,
+      required_qualifications: requiredQualifications,
+    };
+  }
+
+  const response = await apiClient.get<{ data: QualifiedPersonnelResponse }>(
+    '/transportation/qualified-personnel',
+    { params: { role, vehicle_tamcn: vehicleTamcn, exclude_movement_id: excludeMovementId } },
+  );
+  return response.data.data;
+}
+
+export async function validateAssignment(
+  request: ValidateAssignmentRequest,
+): Promise<ValidateAssignmentResponse> {
+  if (isDemoMode) {
+    await mockDelay();
+
+    const person = MOCK_PERSONNEL.find((p) => p.id === request.personnel_id);
+    if (!person) {
+      return { valid: false, reason: 'Personnel not found', missing_qualifications: [], assigned_to_other_vehicle: false };
+    }
+    if (person.status !== 'ACTIVE') {
+      return { valid: false, reason: `Personnel status is ${person.status}, not ACTIVE`, missing_qualifications: [], assigned_to_other_vehicle: false };
+    }
+
+    const missingQuals: string[] = [];
+    const requiredLicense = VEHICLE_LICENSE_REQUIREMENTS[request.vehicle_tamcn];
+
+    switch (request.role) {
+      case 'DRIVER':
+      case 'A_DRIVER':
+        if (!hasCurrentQual(person.id, 'MILITARY_DRIVER')) missingQuals.push('MILITARY_DRIVER');
+        if (requiredLicense && !hasCurrentQual(person.id, requiredLicense)) missingQuals.push(requiredLicense);
+        break;
+      case 'TC':
+        if (!person.pay_grade || !E5_PLUS.includes(person.pay_grade)) {
+          return { valid: false, reason: 'TC must be E5 or above', missing_qualifications: [], assigned_to_other_vehicle: false };
+        }
+        if (!hasCurrentQual(person.id, 'MILITARY_DRIVER')) missingQuals.push('MILITARY_DRIVER');
+        if (requiredLicense && !hasCurrentQual(person.id, requiredLicense)) missingQuals.push(requiredLicense);
+        break;
+      case 'VC':
+        if (!person.pay_grade || !E6_PLUS_OR_OFFICER.includes(person.pay_grade)) {
+          return { valid: false, reason: 'VC must be E6+ or Officer', missing_qualifications: [], assigned_to_other_vehicle: false };
+        }
+        break;
+      case 'GUNNER':
+        if (!hasCurrentQual(person.id, 'WEAPONS_QUAL')) missingQuals.push('WEAPONS_QUAL');
+        break;
+      case 'MEDIC':
+        if (person.mos !== '8404' && !hasCurrentQual(person.id, 'TCCC')) missingQuals.push('TCCC');
+        break;
+      case 'PAX':
+      default:
+        break;
+    }
+
+    if (missingQuals.length > 0) {
+      return {
+        valid: false,
+        reason: `Missing required qualifications: ${missingQuals.join(', ')}`,
+        missing_qualifications: missingQuals,
+        assigned_to_other_vehicle: false,
+      };
+    }
+
+    return { valid: true, reason: 'Personnel meets all requirements', missing_qualifications: [], assigned_to_other_vehicle: false };
+  }
+
+  const response = await apiClient.post<{ data: ValidateAssignmentResponse }>(
+    '/transportation/validate-assignment',
+    request,
+  );
+  return response.data.data;
 }

--- a/frontend/src/api/transportation.ts
+++ b/frontend/src/api/transportation.ts
@@ -12,6 +12,9 @@ import type {
   Movement,
   MovementHistoryRecord,
   LocationInventoryItem,
+  ConvoyCargoItem,
+  FullManifestResponse,
+  FullManifestVehicle,
 } from '@/lib/types';
 import { MovementStatus } from '@/lib/types';
 
@@ -1109,6 +1112,100 @@ const MOCK_INVENTORY: LocationInventoryItem[] = [
   { item_id: 'eq-011', item_type: 'equipment', nomenclature: 'ACOG TA31RCO Rifle Scope', nsn: '1240-01-412-6608', category: 'EQUIPMENT', available_qty: 100, weight_lbs: 0.97, status: 'SERVICEABLE' },
   { item_id: 'eq-012', item_type: 'equipment', nomenclature: 'PVS-14 Night Vision Monocular', nsn: '5855-01-432-0524', category: 'EQUIPMENT', available_qty: 40, weight_lbs: 0.77, status: 'SERVICEABLE' },
 ];
+
+// ---------------------------------------------------------------------------
+// Transportation Personnel Assignment — Manifest & Cargo
+// ---------------------------------------------------------------------------
+
+// In-memory mock cargo store
+let MOCK_CONVOY_CARGO: ConvoyCargoItem[] = [
+  { id: 1, movement_id: 1, convoy_vehicle_id: 1, description: 'MRE Cases (Class I)', quantity: 20, weight_lbs: 450, is_hazmat: false, supply_catalog_item_id: null, equipment_catalog_item_id: null },
+  { id: 2, movement_id: 1, convoy_vehicle_id: 1, description: '5.56mm Ammo Cans (Class V)', quantity: 8, weight_lbs: 216, is_hazmat: true, supply_catalog_item_id: null, equipment_catalog_item_id: null },
+  { id: 3, movement_id: 1, convoy_vehicle_id: 2, description: 'Water Cans (Class I)', quantity: 30, weight_lbs: 840, is_hazmat: false, supply_catalog_item_id: null, equipment_catalog_item_id: null },
+];
+let nextCargoId = 4;
+
+export async function getMovementManifest(movementId: number): Promise<FullManifestResponse> {
+  if (isDemoMode) {
+    await mockDelay();
+
+    // Find a convoy plan that could correspond to this movement
+    const plan = MOCK_CONVOY_PLANS.find((p) => p.id === movementId) ?? MOCK_CONVOY_PLANS[0];
+    const convoyId = `CVY-2026-${String(plan.id).padStart(3, '0')}`;
+
+    // Build vehicles from the plan's serials
+    const vehicles: FullManifestVehicle[] = [];
+    let vehicleCounter = 1;
+
+    for (const serial of plan.serials) {
+      for (let v = 0; v < Math.min(serial.vehicle_count, 3); v++) {
+        const cvId = vehicleCounter;
+        const cargo = MOCK_CONVOY_CARGO.filter(
+          (c) => c.movement_id === movementId && c.convoy_vehicle_id === cvId,
+        );
+        vehicles.push({
+          convoy_vehicle_id: cvId,
+          bumper_number: `${serial.serial_number}-V${v + 1}`,
+          vehicle_type: v === 0 ? 'HMMWV M1151' : 'MTVR MK23',
+          tamcn: v === 0 ? 'D1100' : 'D0090',
+          personnel: [],
+          cargo,
+          total_cargo_weight: cargo.reduce((sum, c) => sum + (c.weight_lbs ?? 0), 0),
+        });
+        vehicleCounter++;
+      }
+    }
+
+    return {
+      movement_id: movementId,
+      convoy_id: convoyId,
+      vehicles,
+    };
+  }
+
+  const response = await apiClient.get<{ data: FullManifestResponse }>(
+    `/transportation/movements/${movementId}/manifest`,
+  );
+  return response.data.data;
+}
+
+export async function addConvoyCargo(
+  movementId: number,
+  cargo: Omit<ConvoyCargoItem, 'id' | 'movement_id'>,
+): Promise<ConvoyCargoItem> {
+  if (isDemoMode) {
+    await mockDelay();
+    const record: ConvoyCargoItem = {
+      id: nextCargoId++,
+      movement_id: movementId,
+      ...cargo,
+    };
+    MOCK_CONVOY_CARGO = [...MOCK_CONVOY_CARGO, record];
+    return record;
+  }
+
+  const response = await apiClient.post<{ data: ConvoyCargoItem }>(
+    `/transportation/movements/${movementId}/cargo`,
+    cargo,
+  );
+  return response.data.data;
+}
+
+export async function removeConvoyCargo(movementId: number, cargoId: number): Promise<void> {
+  if (isDemoMode) {
+    await mockDelay();
+    MOCK_CONVOY_CARGO = MOCK_CONVOY_CARGO.filter(
+      (c) => !(c.id === cargoId && c.movement_id === movementId),
+    );
+    return;
+  }
+
+  await apiClient.delete(`/transportation/movements/${movementId}/cargo/${cargoId}`);
+}
+
+// ---------------------------------------------------------------------------
+// Location Inventory (for manifest building)
+// ---------------------------------------------------------------------------
 
 export async function getLocationInventory(
   _location: string,

--- a/frontend/src/components/personnel/AlphaRosterTable.tsx
+++ b/frontend/src/components/personnel/AlphaRosterTable.tsx
@@ -286,6 +286,7 @@ export default function AlphaRosterTable({ personnel, onRefresh }: AlphaRosterTa
                   )}
                 </th>
               ))}
+              <th style={{ ...headerStyle, width: 85, cursor: 'default' }}>LOCATION</th>
               <th style={{ ...headerStyle, width: 90, textAlign: 'center' }}>ACTIONS</th>
             </tr>
           </thead>
@@ -350,6 +351,38 @@ export default function AlphaRosterTable({ personnel, onRefresh }: AlphaRosterTa
                 </td>
                 <td style={{ ...cellStyle, fontWeight: 600, color: (p.cft_score ?? 0) >= 235 ? 'var(--color-text-bright)' : '#f87171' }}>
                   {p.cft_score ?? '—'}
+                </td>
+                <td style={cellStyle}>
+                  {p.current_movement_id ? (
+                    <span
+                      style={{
+                        display: 'inline-block',
+                        padding: '1px 6px',
+                        borderRadius: 2,
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 9,
+                        fontWeight: 600,
+                        letterSpacing: '0.5px',
+                        color: '#fb923c',
+                        backgroundColor: 'rgba(251, 146, 60, 0.15)',
+                        border: '1px solid rgba(251, 146, 60, 0.4)',
+                        cursor: 'pointer',
+                      }}
+                      title={`Movement #${p.current_movement_id}`}
+                    >
+                      EN ROUTE
+                    </span>
+                  ) : (
+                    <span
+                      style={{
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 9,
+                        color: 'var(--color-text-muted)',
+                      }}
+                    >
+                      PRESENT
+                    </span>
+                  )}
                 </td>
                 <td style={{ ...cellStyle, textAlign: 'center' }}>
                   <div style={{ display: 'flex', gap: 6, justifyContent: 'center' }}>

--- a/frontend/src/components/transportation/ConvoyManifestView.tsx
+++ b/frontend/src/components/transportation/ConvoyManifestView.tsx
@@ -1,0 +1,341 @@
+// =============================================================================
+// ConvoyManifestView — Full manifest view for a convoy (vehicles + crew + cargo)
+// =============================================================================
+
+import { useQuery } from '@tanstack/react-query';
+import { Truck, Users, Package, AlertTriangle } from 'lucide-react';
+import { getMovementManifest } from '@/api/transportation';
+import type { FullManifestVehicle, ConvoyCargoItem } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface ConvoyManifestViewProps {
+  movementId: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ROLE_COLORS: Record<string, { bg: string; text: string; border: string }> = {
+  DRIVER: { bg: 'rgba(96, 165, 250, 0.15)', text: '#60a5fa', border: 'rgba(96, 165, 250, 0.4)' },
+  A_DRIVER: { bg: 'rgba(148, 163, 184, 0.15)', text: '#94a3b8', border: 'rgba(148, 163, 184, 0.4)' },
+  TC: { bg: 'rgba(250, 204, 21, 0.15)', text: '#facc15', border: 'rgba(250, 204, 21, 0.4)' },
+  VC: { bg: 'rgba(251, 146, 60, 0.15)', text: '#fb923c', border: 'rgba(251, 146, 60, 0.4)' },
+  GUNNER: { bg: 'rgba(248, 113, 113, 0.15)', text: '#f87171', border: 'rgba(248, 113, 113, 0.4)' },
+  MEDIC: { bg: 'rgba(74, 222, 128, 0.15)', text: '#4ade80', border: 'rgba(74, 222, 128, 0.4)' },
+  PAX: { bg: 'rgba(148, 163, 184, 0.10)', text: '#64748b', border: 'rgba(148, 163, 184, 0.3)' },
+};
+
+function getRoleColor(role: string) {
+  return ROLE_COLORS[role] ?? ROLE_COLORS.PAX;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function ConvoyManifestView({ movementId }: ConvoyManifestViewProps) {
+  const { data: manifest, isLoading, error } = useQuery({
+    queryKey: ['movement-manifest', movementId],
+    queryFn: () => getMovementManifest(movementId),
+    enabled: movementId > 0,
+  });
+
+  const sectionLabel: React.CSSProperties = {
+    fontFamily: 'var(--font-mono)',
+    fontSize: 9,
+    fontWeight: 600,
+    letterSpacing: '1.5px',
+    color: 'var(--color-text-muted)',
+    textTransform: 'uppercase',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 8,
+  };
+
+  const fieldLabel: React.CSSProperties = {
+    fontFamily: 'var(--font-mono)',
+    fontSize: 9,
+    fontWeight: 600,
+    color: 'var(--color-text-muted)',
+    letterSpacing: '0.5px',
+    marginBottom: 2,
+  };
+
+  const fieldValue: React.CSSProperties = {
+    fontFamily: 'var(--font-mono)',
+    fontSize: 11,
+    color: 'var(--color-text)',
+    lineHeight: 1.4,
+  };
+
+  if (movementId <= 0) {
+    return (
+      <div
+        style={{
+          padding: 24,
+          textAlign: 'center',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 11,
+          color: 'var(--color-text-muted)',
+        }}
+      >
+        No movement associated with this plan. Manifest will be available once a movement is created.
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div
+        style={{
+          padding: 24,
+          textAlign: 'center',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 11,
+          color: 'var(--color-text-muted)',
+        }}
+      >
+        Loading manifest...
+      </div>
+    );
+  }
+
+  if (error || !manifest) {
+    return (
+      <div
+        style={{
+          padding: 24,
+          textAlign: 'center',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 11,
+          color: '#f87171',
+        }}
+      >
+        Failed to load manifest data.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={sectionLabel}>
+          <Truck size={12} />
+          CONVOY {manifest.convoy_id} — {manifest.vehicles.length} VEHICLES
+        </div>
+      </div>
+
+      {/* Vehicle cards */}
+      {manifest.vehicles.map((vehicle: FullManifestVehicle) => (
+        <div
+          key={vehicle.convoy_vehicle_id}
+          style={{
+            backgroundColor: 'var(--color-bg-card)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius)',
+            padding: 14,
+          }}
+        >
+          {/* Vehicle header */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              marginBottom: 10,
+              paddingBottom: 8,
+              borderBottom: '1px solid var(--color-border)',
+            }}
+          >
+            <Truck size={14} style={{ color: 'var(--color-accent)' }} />
+            <div>
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 11,
+                  fontWeight: 700,
+                  color: 'var(--color-text-bright)',
+                }}
+              >
+                {vehicle.vehicle_type}
+              </div>
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 9,
+                  color: 'var(--color-text-muted)',
+                }}
+              >
+                BUMPER: {vehicle.bumper_number} | TAMCN: {vehicle.tamcn}
+              </div>
+            </div>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+            {/* Crew section */}
+            <div>
+              <div style={{ ...sectionLabel, marginBottom: 6 }}>
+                <Users size={10} /> CREW
+              </div>
+              {vehicle.personnel.length === 0 ? (
+                <div
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 10,
+                    color: 'var(--color-text-muted)',
+                    fontStyle: 'italic',
+                  }}
+                >
+                  No crew assigned
+                </div>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  {vehicle.personnel.map((p, idx) => {
+                    const rc = getRoleColor(p.role);
+                    return (
+                      <div
+                        key={`${p.id}-${idx}`}
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 8,
+                        }}
+                      >
+                        <span
+                          style={{
+                            display: 'inline-block',
+                            padding: '1px 6px',
+                            borderRadius: 2,
+                            fontFamily: 'var(--font-mono)',
+                            fontSize: 8,
+                            fontWeight: 700,
+                            letterSpacing: '0.5px',
+                            color: rc.text,
+                            backgroundColor: rc.bg,
+                            border: `1px solid ${rc.border}`,
+                            minWidth: 55,
+                            textAlign: 'center',
+                          }}
+                        >
+                          {p.role}
+                        </span>
+                        <span style={{ ...fieldValue, fontSize: 10 }}>
+                          {p.rank} {p.name}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* Cargo section */}
+            <div>
+              <div style={{ ...sectionLabel, marginBottom: 6 }}>
+                <Package size={10} /> CARGO
+              </div>
+              {vehicle.cargo.length === 0 ? (
+                <div
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 10,
+                    color: 'var(--color-text-muted)',
+                    fontStyle: 'italic',
+                  }}
+                >
+                  No cargo loaded
+                </div>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  {vehicle.cargo.map((c: ConvoyCargoItem) => (
+                    <div
+                      key={c.id}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 8,
+                      }}
+                    >
+                      <span style={{ ...fieldValue, fontSize: 10, flex: 1 }}>
+                        {c.description ?? 'Unknown item'}
+                        {c.is_hazmat && (
+                          <span
+                            style={{
+                              display: 'inline-block',
+                              marginLeft: 6,
+                              padding: '0px 4px',
+                              borderRadius: 2,
+                              fontFamily: 'var(--font-mono)',
+                              fontSize: 8,
+                              fontWeight: 700,
+                              color: '#f87171',
+                              backgroundColor: 'rgba(248, 113, 113, 0.15)',
+                              border: '1px solid rgba(248, 113, 113, 0.4)',
+                              verticalAlign: 'middle',
+                            }}
+                          >
+                            <AlertTriangle size={8} style={{ marginRight: 2, verticalAlign: 'middle' }} />
+                            HAZMAT
+                          </span>
+                        )}
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: 'var(--font-mono)',
+                          fontSize: 9,
+                          color: 'var(--color-text-muted)',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        x{c.quantity}
+                        {c.weight_lbs != null && ` / ${c.weight_lbs} lbs`}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Total weight */}
+              {vehicle.total_cargo_weight > 0 && (
+                <div
+                  style={{
+                    marginTop: 6,
+                    paddingTop: 4,
+                    borderTop: '1px solid var(--color-border)',
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 10,
+                    fontWeight: 600,
+                    color: 'var(--color-text-bright)',
+                  }}
+                >
+                  TOTAL: {vehicle.total_cargo_weight.toLocaleString()} lbs
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      ))}
+
+      {manifest.vehicles.length === 0 && (
+        <div
+          style={{
+            padding: 20,
+            textAlign: 'center',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            color: 'var(--color-text-muted)',
+          }}
+        >
+          No vehicles in this convoy manifest.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/transportation/ConvoyPlanDetail.tsx
+++ b/frontend/src/components/transportation/ConvoyPlanDetail.tsx
@@ -3,12 +3,14 @@
 // =============================================================================
 
 import { useState } from 'react';
-import { ArrowLeft, Clock, MapPin, Radio, ShieldAlert, Cross } from 'lucide-react';
+import { ArrowLeft, Clock, MapPin, Radio, ShieldAlert, Cross, Users } from 'lucide-react';
 import type { ConvoyPlan, ConvoyPlanStatus, RiskAssessmentLevel, ManifestEntry, LocationInventoryItem } from '@/lib/types';
 import Card from '@/components/ui/Card';
 import OriginInventoryTable from '@/components/transportation/OriginInventoryTable';
 import ManifestSummary from '@/components/transportation/ManifestSummary';
 import AddToManifestModal from '@/components/transportation/AddToManifestModal';
+import PersonnelAssignmentModal from '@/components/transportation/PersonnelAssignmentModal';
+import ConvoyManifestView from '@/components/transportation/ConvoyManifestView';
 
 // ---------------------------------------------------------------------------
 // Badge helpers (duplicated for isolation; could be shared in a util)
@@ -78,6 +80,8 @@ export default function ConvoyPlanDetail({
   const [manifest, setManifest] = useState<ManifestEntry[]>([]);
   const [selectedItem, setSelectedItem] = useState<LocationInventoryItem | null>(null);
   const [editingEntry, setEditingEntry] = useState<ManifestEntry | null>(null);
+  const [assignModalOpen, setAssignModalOpen] = useState(false);
+  const [assignVehicle, setAssignVehicle] = useState<{id: number; tamcn: string; vehicleType: string; bumperNumber: string} | null>(null);
 
   const handleAddToManifest = (entry: ManifestEntry) => {
     setManifest(prev => {
@@ -212,6 +216,29 @@ export default function ConvoyPlanDetail({
             }}
           >
             MARCH TABLE
+          </button>
+          <button
+            onClick={() => {
+              setAssignVehicle({ id: 1, tamcn: 'D1100', vehicleType: 'HMMWV M1151', bumperNumber: 'S1-V1' });
+              setAssignModalOpen(true);
+            }}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 4,
+              padding: '5px 12px',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 9,
+              fontWeight: 600,
+              letterSpacing: '0.5px',
+              color: 'var(--color-accent)',
+              backgroundColor: 'rgba(77, 171, 247, 0.1)',
+              border: '1px solid var(--color-accent)',
+              borderRadius: 'var(--radius)',
+              cursor: 'pointer',
+            }}
+          >
+            <Users size={11} /> ASSIGN CREW
           </button>
           {plan.status === 'DRAFT' && (
             <button
@@ -385,6 +412,11 @@ export default function ConvoyPlanDetail({
         </div>
       </Card>
 
+      {/* Manifest */}
+      <Card title="MANIFEST">
+        <ConvoyManifestView movementId={plan.movement_id ?? 0} />
+      </Card>
+
       {/* Contingencies */}
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 16 }}>
         <Card>
@@ -439,6 +471,20 @@ export default function ConvoyPlanDetail({
         existingEntry={editingEntry}
         onClose={() => { setSelectedItem(null); setEditingEntry(null); }}
         onAdd={handleAddToManifest}
+      />
+
+      {/* Personnel Assignment Modal */}
+      <PersonnelAssignmentModal
+        isOpen={assignModalOpen && assignVehicle != null}
+        onClose={() => { setAssignModalOpen(false); setAssignVehicle(null); }}
+        vehicleId={assignVehicle?.id ?? 0}
+        vehicleTamcn={assignVehicle?.tamcn ?? 'D1100'}
+        vehicleType={assignVehicle?.vehicleType ?? 'HMMWV'}
+        bumperNumber={assignVehicle?.bumperNumber ?? ''}
+        movementId={plan.movement_id ?? 0}
+        onSave={(assignments) => {
+          console.log('Personnel assignments saved:', assignments);
+        }}
       />
     </div>
   );

--- a/frontend/src/components/transportation/PersonnelAssignmentModal.tsx
+++ b/frontend/src/components/transportation/PersonnelAssignmentModal.tsx
@@ -1,0 +1,510 @@
+// =============================================================================
+// PersonnelAssignmentModal — Assign personnel to convoy vehicle positions
+// =============================================================================
+
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Users, Shield, Truck, X, Plus, AlertTriangle } from 'lucide-react';
+import { getQualifiedPersonnel } from '@/api/personnel';
+import type { QualifiedPersonnelItem } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface PersonnelAssignmentModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  vehicleId: number;
+  vehicleTamcn: string;
+  vehicleType: string;
+  bumperNumber: string;
+  movementId: number;
+  onSave: (assignments: { role: string; personnel_id: number }[]) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Crew roles
+// ---------------------------------------------------------------------------
+
+const CREW_ROLES: { key: string; label: string; required: boolean }[] = [
+  { key: 'DRIVER', label: 'DRIVER', required: true },
+  { key: 'A_DRIVER', label: 'ASSISTANT DRIVER', required: false },
+  { key: 'TC', label: 'TRUCK COMMANDER', required: false },
+  { key: 'VC', label: 'VEHICLE COMMANDER', required: false },
+  { key: 'GUNNER', label: 'GUNNER', required: false },
+  { key: 'MEDIC', label: 'MEDIC', required: false },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function PersonnelAssignmentModal({
+  isOpen,
+  onClose,
+  vehicleId,
+  vehicleTamcn,
+  vehicleType,
+  bumperNumber,
+  movementId,
+  onSave,
+}: PersonnelAssignmentModalProps) {
+  const [selections, setSelections] = useState<Record<string, number | null>>({
+    DRIVER: null,
+    A_DRIVER: null,
+    TC: null,
+    VC: null,
+    GUNNER: null,
+    MEDIC: null,
+  });
+  const [paxList, setPaxList] = useState<number[]>([]);
+  const [paxDropdownValue, setPaxDropdownValue] = useState<number | null>(null);
+
+  // Fetch qualified personnel for each role
+  const driverQuery = useQuery({
+    queryKey: ['qualified-personnel', 'DRIVER', vehicleTamcn],
+    queryFn: () => getQualifiedPersonnel('DRIVER', vehicleTamcn),
+    enabled: isOpen,
+  });
+  const aDriverQuery = useQuery({
+    queryKey: ['qualified-personnel', 'A_DRIVER', vehicleTamcn],
+    queryFn: () => getQualifiedPersonnel('A_DRIVER', vehicleTamcn),
+    enabled: isOpen,
+  });
+  const tcQuery = useQuery({
+    queryKey: ['qualified-personnel', 'TC', vehicleTamcn],
+    queryFn: () => getQualifiedPersonnel('TC', vehicleTamcn),
+    enabled: isOpen,
+  });
+  const vcQuery = useQuery({
+    queryKey: ['qualified-personnel', 'VC', vehicleTamcn],
+    queryFn: () => getQualifiedPersonnel('VC', vehicleTamcn),
+    enabled: isOpen,
+  });
+  const gunnerQuery = useQuery({
+    queryKey: ['qualified-personnel', 'GUNNER', vehicleTamcn],
+    queryFn: () => getQualifiedPersonnel('GUNNER', vehicleTamcn),
+    enabled: isOpen,
+  });
+  const medicQuery = useQuery({
+    queryKey: ['qualified-personnel', 'MEDIC', vehicleTamcn],
+    queryFn: () => getQualifiedPersonnel('MEDIC', vehicleTamcn),
+    enabled: isOpen,
+  });
+  const paxQuery = useQuery({
+    queryKey: ['qualified-personnel', 'PAX', vehicleTamcn],
+    queryFn: () => getQualifiedPersonnel('PAX', vehicleTamcn),
+    enabled: isOpen,
+  });
+
+  const queryMap: Record<string, typeof driverQuery> = {
+    DRIVER: driverQuery,
+    A_DRIVER: aDriverQuery,
+    TC: tcQuery,
+    VC: vcQuery,
+    GUNNER: gunnerQuery,
+    MEDIC: medicQuery,
+  };
+
+  const canSave = useMemo(() => selections.DRIVER != null, [selections]);
+
+  const handleRoleChange = (role: string, personnelId: number | null) => {
+    setSelections((prev) => ({ ...prev, [role]: personnelId }));
+  };
+
+  const handleAddPax = () => {
+    if (paxDropdownValue != null && !paxList.includes(paxDropdownValue)) {
+      setPaxList((prev) => [...prev, paxDropdownValue]);
+      setPaxDropdownValue(null);
+    }
+  };
+
+  const handleRemovePax = (id: number) => {
+    setPaxList((prev) => prev.filter((p) => p !== id));
+  };
+
+  const handleSave = () => {
+    const assignments: { role: string; personnel_id: number }[] = [];
+    for (const [role, pid] of Object.entries(selections)) {
+      if (pid != null) {
+        assignments.push({ role, personnel_id: pid });
+      }
+    }
+    for (const pid of paxList) {
+      assignments.push({ role: 'PAX', personnel_id: pid });
+    }
+    onSave(assignments);
+    onClose();
+  };
+
+  const formatPersonnel = (p: QualifiedPersonnelItem): string =>
+    `${p.rank ?? ''} ${p.last_name}, ${p.first_name} (${p.mos ?? 'N/A'})`;
+
+  // ---------------------------------------------------------------------------
+  // Styles
+  // ---------------------------------------------------------------------------
+
+  const labelStyle: React.CSSProperties = {
+    fontFamily: 'var(--font-mono)',
+    fontSize: 9,
+    fontWeight: 600,
+    letterSpacing: '1px',
+    color: 'var(--color-text-muted)',
+    textTransform: 'uppercase',
+    marginBottom: 4,
+  };
+
+  const selectStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '6px 10px',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 11,
+    color: 'var(--color-text)',
+    backgroundColor: 'var(--color-bg)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 'var(--radius)',
+    appearance: 'auto' as React.CSSProperties['appearance'],
+  };
+
+  const badgeStyle: React.CSSProperties = {
+    display: 'inline-block',
+    padding: '1px 6px',
+    borderRadius: 2,
+    fontFamily: 'var(--font-mono)',
+    fontSize: 8,
+    fontWeight: 600,
+    letterSpacing: '0.5px',
+    color: 'var(--color-accent)',
+    backgroundColor: 'rgba(77, 171, 247, 0.1)',
+    border: '1px solid rgba(77, 171, 247, 0.3)',
+    marginRight: 4,
+    marginTop: 4,
+  };
+
+  const requiredBadge: React.CSSProperties = {
+    ...badgeStyle,
+    color: '#f87171',
+    backgroundColor: 'rgba(248, 113, 113, 0.1)',
+    border: '1px solid rgba(248, 113, 113, 0.3)',
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div style={{ position: 'fixed', inset: 0, zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div onClick={onClose} style={{ position: 'absolute', inset: 0, backgroundColor: 'rgba(0,0,0,0.7)' }} />
+      <div
+        style={{
+          position: 'relative',
+          width: 700,
+          maxHeight: '80vh',
+          overflow: 'auto',
+          backgroundColor: 'var(--color-bg-card)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius)',
+          padding: 24,
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <Users size={16} style={{ color: 'var(--color-accent)' }} />
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 13,
+                fontWeight: 700,
+                letterSpacing: '1px',
+                color: 'var(--color-text-bright)',
+              }}
+            >
+              ASSIGN PERSONNEL
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 28,
+              height: 28,
+              backgroundColor: 'transparent',
+              border: '1px solid var(--color-border)',
+              borderRadius: 'var(--radius)',
+              color: 'var(--color-text-muted)',
+              cursor: 'pointer',
+            }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* Vehicle Info */}
+        <div
+          style={{
+            display: 'flex',
+            gap: 16,
+            padding: '10px 14px',
+            marginBottom: 20,
+            backgroundColor: 'var(--color-bg-elevated)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius)',
+          }}
+        >
+          <div>
+            <div style={labelStyle}>VEHICLE TYPE</div>
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-text-bright)', fontWeight: 600 }}>
+              <Truck size={12} style={{ marginRight: 4, verticalAlign: 'middle' }} />
+              {vehicleType}
+            </div>
+          </div>
+          <div>
+            <div style={labelStyle}>BUMPER #</div>
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-text)', fontWeight: 600 }}>
+              {bumperNumber}
+            </div>
+          </div>
+          <div>
+            <div style={labelStyle}>TAMCN</div>
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-accent)', fontWeight: 600 }}>
+              {vehicleTamcn}
+            </div>
+          </div>
+        </div>
+
+        {/* Crew Roles */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14, marginBottom: 20 }}>
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 9,
+              fontWeight: 600,
+              letterSpacing: '1.5px',
+              color: 'var(--color-text-muted)',
+              textTransform: 'uppercase',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
+            <Shield size={12} /> CREW ASSIGNMENTS
+          </div>
+
+          {CREW_ROLES.map((role) => {
+            const query = queryMap[role.key];
+            const personnelList = query?.data?.personnel ?? [];
+            const requiredQuals = query?.data?.required_qualifications ?? [];
+            const isLoading = query?.isLoading ?? false;
+            const isEmpty = !isLoading && personnelList.length === 0;
+
+            return (
+              <div key={role.key}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+                  <span style={labelStyle}>{role.label}</span>
+                  {role.required && (
+                    <span style={requiredBadge}>REQUIRED</span>
+                  )}
+                </div>
+                <select
+                  value={selections[role.key] ?? ''}
+                  onChange={(e) =>
+                    handleRoleChange(role.key, e.target.value ? Number(e.target.value) : null)
+                  }
+                  disabled={isLoading}
+                  style={{
+                    ...selectStyle,
+                    opacity: isLoading ? 0.5 : 1,
+                  }}
+                >
+                  <option value="">-- Select {role.label} --</option>
+                  {personnelList.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {formatPersonnel(p)}
+                    </option>
+                  ))}
+                </select>
+                {/* Required qualifications badges */}
+                {requiredQuals.length > 0 && (
+                  <div style={{ marginTop: 4 }}>
+                    {requiredQuals.map((q) => (
+                      <span key={q} style={badgeStyle}>{q.replace(/_/g, ' ')}</span>
+                    ))}
+                  </div>
+                )}
+                {/* No qualified personnel warning */}
+                {isEmpty && (
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 4,
+                      marginTop: 4,
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 10,
+                      color: '#f87171',
+                    }}
+                  >
+                    <AlertTriangle size={11} />
+                    No qualified personnel available
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* PAX Section */}
+        <div style={{ marginBottom: 20 }}>
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 9,
+              fontWeight: 600,
+              letterSpacing: '1.5px',
+              color: 'var(--color-text-muted)',
+              textTransform: 'uppercase',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              marginBottom: 8,
+            }}
+          >
+            <Users size={12} /> PASSENGERS (PAX)
+          </div>
+
+          {/* Current PAX list */}
+          {paxList.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 8 }}>
+              {paxList.map((pid) => {
+                const person = paxQuery.data?.personnel.find((p) => p.id === pid);
+                return (
+                  <div
+                    key={pid}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      padding: '4px 10px',
+                      backgroundColor: 'var(--color-bg-elevated)',
+                      border: '1px solid var(--color-border)',
+                      borderRadius: 'var(--radius)',
+                    }}
+                  >
+                    <span
+                      style={{
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 10,
+                        color: 'var(--color-text)',
+                      }}
+                    >
+                      {person ? formatPersonnel(person) : `Personnel #${pid}`}
+                    </span>
+                    <button
+                      onClick={() => handleRemovePax(pid)}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        width: 20,
+                        height: 20,
+                        backgroundColor: 'transparent',
+                        border: '1px solid rgba(248,113,113,0.3)',
+                        borderRadius: 2,
+                        color: '#f87171',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      <X size={10} />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Add PAX dropdown + button */}
+          <div style={{ display: 'flex', gap: 8 }}>
+            <select
+              value={paxDropdownValue ?? ''}
+              onChange={(e) => setPaxDropdownValue(e.target.value ? Number(e.target.value) : null)}
+              style={{ ...selectStyle, flex: 1 }}
+              disabled={paxQuery.isLoading}
+            >
+              <option value="">-- Select Passenger --</option>
+              {(paxQuery.data?.personnel ?? [])
+                .filter((p) => !paxList.includes(p.id))
+                .map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {formatPersonnel(p)}
+                  </option>
+                ))}
+            </select>
+            <button
+              onClick={handleAddPax}
+              disabled={paxDropdownValue == null}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+                padding: '6px 12px',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 9,
+                fontWeight: 600,
+                color: paxDropdownValue != null ? 'var(--color-accent)' : 'var(--color-text-muted)',
+                backgroundColor: 'transparent',
+                border: '1px solid var(--color-border)',
+                borderRadius: 'var(--radius)',
+                cursor: paxDropdownValue != null ? 'pointer' : 'default',
+                opacity: paxDropdownValue != null ? 1 : 0.5,
+              }}
+            >
+              <Plus size={12} /> ADD
+            </button>
+          </div>
+        </div>
+
+        {/* Footer buttons */}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, borderTop: '1px solid var(--color-border)', paddingTop: 16 }}>
+          <button
+            onClick={onClose}
+            style={{
+              padding: '6px 16px',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              fontWeight: 600,
+              letterSpacing: '0.5px',
+              color: 'var(--color-text-muted)',
+              backgroundColor: 'transparent',
+              border: '1px solid var(--color-border)',
+              borderRadius: 'var(--radius)',
+              cursor: 'pointer',
+            }}
+          >
+            CANCEL
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!canSave}
+            style={{
+              padding: '6px 16px',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              fontWeight: 600,
+              letterSpacing: '0.5px',
+              color: canSave ? '#4ade80' : 'var(--color-text-muted)',
+              backgroundColor: canSave ? 'rgba(74, 222, 128, 0.1)' : 'transparent',
+              border: canSave ? '1px solid rgba(74, 222, 128, 0.4)' : '1px solid var(--color-border)',
+              borderRadius: 'var(--radius)',
+              cursor: canSave ? 'pointer' : 'default',
+              opacity: canSave ? 1 : 0.5,
+            }}
+          >
+            SAVE ASSIGNMENTS
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1275,6 +1275,7 @@ export interface PersonnelRecord {
   swim_qual: SwimQual | null; security_clearance: SecurityClearanceLevel | null;
   clearance_expiry: string | null; drivers_license_military: boolean;
   duty_status: DutyStatusType; status: string;
+  current_movement_id?: number | null;
 }
 
 export interface BilletRecord {
@@ -1366,6 +1367,7 @@ export interface ConvoyPlan {
   created_at: string;
   updated_at: string;
   serials: ConvoySerial[];
+  movement_id?: number | null;
 }
 
 export interface MarchTableData {
@@ -1916,4 +1918,70 @@ export interface ManifestEntry {
   special_handling?: string;
   weight_lbs?: number;
   added_at: string;
+}
+
+// --- Transportation Personnel Assignment & Certification Verification ---
+
+export type QualificationType =
+  | 'MILITARY_DRIVER' | 'HMMWV_LICENSE' | 'MTVR_LICENSE' | 'JLTV_LICENSE'
+  | 'LVSR_LICENSE' | 'LAV_LICENSE' | 'ACV_LICENSE' | 'WEAPONS_QUAL' | 'TCCC' | 'MOS_8404';
+
+export interface ConvoyCargoItem {
+  id: number;
+  movement_id: number;
+  convoy_vehicle_id: number;
+  description: string | null;
+  quantity: number;
+  weight_lbs: number | null;
+  is_hazmat: boolean;
+  supply_catalog_item_id: number | null;
+  equipment_catalog_item_id: number | null;
+}
+
+export interface QualifiedPersonnelItem {
+  id: number;
+  edipi: string;
+  rank: string | null;
+  first_name: string;
+  last_name: string;
+  mos: string | null;
+  pay_grade: string | null;
+  is_assigned_to_movement: boolean;
+  qualifications: { qualification_type: string; qualification_name: string; is_current: boolean; expiration_date: string | null }[];
+}
+
+export interface QualifiedPersonnelResponse {
+  personnel: QualifiedPersonnelItem[];
+  total: number;
+  required_qualifications: string[];
+}
+
+export interface ValidateAssignmentRequest {
+  personnel_id: number;
+  role: string;
+  vehicle_tamcn: string;
+  movement_id: number;
+}
+
+export interface ValidateAssignmentResponse {
+  valid: boolean;
+  reason: string;
+  missing_qualifications: string[];
+  assigned_to_other_vehicle: boolean;
+}
+
+export interface FullManifestVehicle {
+  convoy_vehicle_id: number;
+  bumper_number: string;
+  vehicle_type: string;
+  tamcn: string;
+  personnel: { role: string; id: number; rank: string; name: string }[];
+  cargo: ConvoyCargoItem[];
+  total_cargo_weight: number;
+}
+
+export interface FullManifestResponse {
+  movement_id: number;
+  convoy_id: string;
+  vehicles: FullManifestVehicle[];
 }


### PR DESCRIPTION
## Summary
- **Convoy crew assignment** with role-specific qualification verification (DRIVER needs MILITARY_DRIVER + vehicle license, TC needs E5+, VC needs E6+/Officer, GUNNER needs WEAPONS_QUAL, MEDIC needs MOS 8404 or TCCC, PAX has no requirements)
- **ConvoyCargo model** for tracking supplies/equipment loaded on convoy vehicles with catalog item references
- **Live personnel tracking** via `current_movement_id` — set when convoy goes EN_ROUTE, cleared on COMPLETE
- **LOCATION column** on Alpha Roster showing EN ROUTE badge or PRESENT status
- **Security hardened**: unit access checks on validate-assignment, role input validation, Pydantic field constraints on cargo weight/quantity

## Changes
### Backend
- `models/transportation.py` — ConvoyCargo model, VEHICLE_LICENSE_REQUIREMENTS dict
- `models/personnel.py` — current_movement_id FK on Personnel, cargo relationship on ConvoyVehicle
- `api/transportation.py` — validate-assignment, cargo CRUD, movement status propagation
- `api/personnel.py` — GET /qualified endpoint with role-based filtering
- `schemas/transportation.py` — ConvoyCargo, ValidateAssignment, QualifiedPersonnel schemas

### Frontend
- `PersonnelAssignmentModal.tsx` — Modal with per-role dropdowns using TanStack Query
- `ConvoyManifestView.tsx` — Full convoy manifest display with crew and cargo
- `ConvoyPlanDetail.tsx` — ASSIGN CREW button, MANIFEST section
- `AlphaRosterTable.tsx` — LOCATION column with EN ROUTE/PRESENT badges
- `types.ts`, `personnel.ts`, `transportation.ts` — Types and API layer

## Test plan
- [x] Python compile check (`python3 -m py_compile`) on all changed backend files
- [x] Ruff lint pass on backend
- [x] TypeScript build pass (`npx tsc -b`)
- [x] DevSecOps review — 4 medium findings, 3 fixed (M-1 unit access, M-2 field constraints, M-3 role validation)
- [x] Smoke test — PersonnelAssignmentModal renders with correct qualification filtering per role
- [x] Smoke test — Alpha Roster LOCATION column shows PRESENT for all personnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)