### PR TITLE
fix: resolve all CI lint failures

### DIFF
--- a/backend/alembic/versions/002_initial_schema.py
+++ b/backend/alembic/versions/002_initial_schema.py
@@ -20,7 +20,6 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers
 revision: str = "002_initial_schema"

--- a/backend/app/api/ws.py
+++ b/backend/app/api/ws.py
@@ -1,6 +1,5 @@
 """WebSocket endpoint for real-time event broadcasting."""
 
-import json
 from typing import Set
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,7 @@ from app.config import settings
 from app.database import Base, engine, async_session
 from app.middleware.request_logging import RequestLoggingMiddleware
 from app.middleware.rate_limit import setup_rate_limiting
+from prometheus_fastapi_instrumentator import Instrumentator
 
 # ---------------------------------------------------------------------------
 # Structured logging configuration
@@ -557,7 +558,6 @@ app.add_middleware(RequestLoggingMiddleware)
 setup_rate_limiting(app)
 
 # Prometheus metrics instrumentation
-from prometheus_fastapi_instrumentator import Instrumentator
 Instrumentator().instrument(app).expose(app)
 
 # Include all API routers under /api/v1

--- a/backend/app/middleware/audit.py
+++ b/backend/app/middleware/audit.py
@@ -5,7 +5,6 @@ create / update / delete action.  This is intentionally decoupled from the
 Custody-specific ``AuditService`` so it can be used across all domains.
 """
 
-from datetime import datetime, timezone
 from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/backend/tests/test_api_auth.py
+++ b/backend/tests/test_api_auth.py
@@ -3,7 +3,7 @@
 import pytest
 from httpx import AsyncClient
 
-from app.models.user import Role, User
+from app.models.user import User
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_api_rbac.py
+++ b/backend/tests/test_api_rbac.py
@@ -5,7 +5,6 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.rbac import CustomRole, Permission
-from app.models.unit import Unit
 from app.models.user import User
 
 

--- a/backend/tests/test_api_readiness.py
+++ b/backend/tests/test_api_readiness.py
@@ -2,7 +2,6 @@
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.unit import Unit
 from app.models.user import User

--- a/backend/tests/test_api_reports.py
+++ b/backend/tests/test_api_reports.py
@@ -9,7 +9,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.report import (
     Report,
     ReportStatus,
-    ReportTemplate,
     ReportType,
 )
 from app.models.unit import Unit

--- a/backend/tests/test_api_requisitions.py
+++ b/backend/tests/test_api_requisitions.py
@@ -6,7 +6,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.requisition import (
     Requisition,
-    RequisitionLineItem,
     RequisitionPriority,
     RequisitionStatus,
 )

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestGenerateReportTask:
     """Tests for the generate_report_task Celery task."""
@@ -96,7 +94,7 @@ class TestProcessMIRCUploadTask:
         self, mock_parse, mock_normalize, mock_engine
     ):
         """process_mirc_upload handles empty parse results."""
-        from app.models.raw_data import ParseStatus, RawData, SourceType
+        from app.models.raw_data import ParseStatus, RawData
 
         mock_raw = MagicMock(spec=RawData)
         mock_raw.id = 1
@@ -126,7 +124,7 @@ class TestProcessMIRCUploadTask:
         self, mock_parse, mock_normalize, mock_engine
     ):
         """process_mirc_upload processes records successfully."""
-        from app.models.raw_data import ParseStatus, RawData, SourceType
+        from app.models.raw_data import ParseStatus, RawData
 
         mock_raw = MagicMock(spec=RawData)
         mock_raw.id = 1

--- a/frontend/src/api/sensitiveItemCatalog.ts
+++ b/frontend/src/api/sensitiveItemCatalog.ts
@@ -1,0 +1,189 @@
+// =============================================================================
+// Sensitive Item Catalog API — CRUD for catalog item types
+// Includes inline mock data for demo mode (falls back to static catalog)
+// =============================================================================
+
+import apiClient from './client';
+import { isDemoMode } from './mockClient';
+import {
+  SENSITIVE_ITEM_CATALOG,
+  searchCatalog as staticSearchCatalog,
+  type CatalogEntry,
+} from '@/data/sensitiveItemCatalog';
+import type { SensitiveItemType } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SensitiveItemCatalogItem {
+  id: number;
+  nomenclature: string;
+  nsn: string | null;
+  item_type: string;
+  tamcn: string | null;
+  aliases: string[];
+  is_active: boolean;
+}
+
+export interface SensitiveItemCatalogItemCreate {
+  nomenclature: string;
+  nsn?: string;
+  item_type: string;
+  tamcn?: string;
+  aliases?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Mock data derived from static catalog
+// ---------------------------------------------------------------------------
+
+let mockCatalogItems: SensitiveItemCatalogItem[] = SENSITIVE_ITEM_CATALOG.map(
+  (entry, index) => ({
+    id: index + 1,
+    nomenclature: entry.nomenclature,
+    nsn: entry.nsn,
+    item_type: entry.itemType,
+    tamcn: entry.tamcn ?? null,
+    aliases: entry.aliases,
+    is_active: true,
+  }),
+);
+
+let mockNextId = mockCatalogItems.length + 1;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockDelay = (ms = 100 + Math.random() * 100): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+function matchesQuery(q: string, ...fields: (string | null | undefined)[]): boolean {
+  const lower = q.toLowerCase();
+  return fields.some((f) => f != null && f.toLowerCase().includes(lower));
+}
+
+// ---------------------------------------------------------------------------
+// API Functions
+// ---------------------------------------------------------------------------
+
+/** GET /api/v1/catalog/items?q=searchterm&item_type=WEAPON */
+export async function getCatalogItems(params?: {
+  q?: string;
+  item_type?: string;
+}): Promise<SensitiveItemCatalogItem[]> {
+  if (isDemoMode) {
+    await mockDelay();
+    let results = [...mockCatalogItems];
+    if (params?.item_type) {
+      results = results.filter((i) => i.item_type === params.item_type);
+    }
+    if (params?.q && params.q.trim().length > 0) {
+      const q = params.q;
+      results = results.filter(
+        (i) =>
+          matchesQuery(q, i.nomenclature, i.nsn, i.item_type, i.tamcn) ||
+          i.aliases.some((a) => a.toLowerCase().includes(q.toLowerCase())),
+      );
+    }
+    return results;
+  }
+  const response = await apiClient.get<{ data: SensitiveItemCatalogItem[] }>(
+    '/catalog/items',
+    { params },
+  );
+  return response.data.data;
+}
+
+/** POST /api/v1/catalog/items */
+export async function createCatalogItem(
+  data: SensitiveItemCatalogItemCreate,
+): Promise<SensitiveItemCatalogItem> {
+  if (isDemoMode) {
+    await mockDelay();
+    const newItem: SensitiveItemCatalogItem = {
+      id: mockNextId++,
+      nomenclature: data.nomenclature,
+      nsn: data.nsn ?? null,
+      item_type: data.item_type,
+      tamcn: data.tamcn ?? null,
+      aliases: data.aliases ?? [],
+      is_active: true,
+    };
+    mockCatalogItems = [...mockCatalogItems, newItem];
+    return newItem;
+  }
+  const response = await apiClient.post<{ data: SensitiveItemCatalogItem }>(
+    '/catalog/items',
+    data,
+  );
+  return response.data.data;
+}
+
+/** PUT /api/v1/catalog/items/{id} */
+export async function updateCatalogItem(
+  id: number,
+  data: Partial<SensitiveItemCatalogItemCreate>,
+): Promise<SensitiveItemCatalogItem> {
+  if (isDemoMode) {
+    await mockDelay();
+    mockCatalogItems = mockCatalogItems.map((item) =>
+      item.id === id
+        ? {
+            ...item,
+            ...(data.nomenclature !== undefined && { nomenclature: data.nomenclature }),
+            ...(data.nsn !== undefined && { nsn: data.nsn ?? null }),
+            ...(data.item_type !== undefined && { item_type: data.item_type }),
+            ...(data.tamcn !== undefined && { tamcn: data.tamcn ?? null }),
+            ...(data.aliases !== undefined && { aliases: data.aliases ?? [] }),
+          }
+        : item,
+    );
+    const updated = mockCatalogItems.find((i) => i.id === id);
+    if (!updated) throw new Error('Item not found');
+    return updated;
+  }
+  const response = await apiClient.put<{ data: SensitiveItemCatalogItem }>(
+    `/catalog/items/${id}`,
+    data,
+  );
+  return response.data.data;
+}
+
+/** DELETE /api/v1/catalog/items/{id} */
+export async function deleteCatalogItem(id: number): Promise<void> {
+  if (isDemoMode) {
+    await mockDelay();
+    mockCatalogItems = mockCatalogItems.filter((i) => i.id !== id);
+    return;
+  }
+  await apiClient.delete(`/catalog/items/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// Catalog search for auto-complete (used by CustodyPage)
+// In demo mode: uses static catalog. In live mode: uses API.
+// ---------------------------------------------------------------------------
+
+export async function searchCatalogApi(
+  query: string,
+  limit = 8,
+): Promise<CatalogEntry[]> {
+  if (isDemoMode) {
+    return staticSearchCatalog(query, limit);
+  }
+  // In live mode, query the API and map to CatalogEntry format
+  if (!query || query.length < 2) return [];
+  const items = await getCatalogItems({ q: query });
+  return items
+    .filter((i) => i.is_active)
+    .slice(0, limit)
+    .map((i) => ({
+      nomenclature: i.nomenclature,
+      nsn: i.nsn ?? '',
+      itemType: i.item_type as SensitiveItemType,
+      tamcn: i.tamcn ?? undefined,
+      aliases: i.aliases,
+    }));
+}


### PR DESCRIPTION
## Summary
Fixes all failing lint checks in the DSOP pipeline:

**Frontend (2 errors):**
- Add missing `sensitiveItemCatalog.ts` — was created locally but never committed, causing `Cannot find module` errors in CustodyPage.tsx and CatalogManager.tsx

**Backend (10 errors):**
- Remove unused imports across 8 files (json, datetime, timezone, RequisitionLineItem, ReportTemplate, AsyncSession, Unit, Role, SourceType, pytest)
- Move `prometheus_fastapi_instrumentator` import to top of file (E402)
- Remove unused `sqlalchemy.dialects.postgresql` import from alembic migration

## Test plan
- [x] `ruff check .` → "All checks passed!"
- [x] `npx tsc --noEmit` → clean
- [ ] CI pipeline passes all lint jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)