### PR TITLE
fix: ruff format + mypy compliance for CI

### DIFF
--- a/backend/alembic/versions/002_initial_schema.py
+++ b/backend/alembic/versions/002_initial_schema.py
@@ -52,9 +52,21 @@ def upgrade() -> None:
         sa.Column("longitude", sa.Float(), nullable=True),
         sa.Column("mgrs", sa.String(length=30), nullable=True),
         sa.Column("mil_symbol_sidc", sa.String(length=30), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["parent_id"], ["units.id"]),
     )
@@ -70,11 +82,23 @@ def upgrade() -> None:
         sa.Column("full_name", sa.String(length=200), nullable=True),
         sa.Column("role", sa.String(length=50), nullable=False),
         sa.Column("unit_id", sa.Integer(), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")
+        ),
         sa.Column("custom_role_id", sa.Integer(), nullable=True),
         sa.Column("last_login", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -89,9 +113,21 @@ def upgrade() -> None:
         sa.Column("base_role", sa.String(length=50), nullable=False),
         sa.Column("unit_id", sa.Integer(), nullable=True),
         sa.Column("created_by_id", sa.Integer(), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
         sa.ForeignKeyConstraint(["created_by_id"], ["users.id"]),
@@ -124,7 +160,12 @@ def upgrade() -> None:
         sa.Column("key", sa.String(length=100), nullable=False),
         sa.Column("value", sa.Text(), nullable=True),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index("ix_system_settings_key", "system_settings", ["key"], unique=True)
@@ -137,7 +178,12 @@ def upgrade() -> None:
         sa.Column("amber_min", sa.Float(), nullable=False),
         sa.Column("red_min", sa.Float(), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
 
@@ -149,12 +195,24 @@ def upgrade() -> None:
         sa.Column("data_type", sa.String(length=50), nullable=False),
         sa.Column("category", sa.String(length=100), nullable=True),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("is_required", sa.Boolean(), nullable=True, server_default=sa.text("false")),
+        sa.Column(
+            "is_required", sa.Boolean(), nullable=True, server_default=sa.text("false")
+        ),
         sa.Column("validation_regex", sa.String(length=500), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index("ix_canonical_fields_field_name", "canonical_fields", ["field_name"], unique=True)
+    op.create_index(
+        "ix_canonical_fields_field_name",
+        "canonical_fields",
+        ["field_name"],
+        unique=True,
+    )
 
     # --- Catalog tables ---
 
@@ -167,10 +225,17 @@ def upgrade() -> None:
         sa.Column("category", sa.String(length=100), nullable=True),
         sa.Column("subcategory", sa.String(length=100), nullable=True),
         sa.Column("equipment_type", sa.String(length=100), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index("ix_equipment_catalog_tamcn", "equipment_catalog", ["tamcn"], unique=True)
+    op.create_index(
+        "ix_equipment_catalog_tamcn", "equipment_catalog", ["tamcn"], unique=True
+    )
 
     op.create_table(
         "supply_catalog",
@@ -181,7 +246,12 @@ def upgrade() -> None:
         sa.Column("supply_class", sa.String(length=20), nullable=False),
         sa.Column("unit_of_issue", sa.String(length=20), nullable=True),
         sa.Column("unit_price", sa.Float(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
 
@@ -194,10 +264,17 @@ def upgrade() -> None:
         sa.Column("ammunition_type", sa.String(length=100), nullable=True),
         sa.Column("unit_of_issue", sa.String(length=20), nullable=True),
         sa.Column("weight_per_round_lbs", sa.Float(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index("ix_ammunition_catalog_dodic", "ammunition_catalog", ["dodic"], unique=True)
+    op.create_index(
+        "ix_ammunition_catalog_dodic", "ammunition_catalog", ["dodic"], unique=True
+    )
 
     # --- Data management tables ---
 
@@ -209,9 +286,21 @@ def upgrade() -> None:
         sa.Column("source_type", sa.String(length=50), nullable=True),
         sa.Column("field_mappings", sa.JSON(), nullable=True),
         sa.Column("created_by_id", sa.Integer(), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["created_by_id"], ["users.id"]),
     )
@@ -226,8 +315,18 @@ def upgrade() -> None:
         sa.Column("last_sync_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("error_message", sa.Text(), nullable=True),
         sa.Column("created_by_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["created_by_id"], ["users.id"]),
     )
@@ -243,7 +342,12 @@ def upgrade() -> None:
         sa.Column("error_message", sa.Text(), nullable=True),
         sa.Column("uploaded_by_id", sa.Integer(), nullable=True),
         sa.Column("unit_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["uploaded_by_id"], ["users.id"]),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
@@ -258,7 +362,12 @@ def upgrade() -> None:
         sa.Column("records_processed", sa.Integer(), nullable=True),
         sa.Column("status", sa.String(length=50), nullable=True),
         sa.Column("error_message", sa.Text(), nullable=True),
-        sa.Column("processed_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "processed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["data_source_id"], ["data_sources.id"]),
     )
@@ -274,8 +383,18 @@ def upgrade() -> None:
         sa.Column("last_connected_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("error_message", sa.Text(), nullable=True),
         sa.Column("created_by_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["created_by_id"], ["users.id"]),
     )
@@ -294,9 +413,24 @@ def upgrade() -> None:
         sa.Column("dos", sa.Float(), nullable=True),
         sa.Column("consumption_rate", sa.Float(), nullable=True),
         sa.Column("status", sa.String(length=50), nullable=True),
-        sa.Column("reported_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "reported_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -314,8 +448,18 @@ def upgrade() -> None:
         sa.Column("category", sa.String(length=100), nullable=True),
         sa.Column("status", sa.String(length=50), nullable=True),
         sa.Column("location", sa.String(length=200), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -328,14 +472,45 @@ def upgrade() -> None:
         sa.Column("equipment_id", sa.Integer(), nullable=True),
         sa.Column("nomenclature", sa.String(length=300), nullable=True),
         sa.Column("tamcn", sa.String(length=20), nullable=True),
-        sa.Column("total_possessed", sa.Integer(), nullable=True, server_default=sa.text("0")),
-        sa.Column("total_required", sa.Integer(), nullable=True, server_default=sa.text("0")),
-        sa.Column("mission_capable", sa.Integer(), nullable=True, server_default=sa.text("0")),
-        sa.Column("not_mission_capable_maintenance", sa.Integer(), nullable=True, server_default=sa.text("0")),
-        sa.Column("not_mission_capable_supply", sa.Integer(), nullable=True, server_default=sa.text("0")),
-        sa.Column("reported_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "total_possessed", sa.Integer(), nullable=True, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "total_required", sa.Integer(), nullable=True, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "mission_capable", sa.Integer(), nullable=True, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "not_mission_capable_maintenance",
+            sa.Integer(),
+            nullable=True,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "not_mission_capable_supply",
+            sa.Integer(),
+            nullable=True,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "reported_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
         sa.ForeignKeyConstraint(["equipment_id"], ["equipment.id"]),
@@ -349,9 +524,16 @@ def upgrade() -> None:
         sa.Column("fault_description", sa.Text(), nullable=False),
         sa.Column("severity", sa.String(length=50), nullable=True),
         sa.Column("reported_by_id", sa.Integer(), nullable=True),
-        sa.Column("resolved", sa.Boolean(), nullable=True, server_default=sa.text("false")),
+        sa.Column(
+            "resolved", sa.Boolean(), nullable=True, server_default=sa.text("false")
+        ),
         sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["equipment_id"], ["equipment.id"]),
         sa.ForeignKeyConstraint(["reported_by_id"], ["users.id"]),
@@ -362,9 +544,16 @@ def upgrade() -> None:
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
         sa.Column("equipment_id", sa.Integer(), nullable=False),
         sa.Column("driver_id", sa.Integer(), nullable=False),
-        sa.Column("assigned_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "assigned_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.Column("unassigned_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["equipment_id"], ["equipment.id"]),
         sa.ForeignKeyConstraint(["driver_id"], ["users.id"]),
@@ -386,8 +575,18 @@ def upgrade() -> None:
         sa.Column("personnel_count", sa.Integer(), nullable=True),
         sa.Column("notes", sa.Text(), nullable=True),
         sa.Column("created_by_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
         sa.ForeignKeyConstraint(["created_by_id"], ["users.id"]),
@@ -409,8 +608,18 @@ def upgrade() -> None:
         sa.Column("route_description", sa.Text(), nullable=True),
         sa.Column("notes", sa.Text(), nullable=True),
         sa.Column("created_by_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
         sa.ForeignKeyConstraint(["movement_id"], ["movements.id"]),
@@ -424,7 +633,12 @@ def upgrade() -> None:
         sa.Column("serial_number", sa.Integer(), nullable=False),
         sa.Column("name", sa.String(length=200), nullable=True),
         sa.Column("order_in_convoy", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["convoy_plan_id"], ["convoy_plans.id"]),
     )
@@ -446,8 +660,18 @@ def upgrade() -> None:
         sa.Column("required_delivery_date", sa.DateTime(timezone=True), nullable=True),
         sa.Column("notes", sa.Text(), nullable=True),
         sa.Column("created_by_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["convoy_plan_id"], ["convoy_plans.id"]),
         sa.ForeignKeyConstraint(["requesting_unit_id"], ["units.id"]),
@@ -462,7 +686,12 @@ def upgrade() -> None:
         sa.Column("movement_id", sa.Integer(), nullable=True),
         sa.Column("position_in_serial", sa.Integer(), nullable=True),
         sa.Column("callsign", sa.String(length=50), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["convoy_serial_id"], ["convoy_serials.id"]),
         sa.ForeignKeyConstraint(["equipment_id"], ["equipment.id"]),
@@ -476,8 +705,15 @@ def upgrade() -> None:
         sa.Column("description", sa.Text(), nullable=True),
         sa.Column("weight_lbs", sa.Float(), nullable=True),
         sa.Column("cube_ft3", sa.Float(), nullable=True),
-        sa.Column("hazmat", sa.Boolean(), nullable=True, server_default=sa.text("false")),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "hazmat", sa.Boolean(), nullable=True, server_default=sa.text("false")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["convoy_vehicle_id"], ["convoy_vehicles.id"]),
     )
@@ -503,8 +739,18 @@ def upgrade() -> None:
         sa.Column("swim_qualification", sa.String(length=50), nullable=True),
         sa.Column("current_movement_id", sa.Integer(), nullable=True),
         sa.Column("user_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
         sa.ForeignKeyConstraint(["current_movement_id"], ["movements.id"]),
@@ -519,7 +765,12 @@ def upgrade() -> None:
         sa.Column("personnel_id", sa.Integer(), nullable=False),
         sa.Column("weapon_type", sa.String(length=100), nullable=False),
         sa.Column("serial_number", sa.String(length=100), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["personnel_id"], ["personnel.id"]),
     )
@@ -530,7 +781,12 @@ def upgrade() -> None:
         sa.Column("personnel_id", sa.Integer(), nullable=False),
         sa.Column("ammunition_type", sa.String(length=100), nullable=False),
         sa.Column("quantity", sa.Integer(), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["personnel_id"], ["personnel.id"]),
     )
@@ -541,7 +797,12 @@ def upgrade() -> None:
         sa.Column("convoy_vehicle_id", sa.Integer(), nullable=False),
         sa.Column("personnel_id", sa.Integer(), nullable=True),
         sa.Column("role", sa.String(length=50), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["convoy_vehicle_id"], ["convoy_vehicles.id"]),
         sa.ForeignKeyConstraint(["personnel_id"], ["personnel.id"]),
@@ -557,8 +818,18 @@ def upgrade() -> None:
         sa.Column("pay_grade", sa.String(length=10), nullable=False),
         sa.Column("billet_count", sa.Integer(), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -571,7 +842,12 @@ def upgrade() -> None:
         sa.Column("assigned", sa.Integer(), nullable=False),
         sa.Column("present_for_duty", sa.Integer(), nullable=True),
         sa.Column("snapshot_date", sa.Date(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -583,8 +859,15 @@ def upgrade() -> None:
         sa.Column("qualification_type", sa.String(length=100), nullable=False),
         sa.Column("qualification_name", sa.String(length=200), nullable=False),
         sa.Column("expiration_date", sa.Date(), nullable=True),
-        sa.Column("is_current", sa.Boolean(), nullable=True, server_default=sa.text("true")),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "is_current", sa.Boolean(), nullable=True, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["personnel_id"], ["personnel.id"]),
     )
@@ -600,11 +883,18 @@ def upgrade() -> None:
         sa.Column("unit_id", sa.Integer(), nullable=True),
         sa.Column("entity_type", sa.String(length=50), nullable=True),
         sa.Column("entity_id", sa.Integer(), nullable=True),
-        sa.Column("acknowledged", sa.Boolean(), nullable=True, server_default=sa.text("false")),
+        sa.Column(
+            "acknowledged", sa.Boolean(), nullable=True, server_default=sa.text("false")
+        ),
         sa.Column("acknowledged_by_id", sa.Integer(), nullable=True),
         sa.Column("acknowledged_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("rule_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
         sa.ForeignKeyConstraint(["acknowledged_by_id"], ["users.id"]),
@@ -624,21 +914,43 @@ def upgrade() -> None:
         sa.Column("operator", sa.String(length=50), nullable=True),
         sa.Column("threshold", sa.Float(), nullable=True),
         sa.Column("unit_id", sa.Integer(), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")
+        ),
         sa.Column("scope_type", sa.String(length=50), nullable=True),
         sa.Column("scope_echelon", sa.String(length=50), nullable=True),
-        sa.Column("include_subordinates", sa.Boolean(), nullable=True, server_default=sa.text("true")),
+        sa.Column(
+            "include_subordinates",
+            sa.Boolean(),
+            nullable=True,
+            server_default=sa.text("true"),
+        ),
         sa.Column("metric_type", sa.String(length=50), nullable=True),
         sa.Column("metric_item_filter", sa.String(length=200), nullable=True),
         sa.Column("notify_roles", sa.JSON(), nullable=True),
         sa.Column("check_interval_minutes", sa.Integer(), nullable=True),
-        sa.Column("auto_recommend", sa.Boolean(), nullable=True, server_default=sa.text("false")),
+        sa.Column(
+            "auto_recommend",
+            sa.Boolean(),
+            nullable=True,
+            server_default=sa.text("false"),
+        ),
         sa.Column("recommend_type", sa.String(length=50), nullable=True),
         sa.Column("recommend_source_unit_id", sa.Integer(), nullable=True),
         sa.Column("recommend_assign_to_role", sa.String(length=50), nullable=True),
         sa.Column("created_by_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
         sa.ForeignKeyConstraint(["created_by_id"], ["users.id"]),
@@ -653,7 +965,12 @@ def upgrade() -> None:
         sa.Column("channel", sa.String(length=50), nullable=True),
         sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("read_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["alert_id"], ["alerts.id"]),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
@@ -665,8 +982,15 @@ def upgrade() -> None:
         sa.Column("user_id", sa.Integer(), nullable=False),
         sa.Column("alert_type", sa.String(length=50), nullable=True),
         sa.Column("channel", sa.String(length=50), nullable=True),
-        sa.Column("is_enabled", sa.Boolean(), nullable=True, server_default=sa.text("true")),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "is_enabled", sa.Boolean(), nullable=True, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
     )
@@ -686,18 +1010,42 @@ def upgrade() -> None:
         sa.Column("echelon_of_maintenance", sa.String(length=50), nullable=True),
         sa.Column("maintenance_level", sa.String(length=50), nullable=True),
         sa.Column("assigned_to_id", sa.Integer(), nullable=True),
-        sa.Column("opened_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "opened_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("estimated_completion", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["equipment_id"], ["equipment.id"]),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
         sa.ForeignKeyConstraint(["assigned_to_id"], ["users.id"]),
     )
-    op.create_index("ix_maintenance_work_orders_work_order_number", "maintenance_work_orders", ["work_order_number"], unique=True)
-    op.create_index("ix_maintenance_work_orders_assigned_to_id", "maintenance_work_orders", ["assigned_to_id"])
+    op.create_index(
+        "ix_maintenance_work_orders_work_order_number",
+        "maintenance_work_orders",
+        ["work_order_number"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_maintenance_work_orders_assigned_to_id",
+        "maintenance_work_orders",
+        ["assigned_to_id"],
+    )
 
     op.create_table(
         "maintenance_parts",
@@ -710,7 +1058,12 @@ def upgrade() -> None:
         sa.Column("quantity_on_hand", sa.Integer(), nullable=True),
         sa.Column("source", sa.String(length=50), nullable=True),
         sa.Column("status", sa.String(length=50), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["work_order_id"], ["maintenance_work_orders.id"]),
     )
@@ -724,7 +1077,12 @@ def upgrade() -> None:
         sa.Column("hours", sa.Float(), nullable=True),
         sa.Column("description", sa.Text(), nullable=True),
         sa.Column("performed_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["work_order_id"], ["maintenance_work_orders.id"]),
         sa.ForeignKeyConstraint(["technician_id"], ["users.id"]),
@@ -736,9 +1094,16 @@ def upgrade() -> None:
         sa.Column("work_order_id", sa.Integer(), nullable=False),
         sa.Column("assigned_to_id", sa.Integer(), nullable=False),
         sa.Column("assigned_by_id", sa.Integer(), nullable=True),
-        sa.Column("assigned_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "assigned_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.Column("unassigned_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["work_order_id"], ["maintenance_work_orders.id"]),
         sa.ForeignKeyConstraint(["assigned_to_id"], ["users.id"]),
@@ -757,7 +1122,12 @@ def upgrade() -> None:
         sa.Column("interval_days", sa.Integer(), nullable=True),
         sa.Column("last_performed_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("next_due_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["equipment_id"], ["equipment.id"]),
     )
@@ -768,10 +1138,20 @@ def upgrade() -> None:
         sa.Column("equipment_id", sa.Integer(), nullable=False),
         sa.Column("reason", sa.String(length=50), nullable=True),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("deadlined_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "deadlined_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.Column("restored_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("work_order_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["equipment_id"], ["equipment.id"]),
         sa.ForeignKeyConstraint(["work_order_id"], ["maintenance_work_orders.id"]),
@@ -784,9 +1164,19 @@ def upgrade() -> None:
         sa.Column("work_order_id", sa.Integer(), nullable=True),
         sa.Column("status", sa.String(length=50), nullable=True),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("submitted_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "submitted_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["equipment_id"], ["equipment.id"]),
         sa.ForeignKeyConstraint(["work_order_id"], ["maintenance_work_orders.id"]),
@@ -802,7 +1192,12 @@ def upgrade() -> None:
         sa.Column("description", sa.Text(), nullable=True),
         sa.Column("template_config", sa.JSON(), nullable=True),
         sa.Column("created_by_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["created_by_id"], ["users.id"]),
     )
@@ -821,8 +1216,18 @@ def upgrade() -> None:
         sa.Column("file_path", sa.String(length=500), nullable=True),
         sa.Column("generated_by_id", sa.Integer(), nullable=True),
         sa.Column("generated_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
         sa.ForeignKeyConstraint(["template_id"], ["report_templates.id"]),
@@ -837,8 +1242,15 @@ def upgrade() -> None:
         sa.Column("config", sa.JSON(), nullable=True),
         sa.Column("auth_type", sa.String(length=50), nullable=True),
         sa.Column("auth_config", sa.JSON(), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
 
@@ -849,11 +1261,18 @@ def upgrade() -> None:
         sa.Column("frequency", sa.String(length=50), nullable=False),
         sa.Column("cron_expression", sa.String(length=100), nullable=True),
         sa.Column("destination_id", sa.Integer(), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=True, server_default=sa.text("true")
+        ),
         sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("next_run_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("created_by_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["template_id"], ["report_templates.id"]),
         sa.ForeignKeyConstraint(["destination_id"], ["report_export_destinations.id"]),
@@ -874,8 +1293,18 @@ def upgrade() -> None:
         sa.Column("heading", sa.Float(), nullable=True),
         sa.Column("speed_knots", sa.Float(), nullable=True),
         sa.Column("source", sa.String(length=50), nullable=True),
-        sa.Column("reported_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "reported_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index("ix_locations_entity", "locations", ["entity_type", "entity_id"])
@@ -892,8 +1321,18 @@ def upgrade() -> None:
         sa.Column("mgrs", sa.String(length=30), nullable=True),
         sa.Column("capacity_tons", sa.Float(), nullable=True),
         sa.Column("current_stock_tons", sa.Float(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -909,8 +1348,18 @@ def upgrade() -> None:
         sa.Column("distance_km", sa.Float(), nullable=True),
         sa.Column("estimated_time_hours", sa.Float(), nullable=True),
         sa.Column("waypoints", sa.JSON(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["origin_id"], ["supply_points.id"]),
         sa.ForeignKeyConstraint(["destination_id"], ["supply_points.id"]),
@@ -927,7 +1376,12 @@ def upgrade() -> None:
         sa.Column("supply_readiness_pct", sa.Float(), nullable=True),
         sa.Column("personnel_readiness_pct", sa.Float(), nullable=True),
         sa.Column("snapshot_date", sa.Date(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -941,7 +1395,12 @@ def upgrade() -> None:
         sa.Column("present", sa.Integer(), nullable=True),
         sa.Column("deployable", sa.Integer(), nullable=True),
         sa.Column("snapshot_date", sa.Date(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -958,13 +1417,28 @@ def upgrade() -> None:
         sa.Column("submitted_by_id", sa.Integer(), nullable=True),
         sa.Column("submitted_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("notes", sa.Text(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
         sa.ForeignKeyConstraint(["submitted_by_id"], ["users.id"]),
     )
-    op.create_index("ix_requisitions_document_number", "requisitions", ["document_number"], unique=True)
+    op.create_index(
+        "ix_requisitions_document_number",
+        "requisitions",
+        ["document_number"],
+        unique=True,
+    )
 
     op.create_table(
         "requisition_line_items",
@@ -976,7 +1450,12 @@ def upgrade() -> None:
         sa.Column("quantity_issued", sa.Integer(), nullable=True),
         sa.Column("unit_price", sa.Float(), nullable=True),
         sa.Column("condition_code", sa.String(length=10), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["requisition_id"], ["requisitions.id"]),
     )
@@ -988,7 +1467,12 @@ def upgrade() -> None:
         sa.Column("approver_id", sa.Integer(), nullable=True),
         sa.Column("action", sa.String(length=50), nullable=True),
         sa.Column("comments", sa.Text(), nullable=True),
-        sa.Column("acted_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "acted_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["requisition_id"], ["requisitions.id"]),
         sa.ForeignKeyConstraint(["approver_id"], ["users.id"]),
@@ -1002,7 +1486,12 @@ def upgrade() -> None:
         sa.Column("new_status", sa.String(length=50), nullable=False),
         sa.Column("changed_by_id", sa.Integer(), nullable=True),
         sa.Column("notes", sa.Text(), nullable=True),
-        sa.Column("changed_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "changed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["requisition_id"], ["requisitions.id"]),
         sa.ForeignKeyConstraint(["changed_by_id"], ["users.id"]),
@@ -1019,8 +1508,18 @@ def upgrade() -> None:
         sa.Column("quantity_on_hand", sa.Integer(), nullable=True),
         sa.Column("location", sa.String(length=200), nullable=True),
         sa.Column("last_inventoried_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -1034,7 +1533,12 @@ def upgrade() -> None:
         sa.Column("reference_number", sa.String(length=100), nullable=True),
         sa.Column("notes", sa.Text(), nullable=True),
         sa.Column("performed_by_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["inventory_record_id"], ["inventory_records.id"]),
         sa.ForeignKeyConstraint(["performed_by_id"], ["users.id"]),
@@ -1053,8 +1557,18 @@ def upgrade() -> None:
         sa.Column("longitude", sa.Float(), nullable=True),
         sa.Column("bed_capacity", sa.Integer(), nullable=True),
         sa.Column("beds_available", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -1072,9 +1586,24 @@ def upgrade() -> None:
         sa.Column("mtf_id", sa.Integer(), nullable=True),
         sa.Column("injury_description", sa.Text(), nullable=True),
         sa.Column("reported_by_id", sa.Integer(), nullable=True),
-        sa.Column("reported_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "reported_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["personnel_id"], ["personnel.id"]),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
@@ -1088,7 +1617,12 @@ def upgrade() -> None:
         sa.Column("casualty_report_id", sa.Integer(), nullable=False),
         sa.Column("log_entry", sa.Text(), nullable=False),
         sa.Column("logged_by_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["casualty_report_id"], ["casualty_reports.id"]),
         sa.ForeignKeyConstraint(["logged_by_id"], ["users.id"]),
@@ -1102,7 +1636,12 @@ def upgrade() -> None:
         sa.Column("daily_usage_rate", sa.Float(), nullable=True),
         sa.Column("on_hand_qty", sa.Float(), nullable=True),
         sa.Column("dos", sa.Float(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -1115,8 +1654,18 @@ def upgrade() -> None:
         sa.Column("blood_type", sa.String(length=10), nullable=True),
         sa.Column("units_available", sa.Integer(), nullable=True),
         sa.Column("expiration_date", sa.Date(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["mtf_id"], ["medical_treatment_facilities.id"]),
     )
@@ -1135,8 +1684,18 @@ def upgrade() -> None:
         sa.Column("longitude", sa.Float(), nullable=True),
         sa.Column("capacity_gallons", sa.Float(), nullable=True),
         sa.Column("current_level_gallons", sa.Float(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -1151,7 +1710,12 @@ def upgrade() -> None:
         sa.Column("equipment_id", sa.Integer(), nullable=True),
         sa.Column("unit_id", sa.Integer(), nullable=True),
         sa.Column("performed_by_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["storage_point_id"], ["fuel_storage_points.id"]),
         sa.ForeignKeyConstraint(["equipment_id"], ["equipment.id"]),
@@ -1167,8 +1731,18 @@ def upgrade() -> None:
         sa.Column("source", sa.String(length=50), nullable=True),
         sa.Column("operational_tempo", sa.String(length=50), nullable=True),
         sa.Column("gallons_per_day", sa.Float(), nullable=True),
-        sa.Column("recorded_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "recorded_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -1181,7 +1755,12 @@ def upgrade() -> None:
         sa.Column("forecast_date", sa.Date(), nullable=True),
         sa.Column("projected_demand_gallons", sa.Float(), nullable=True),
         sa.Column("projected_supply_gallons", sa.Float(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
     )
@@ -1201,8 +1780,18 @@ def upgrade() -> None:
         sa.Column("assigned_to_role", sa.String(length=50), nullable=True),
         sa.Column("acted_on_by_id", sa.Integer(), nullable=True),
         sa.Column("acted_on_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["alert_id"], ["alerts.id"]),
         sa.ForeignKeyConstraint(["source_unit_id"], ["units.id"]),
@@ -1225,13 +1814,28 @@ def upgrade() -> None:
         sa.Column("custodian_id", sa.Integer(), nullable=True),
         sa.Column("location", sa.String(length=200), nullable=True),
         sa.Column("nsn", sa.String(length=20), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
         sa.ForeignKeyConstraint(["custodian_id"], ["users.id"]),
     )
-    op.create_index("ix_sensitive_items_serial_number", "sensitive_items", ["serial_number"], unique=True)
+    op.create_index(
+        "ix_sensitive_items_serial_number",
+        "sensitive_items",
+        ["serial_number"],
+        unique=True,
+    )
 
     op.create_table(
         "custody_transfers",
@@ -1241,8 +1845,18 @@ def upgrade() -> None:
         sa.Column("to_custodian_id", sa.Integer(), nullable=True),
         sa.Column("transfer_type", sa.String(length=50), nullable=True),
         sa.Column("notes", sa.Text(), nullable=True),
-        sa.Column("transferred_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "transferred_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["sensitive_item_id"], ["sensitive_items.id"]),
         sa.ForeignKeyConstraint(["from_custodian_id"], ["users.id"]),
@@ -1259,7 +1873,12 @@ def upgrade() -> None:
         sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("notes", sa.Text(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),
         sa.ForeignKeyConstraint(["conducted_by_id"], ["users.id"]),
@@ -1273,7 +1892,12 @@ def upgrade() -> None:
         sa.Column("found", sa.Boolean(), nullable=True, server_default=sa.text("true")),
         sa.Column("discrepancy_type", sa.String(length=50), nullable=True),
         sa.Column("notes", sa.Text(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["inventory_event_id"], ["inventory_events.id"]),
         sa.ForeignKeyConstraint(["sensitive_item_id"], ["sensitive_items.id"]),
@@ -1288,7 +1912,12 @@ def upgrade() -> None:
         sa.Column("user_id", sa.Integer(), nullable=True),
         sa.Column("details", sa.JSON(), nullable=True),
         sa.Column("ip_address", sa.String(length=50), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
     )
@@ -1305,7 +1934,12 @@ def upgrade() -> None:
         sa.Column("user_id", sa.Integer(), nullable=True),
         sa.Column("unit_id", sa.Integer(), nullable=True),
         sa.Column("metadata_json", sa.JSON(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
         sa.ForeignKeyConstraint(["unit_id"], ["units.id"]),

--- a/backend/app/api/catalog_sensitive_item.py
+++ b/backend/app/api/catalog_sensitive_item.py
@@ -104,9 +104,7 @@ async def get_sensitive_item_catalog_entry(
 ):
     """Get a single sensitive item catalog entry by ID."""
     result = await db.execute(
-        select(SensitiveItemCatalogEntry).where(
-            SensitiveItemCatalogEntry.id == item_id
-        )
+        select(SensitiveItemCatalogEntry).where(SensitiveItemCatalogEntry.id == item_id)
     )
     entry = result.scalar_one_or_none()
     if not entry:
@@ -156,9 +154,7 @@ async def update_sensitive_item_catalog_entry(
 ):
     """Update a sensitive item catalog entry. ADMIN only."""
     result = await db.execute(
-        select(SensitiveItemCatalogEntry).where(
-            SensitiveItemCatalogEntry.id == item_id
-        )
+        select(SensitiveItemCatalogEntry).where(SensitiveItemCatalogEntry.id == item_id)
     )
     entry = result.scalar_one_or_none()
     if not entry:
@@ -190,9 +186,7 @@ async def delete_sensitive_item_catalog_entry(
 ):
     """Soft-delete a sensitive item catalog entry (set is_active=False). ADMIN only."""
     result = await db.execute(
-        select(SensitiveItemCatalogEntry).where(
-            SensitiveItemCatalogEntry.id == item_id
-        )
+        select(SensitiveItemCatalogEntry).where(SensitiveItemCatalogEntry.id == item_id)
     )
     entry = result.scalar_one_or_none()
     if not entry:

--- a/backend/app/api/dashboard.py
+++ b/backend/app/api/dashboard.py
@@ -72,7 +72,9 @@ async def get_dashboard_summary(
         )
 
     # Check Redis cache first
-    cache_key = f"dashboard:overview:{unit_id}:{','.join(str(u) for u in sorted(unit_ids))}"
+    cache_key = (
+        f"dashboard:overview:{unit_id}:{','.join(str(u) for u in sorted(unit_ids))}"
+    )
     try:
         cached = await cache_get(cache_key)
         if cached:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,8 +40,8 @@ else:
     renderer = structlog.processors.JSONRenderer()
 
 structlog.configure(
-    processors=[
-        *shared_processors,
+    processors=shared_processors
+    + [
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
     ],
     logger_factory=structlog.stdlib.LoggerFactory(),
@@ -585,6 +585,7 @@ async def health_check():
     # Check Redis
     try:
         import redis
+
         r = redis.from_url(settings.REDIS_URL)
         r.ping()
         checks["redis"] = "connected"

--- a/backend/app/middleware/request_logging.py
+++ b/backend/app/middleware/request_logging.py
@@ -9,7 +9,9 @@ logger = structlog.get_logger("request")
 
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
         request_id = str(uuid.uuid4())[:8]
         start = time.perf_counter()
 
@@ -20,7 +22,10 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             try:
                 from jose import jwt
                 from app.config import settings
-                payload = jwt.decode(auth[7:], settings.SECRET_KEY, algorithms=[settings.JWT_ALGORITHM])
+
+                payload = jwt.decode(
+                    auth[7:], settings.SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]
+                )
                 user = payload.get("sub", "anonymous")
             except Exception:
                 pass

--- a/backend/tests/test_api_auth.py
+++ b/backend/tests/test_api_auth.py
@@ -46,6 +46,7 @@ async def test_login_rate_limiting(client: AsyncClient, admin_user: User):
     """5 failed login attempts should trigger rate limiting (429)."""
     # Clear any previous state in the module-level dict
     from app.api.auth import _login_failures
+
     _login_failures.clear()
 
     for _ in range(5):
@@ -67,9 +68,12 @@ async def test_login_rate_limiting(client: AsyncClient, admin_user: User):
 
 
 @pytest.mark.asyncio
-async def test_login_rate_limit_cleared_on_success(client: AsyncClient, admin_user: User):
+async def test_login_rate_limit_cleared_on_success(
+    client: AsyncClient, admin_user: User
+):
     """Successful login clears the rate-limit counter."""
     from app.api.auth import _login_failures
+
     _login_failures.clear()
 
     # Record 3 failures
@@ -91,7 +95,9 @@ async def test_login_rate_limit_cleared_on_success(client: AsyncClient, admin_us
 
 
 @pytest.mark.asyncio
-async def test_get_me_with_valid_token(client: AsyncClient, admin_user: User, admin_token: str):
+async def test_get_me_with_valid_token(
+    client: AsyncClient, admin_user: User, admin_token: str
+):
     """GET /api/v1/auth/me with valid token returns user data."""
     resp = await client.get(
         "/api/v1/auth/me",
@@ -258,6 +264,7 @@ async def test_list_users_as_non_admin(
 async def test_login_returns_permissions(client: AsyncClient, admin_user: User):
     """Login response includes a permissions list."""
     from app.api.auth import _login_failures
+
     _login_failures.clear()
 
     resp = await client.post(

--- a/backend/tests/test_api_ingestion.py
+++ b/backend/tests/test_api_ingestion.py
@@ -14,7 +14,9 @@ from app.models.user import User
 class TestMIRCIngestion:
     """Tests for /api/v1/ingestion/mirc upload endpoint."""
 
-    async def test_upload_mirc_log(self, client: AsyncClient, admin_token: str, admin_user: User):
+    async def test_upload_mirc_log(
+        self, client: AsyncClient, admin_token: str, admin_user: User
+    ):
         """POST /api/v1/ingestion/mirc uploads a text file."""
         content = b"[12:00] <ALPHA> Supply status: Class I GREEN, DOS 7\n"
         resp = await client.post(
@@ -62,7 +64,13 @@ class TestExcelIngestion:
         content = b"PK\x03\x04"  # ZIP magic bytes (xlsx is a ZIP)
         resp = await client.post(
             "/api/v1/ingestion/excel",
-            files={"file": ("data.xlsx", io.BytesIO(content), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")},
+            files={
+                "file": (
+                    "data.xlsx",
+                    io.BytesIO(content),
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            },
             headers={"Authorization": f"Bearer {admin_token}"},
         )
         assert resp.status_code == 200
@@ -210,7 +218,9 @@ class TestRouteIngestion:
         content = b"not a route file"
         resp = await client.post(
             "/api/v1/ingestion/routes",
-            files={"file": ("route.docx", io.BytesIO(content), "application/octet-stream")},
+            files={
+                "file": ("route.docx", io.BytesIO(content), "application/octet-stream")
+            },
             headers={"Authorization": f"Bearer {admin_token}"},
         )
         assert resp.status_code == 400

--- a/backend/tests/test_api_transportation.py
+++ b/backend/tests/test_api_transportation.py
@@ -40,7 +40,11 @@ class TestMovementEndpoints:
         test_unit: Unit,
     ):
         """GET /api/v1/transportation/active returns only active movements."""
-        for status in [MovementStatus.EN_ROUTE, MovementStatus.PLANNED, MovementStatus.COMPLETE]:
+        for status in [
+            MovementStatus.EN_ROUTE,
+            MovementStatus.PLANNED,
+            MovementStatus.COMPLETE,
+        ]:
             mv = Movement(
                 unit_id=test_unit.id,
                 origin="Origin",

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -90,9 +90,7 @@ class TestProcessMIRCUploadTask:
     @patch("app.tasks.ingest_mirc.sync_engine")
     @patch("app.tasks.ingest_mirc.normalize_record")
     @patch("app.tasks.ingest_mirc.parse_mirc_log")
-    def test_process_mirc_no_records(
-        self, mock_parse, mock_normalize, mock_engine
-    ):
+    def test_process_mirc_no_records(self, mock_parse, mock_normalize, mock_engine):
         """process_mirc_upload handles empty parse results."""
         from app.models.raw_data import ParseStatus, RawData
 
@@ -120,9 +118,7 @@ class TestProcessMIRCUploadTask:
     @patch("app.tasks.ingest_mirc.sync_engine")
     @patch("app.tasks.ingest_mirc.normalize_record")
     @patch("app.tasks.ingest_mirc.parse_mirc_log")
-    def test_process_mirc_success(
-        self, mock_parse, mock_normalize, mock_engine
-    ):
+    def test_process_mirc_success(self, mock_parse, mock_normalize, mock_engine):
         """process_mirc_upload processes records successfully."""
         from app.models.raw_data import ParseStatus, RawData
 

--- a/backend/tests/test_health_endpoint.py
+++ b/backend/tests/test_health_endpoint.py
@@ -31,7 +31,9 @@ class TestHealthEndpoint:
         assert "redis" in data
         assert isinstance(data["redis"], str)
         # Redis won't be running in test env, so expect either connected or error
-        assert data["redis"].startswith("connected") or data["redis"].startswith("error")
+        assert data["redis"].startswith("connected") or data["redis"].startswith(
+            "error"
+        )
 
     async def test_health_status_values(self, client: AsyncClient):
         """GET /health status is either 'healthy' or 'degraded'."""


### PR DESCRIPTION
## Summary
- Auto-format 10 Python files to pass `ruff format --check`
- Fix mypy `list-item` error in `structlog.configure()` — replaced `[*list, item]` spread with `list + [item]` concatenation

## Test plan
- [x] `ruff check .` → All checks passed
- [x] `ruff format --check .` → 234 files already formatted
- [x] `mypy app/ ...` → Success: no issues found in 165 source files
- [ ] CI pipeline Lint: Backend passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)