### PR TITLE
fix: guided tour tooltip click-blocking overlay

### DIFF
--- a/charts/keystone/Chart.yaml
+++ b/charts/keystone/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: keystone
 description: USMC Logistics Common Operating Picture
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.0.0"

--- a/frontend/src/components/onboarding/GuidedTour.tsx
+++ b/frontend/src/components/onboarding/GuidedTour.tsx
@@ -226,7 +226,7 @@ export function GuidedTour() {
 
       {/* Tooltip */}
       <div
-        className="bg-[var(--color-bg-surface)] border border-[var(--color-accent)] rounded-[var(--radius)] z-[9999] overflow-hidden" style={{ boxShadow: '0 12px 40px rgba(0, 0, 0, 0.6)' }}
+        className="bg-[var(--color-bg-surface)] border border-[var(--color-accent)] rounded-[var(--radius)] z-[9999] overflow-hidden" style={{ ...getTooltipStyle(), boxShadow: '0 12px 40px rgba(0, 0, 0, 0.6)', width: 340 }}
       >
         {/* Header */}
         <div


### PR DESCRIPTION
## Summary
- **Bug**: The onboarding GuidedTour tooltip was unclickable because a transparent SVG overlay sat on top of it, intercepting all pointer events.
- **Root cause**: `getTooltipStyle()` (which returns `position: fixed` + coordinates) was defined but never applied to the tooltip element. Without positioning, `z-index: 9999` had no effect, and the fixed SVG overlay painted above the tooltip.
- **Fix**: Applied `getTooltipStyle()` to the tooltip's `style` prop, giving it proper fixed positioning and a width of 340px.

## Test plan
- [x] `tsc -b` — clean, no type errors
- [x] `vitest run` — 224/224 tests passing
- [x] `docker compose build frontend` — image builds successfully
- [ ] Manual: visit app as new user (clear `keystone_onboarding_complete` from localStorage), verify tour tooltip renders centered/positioned and all buttons (Skip, Next, Prev, Finish) are clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)