### PR TITLE
fix: ruff format backend to pass DSOP CI

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -94,4 +94,6 @@ api_router.include_router(
     custody_router, prefix="/custody", tags=["Custody & Accountability"]
 )
 api_router.include_router(rbac_router, prefix="/rbac", tags=["RBAC"])
-api_router.include_router(predictions_router, prefix="/predictions", tags=["Predictions"])
+api_router.include_router(
+    predictions_router, prefix="/predictions", tags=["Predictions"]
+)

--- a/backend/app/api/alerts.py
+++ b/backend/app/api/alerts.py
@@ -341,9 +341,7 @@ async def evaluate_alert_rule(
     return {
         "rule_id": rule_id,
         "alerts_fired": len(alerts),
-        "message": (
-            f"Rule '{rule.name}' evaluated: {len(alerts)} alert(s) fired"
-        ),
+        "message": (f"Rule '{rule.name}' evaluated: {len(alerts)} alert(s) fired"),
     }
 
 

--- a/backend/app/api/personnel.py
+++ b/backend/app/api/personnel.py
@@ -156,17 +156,36 @@ async def get_qualified_personnel(
 
     # E5+ pay grades
     e5_plus = {
-        PayGrade.E5, PayGrade.E6, PayGrade.E7, PayGrade.E8, PayGrade.E9,
+        PayGrade.E5,
+        PayGrade.E6,
+        PayGrade.E7,
+        PayGrade.E8,
+        PayGrade.E9,
     }
     # E6+ pay grades
     e6_plus = {
-        PayGrade.E6, PayGrade.E7, PayGrade.E8, PayGrade.E9,
+        PayGrade.E6,
+        PayGrade.E7,
+        PayGrade.E8,
+        PayGrade.E9,
     }
     # Officer / warrant pay grades
     officer_grades = {
-        PayGrade.W1, PayGrade.W2, PayGrade.W3, PayGrade.W4, PayGrade.W5,
-        PayGrade.O1, PayGrade.O2, PayGrade.O3, PayGrade.O4, PayGrade.O5,
-        PayGrade.O6, PayGrade.O7, PayGrade.O8, PayGrade.O9, PayGrade.O10,
+        PayGrade.W1,
+        PayGrade.W2,
+        PayGrade.W3,
+        PayGrade.W4,
+        PayGrade.W5,
+        PayGrade.O1,
+        PayGrade.O2,
+        PayGrade.O3,
+        PayGrade.O4,
+        PayGrade.O5,
+        PayGrade.O6,
+        PayGrade.O7,
+        PayGrade.O8,
+        PayGrade.O9,
+        PayGrade.O10,
     }
 
     def has_current_qual(person: Personnel, qual_name: str) -> bool:
@@ -211,8 +230,7 @@ async def get_qualified_personnel(
                 person.pay_grade in e5_plus
                 and has_current_qual(person, "MILITARY_DRIVER")
                 and (
-                    vehicle_license is None
-                    or has_current_qual(person, vehicle_license)
+                    vehicle_license is None or has_current_qual(person, vehicle_license)
                 )
             )
 
@@ -239,7 +257,9 @@ async def get_qualified_personnel(
                     "qualification_name": q.qualification_name,
                     "qualification_type": q.qualification_type,
                     "is_current": q.is_current,
-                    "expiration_date": str(q.expiration_date) if q.expiration_date else None,
+                    "expiration_date": str(q.expiration_date)
+                    if q.expiration_date
+                    else None,
                 }
                 for q in person.qualifications
             ]

--- a/backend/app/api/predictions.py
+++ b/backend/app/api/predictions.py
@@ -38,14 +38,10 @@ async def list_recommendations(
     if status:
         query = query.where(LogisticsRecommendation.status == status)
     if target_unit_id:
-        query = query.where(
-            LogisticsRecommendation.target_unit_id == target_unit_id
-        )
+        query = query.where(LogisticsRecommendation.target_unit_id == target_unit_id)
     result = await db.execute(query)
     recs = result.scalars().all()
-    return [
-        LogisticsRecommendationResponse.model_validate(r) for r in recs
-    ]
+    return [LogisticsRecommendationResponse.model_validate(r) for r in recs]
 
 
 @router.get(

--- a/backend/app/api/transportation.py
+++ b/backend/app/api/transportation.py
@@ -241,7 +241,9 @@ async def validate_assignment(
     # Validate role against ConvoyRole enum
     valid_roles = {"DRIVER", "A_DRIVER", "GUNNER", "TC", "VC", "MEDIC", "PAX"}
     if data.role.upper() not in valid_roles:
-        raise BadRequestError(f"Invalid role: {data.role}. Must be one of {', '.join(sorted(valid_roles))}")
+        raise BadRequestError(
+            f"Invalid role: {data.role}. Must be one of {', '.join(sorted(valid_roles))}"
+        )
 
     # Check if already assigned to another vehicle in this movement
     cp_result = await db.execute(
@@ -271,15 +273,34 @@ async def validate_assignment(
     from app.models.personnel import PayGrade
 
     e5_plus = {
-        PayGrade.E5, PayGrade.E6, PayGrade.E7, PayGrade.E8, PayGrade.E9,
+        PayGrade.E5,
+        PayGrade.E6,
+        PayGrade.E7,
+        PayGrade.E8,
+        PayGrade.E9,
     }
     e6_plus = {
-        PayGrade.E6, PayGrade.E7, PayGrade.E8, PayGrade.E9,
+        PayGrade.E6,
+        PayGrade.E7,
+        PayGrade.E8,
+        PayGrade.E9,
     }
     officer_grades = {
-        PayGrade.W1, PayGrade.W2, PayGrade.W3, PayGrade.W4, PayGrade.W5,
-        PayGrade.O1, PayGrade.O2, PayGrade.O3, PayGrade.O4, PayGrade.O5,
-        PayGrade.O6, PayGrade.O7, PayGrade.O8, PayGrade.O9, PayGrade.O10,
+        PayGrade.W1,
+        PayGrade.W2,
+        PayGrade.W3,
+        PayGrade.W4,
+        PayGrade.W5,
+        PayGrade.O1,
+        PayGrade.O2,
+        PayGrade.O3,
+        PayGrade.O4,
+        PayGrade.O5,
+        PayGrade.O6,
+        PayGrade.O7,
+        PayGrade.O8,
+        PayGrade.O9,
+        PayGrade.O10,
     }
 
     if role_upper in ("DRIVER", "A_DRIVER"):

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,7 +11,12 @@ from app.models.equipment import (
     FaultSeverity,
     EquipmentDriverAssignment,
 )
-from app.models.transportation import Movement, MovementStatus, ConvoyCargo, VEHICLE_LICENSE_REQUIREMENTS
+from app.models.transportation import (
+    Movement,
+    MovementStatus,
+    ConvoyCargo,
+    VEHICLE_LICENSE_REQUIREMENTS,
+)
 from app.models.convoy_planning import (
     ConvoyPlan,
     ConvoySerial,

--- a/backend/app/models/alert.py
+++ b/backend/app/models/alert.py
@@ -190,7 +190,9 @@ class AlertRule(Base):
     recommend_assign_to_role = Column(String(20), nullable=True)
 
     scope_unit = relationship("Unit", foreign_keys=[scope_unit_id])
-    recommend_source_unit = relationship("Unit", foreign_keys=[recommend_source_unit_id])
+    recommend_source_unit = relationship(
+        "Unit", foreign_keys=[recommend_source_unit_id]
+    )
 
 
 class Notification(Base):

--- a/backend/app/models/maintenance.py
+++ b/backend/app/models/maintenance.py
@@ -99,7 +99,9 @@ class MaintenanceWorkOrder(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     completed_at = Column(DateTime(timezone=True), nullable=True)
     assigned_to = Column(String(100), nullable=True)
-    assigned_to_id = Column(Integer, ForeignKey("personnel.id"), nullable=True, index=True)
+    assigned_to_id = Column(
+        Integer, ForeignKey("personnel.id"), nullable=True, index=True
+    )
     assigned_to_user = relationship("Personnel", foreign_keys=[assigned_to_id])
     team_assignments = relationship(
         "WorkOrderAssignment",
@@ -202,7 +204,9 @@ class WorkOrderAssignment(Base):
         nullable=False,
         index=True,
     )
-    role = Column(SQLEnum(AssignmentRole), nullable=False, default=AssignmentRole.SUPPORT)
+    role = Column(
+        SQLEnum(AssignmentRole), nullable=False, default=AssignmentRole.SUPPORT
+    )
     assigned_at = Column(DateTime(timezone=True), server_default=func.now())
     unassigned_at = Column(DateTime(timezone=True), nullable=True)
 

--- a/backend/app/models/personnel.py
+++ b/backend/app/models/personnel.py
@@ -136,7 +136,10 @@ class Personnel(Base):
     duty_status = Column(SQLEnum(DutyStatus), nullable=True, default=DutyStatus.PRESENT)
 
     current_movement_id = Column(
-        Integer, ForeignKey("movements.id", ondelete="SET NULL"), nullable=True, index=True
+        Integer,
+        ForeignKey("movements.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
     )
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/prediction.py
+++ b/backend/app/models/prediction.py
@@ -33,15 +33,11 @@ class LogisticsRecommendation(Base):
 
     # What triggered this?
     recommendation_type = Column(String(30), nullable=False)
-    triggered_by_rule_id = Column(
-        Integer, ForeignKey("alert_rules.id"), nullable=True
-    )
+    triggered_by_rule_id = Column(Integer, ForeignKey("alert_rules.id"), nullable=True)
     triggered_by_metric = Column(String(200), nullable=True)
 
     # What's recommended?
-    target_unit_id = Column(
-        Integer, ForeignKey("units.id"), nullable=False, index=True
-    )
+    target_unit_id = Column(Integer, ForeignKey("units.id"), nullable=False, index=True)
     description = Column(Text, nullable=False)
 
     # Details
@@ -56,9 +52,7 @@ class LogisticsRecommendation(Base):
 
     # Approval workflow
     status = Column(String(20), default="PENDING", index=True)
-    assigned_to_user_id = Column(
-        Integer, ForeignKey("users.id"), nullable=True
-    )
+    assigned_to_user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     assigned_to_role = Column(String(20), nullable=True)
 
     # Outcomes

--- a/backend/app/services/maintenance_analytics.py
+++ b/backend/app/services/maintenance_analytics.py
@@ -346,7 +346,9 @@ class MaintenanceAnalytics:
                 Personnel.mos,
                 MaintenanceLabor.labor_type,
                 func.sum(MaintenanceLabor.hours).label("hours"),
-                func.count(func.distinct(MaintenanceLabor.work_order_id)).label("wo_count"),
+                func.count(func.distinct(MaintenanceLabor.work_order_id)).label(
+                    "wo_count"
+                ),
             )
             .select_from(MaintenanceLabor)
             .join(Personnel, MaintenanceLabor.personnel_id == Personnel.id)
@@ -406,13 +408,21 @@ class MaintenanceAnalytics:
                 func.count(MaintenanceWorkOrder.id).label("total_wos"),
                 func.sum(
                     sql_case(
-                        (MaintenanceWorkOrder.category == WorkOrderCategory.CORRECTIVE, 1),
+                        (
+                            MaintenanceWorkOrder.category
+                            == WorkOrderCategory.CORRECTIVE,
+                            1,
+                        ),
                         else_=0,
                     )
                 ).label("corrective"),
                 func.sum(
                     sql_case(
-                        (MaintenanceWorkOrder.category == WorkOrderCategory.PREVENTIVE, 1),
+                        (
+                            MaintenanceWorkOrder.category
+                            == WorkOrderCategory.PREVENTIVE,
+                            1,
+                        ),
                         else_=0,
                     )
                 ).label("preventive"),
@@ -588,15 +598,17 @@ class MaintenanceAnalytics:
             elif trend == "DEGRADING":
                 score = max(0, score - 20)
 
-            results.append({
-                "equipment_type": eq_type,
-                "mtbf_days": round(mtbf, 1),
-                "mttr_hours": round(mttr, 1),
-                "mtbf_trend": trend,
-                "corrective_wos_total": len(wos),
-                "last_corrective_date": wos[-1][0].isoformat() if wos else None,
-                "health_score": score,
-            })
+            results.append(
+                {
+                    "equipment_type": eq_type,
+                    "mtbf_days": round(mtbf, 1),
+                    "mttr_hours": round(mttr, 1),
+                    "mtbf_trend": trend,
+                    "corrective_wos_total": len(wos),
+                    "last_corrective_date": wos[-1][0].isoformat() if wos else None,
+                    "health_score": score,
+                }
+            )
 
         return sorted(results, key=lambda x: x["mtbf_days"])
 

--- a/backend/app/services/prediction_engine.py
+++ b/backend/app/services/prediction_engine.py
@@ -40,9 +40,7 @@ class PredictionEngine:
         if rec_type == "RESUPPLY":
             rec = await self._build_resupply(rule, target_unit, metric_desc)
         elif rec_type == "MAINTENANCE":
-            rec = await self._build_maintenance(
-                rule, target_unit, metric_desc
-            )
+            rec = await self._build_maintenance(rule, target_unit, metric_desc)
         elif rec_type == "FUEL_DELIVERY":
             rec = await self._build_fuel(rule, target_unit, metric_desc)
         elif rec_type == "PERSONNEL_MOVE":
@@ -54,8 +52,7 @@ class PredictionEngine:
             self.db.add(rec)
             await self.db.flush()
             logger.info(
-                f"Generated {rec_type} recommendation {rec.id} for "
-                f"alert rule {rule.id}"
+                f"Generated {rec_type} recommendation {rec.id} for alert rule {rule.id}"
             )
 
         return rec
@@ -99,9 +96,7 @@ class PredictionEngine:
             triggered_by_metric=metric_desc,
             target_unit_id=unit.id,
             description=f"Address maintenance backlog at {unit.name}",
-            recommended_items=[
-                {"category": "Open work orders", "count": 0}
-            ],
+            recommended_items=[{"category": "Open work orders", "count": 0}],
             status="PENDING",
             assigned_to_role=rule.recommend_assign_to_role or "CO",
             expires_at=datetime.now(timezone.utc) + timedelta(days=7),
@@ -124,9 +119,7 @@ class PredictionEngine:
             target_unit_id=unit.id,
             description=f"Deliver fuel to {unit.name} from {source_name}",
             recommended_source=source_name,
-            recommended_items=[
-                {"fuel_type": "JP-8", "quantity": 0, "unit": "gallons"}
-            ],
+            recommended_items=[{"fuel_type": "JP-8", "quantity": 0, "unit": "gallons"}],
             status="PENDING",
             assigned_to_role=rule.recommend_assign_to_role or "S4",
             expires_at=datetime.now(timezone.utc) + timedelta(hours=12),

--- a/backend/app/services/rule_engine.py
+++ b/backend/app/services/rule_engine.py
@@ -87,8 +87,7 @@ class RuleEngine:
                         await engine.generate_recommendation(rule, alert)
                 except Exception as e:
                     logger.error(
-                        f"Failed to generate recommendation for rule "
-                        f"{rule.id}: {e}"
+                        f"Failed to generate recommendation for rule {rule.id}: {e}"
                     )
 
         return alerts_generated
@@ -132,18 +131,14 @@ class RuleEngine:
 
     async def _get_subordinate_units(self, parent_id: int) -> List[Unit]:
         """Recursively get all subordinate units."""
-        result = await self.db.execute(
-            select(Unit).where(Unit.parent_id == parent_id)
-        )
+        result = await self.db.execute(select(Unit).where(Unit.parent_id == parent_id))
         children = list(result.scalars().all())
         all_subs = list(children)
         for child in children:
             all_subs.extend(await self._get_subordinate_units(child.id))
         return all_subs
 
-    async def _get_metric_value(
-        self, rule: AlertRule, unit: Unit
-    ) -> Optional[float]:
+    async def _get_metric_value(self, rule: AlertRule, unit: Unit) -> Optional[float]:
         """Query the database for the metric value."""
         metric = rule.metric_type or rule.metric
 
@@ -171,9 +166,7 @@ class RuleEngine:
         elif metric in ("READINESS_PCT", "equipment_readiness_pct"):
             from app.models.equipment import EquipmentStatus
 
-            query = select(EquipmentStatus).where(
-                EquipmentStatus.unit_id == unit.id
-            )
+            query = select(EquipmentStatus).where(EquipmentStatus.unit_id == unit.id)
             result = await self.db.execute(query)
             records = result.scalars().all()
             if not records:
@@ -210,27 +203,19 @@ class RuleEngine:
                 from app.models.fuel import FuelStorage
 
                 result = await self.db.execute(
-                    select(FuelStorage).where(
-                        FuelStorage.unit_id == unit.id
-                    )
+                    select(FuelStorage).where(FuelStorage.unit_id == unit.id)
                 )
                 storage = result.scalar_one_or_none()
                 if not storage or not storage.capacity_gallons:
                     return None
-                return (
-                    storage.current_gallons
-                    / storage.capacity_gallons
-                    * 100
-                )
+                return storage.current_gallons / storage.capacity_gallons * 100
             except Exception:
                 return None
 
         return None
 
     @staticmethod
-    def _check_condition(
-        operator: str, actual: float, threshold: float
-    ) -> bool:
+    def _check_condition(operator: str, actual: float, threshold: float) -> bool:
         """Check if operator(actual, threshold) is true."""
         ops = {
             "LT": lambda a, t: a < t,
@@ -244,9 +229,7 @@ class RuleEngine:
         return fn(actual, threshold) if fn else False
 
     @staticmethod
-    def _format_message(
-        rule: AlertRule, unit: Unit, metric_value: float
-    ) -> str:
+    def _format_message(rule: AlertRule, unit: Unit, metric_value: float) -> str:
         """Format a human-readable alert message."""
         metric_name = rule.metric_type or rule.metric
         op_symbols = {


### PR DESCRIPTION
## Summary

- Auto-format 13 backend Python files to pass the `ruff format --check .` step in the DSOP CI pipeline
- No functional changes — formatting only

## Test plan
- [x] `ruff format --check .` passes (200 files already formatted)
- [x] `ruff check .` passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)