### PR TITLE
feat: SRE Platform deployment support

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -59,3 +59,12 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 EXPOSE 8000
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+# STAGE: SRE / Kubernetes deployment
+FROM production AS sre
+
+# SRE defaults — Istio handles mTLS, no SSL needed for DB connections
+ENV DATABASE_URL="postgresql+asyncpg://keystone:keystone_dev@db:5432/keystone?ssl=disable" \
+    DATABASE_URL_SYNC="postgresql://keystone:keystone_dev@db:5432/keystone?sslmode=disable" \
+    REDIS_URL="redis://redis:6379/0" \
+    ENV_MODE="production"

--- a/backend/alembic/versions/001_add_new_echelon_values.py
+++ b/backend/alembic/versions/001_add_new_echelon_values.py
@@ -7,6 +7,7 @@ Create Date: 2026-03-04
 
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers
@@ -17,12 +18,18 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # PostgreSQL requires ALTER TYPE to add enum values
-    # IF NOT EXISTS prevents errors if values already exist (PostgreSQL 9.3+)
-    op.execute("ALTER TYPE echelon ADD VALUE IF NOT EXISTS 'HQMC'")
-    op.execute("ALTER TYPE echelon ADD VALUE IF NOT EXISTS 'WING'")
-    op.execute("ALTER TYPE echelon ADD VALUE IF NOT EXISTS 'GRP'")
-    op.execute("ALTER TYPE echelon ADD VALUE IF NOT EXISTS 'SQDN'")
+    # Only alter the echelon type if it exists (for databases created by create_all())
+    # On fresh databases where alembic runs from scratch, the echelon column is
+    # a VARCHAR, not a native PostgreSQL enum, so this is a no-op.
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text("SELECT 1 FROM pg_type WHERE typname = 'echelon'")
+    )
+    if result.fetchone():
+        op.execute("ALTER TYPE echelon ADD VALUE IF NOT EXISTS 'HQMC'")
+        op.execute("ALTER TYPE echelon ADD VALUE IF NOT EXISTS 'WING'")
+        op.execute("ALTER TYPE echelon ADD VALUE IF NOT EXISTS 'GRP'")
+        op.execute("ALTER TYPE echelon ADD VALUE IF NOT EXISTS 'SQDN'")
 
 
 def downgrade() -> None:

--- a/docker-compose.sre.yml
+++ b/docker-compose.sre.yml
@@ -1,0 +1,12 @@
+# docker-compose.sre.yml — Override for SRE/Kubernetes deployment
+# Usage: docker compose -f docker-compose.yml -f docker-compose.sre.yml up
+services:
+  backend:
+    build:
+      target: sre
+  frontend:
+    build:
+      target: sre
+  celery_worker:
+    build:
+      target: sre

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
   backend:
     build:
       context: ./backend
-      target: production
+      target: production    # For SRE/K8s deployment, use target: sre (see docker-compose.sre.yml)
     user: "1001:1001"
     ports: ["8000:8000"]
     environment:

--- a/docs/sre-deployment.md
+++ b/docs/sre-deployment.md
@@ -1,0 +1,61 @@
+# Deploying KEYSTONE on SRE Platform
+
+KEYSTONE supports deployment on the SRE Platform (Secure Runtime Environment) — a
+government-compliant Kubernetes platform with Istio service mesh, automated builds,
+and security hardening.
+
+## Quick Deploy
+
+1. Open the SRE Dashboard at `https://dashboard.apps.sre.example.com`
+2. Navigate to **Deploy App** > **Deploy from Git**
+3. Enter:
+   - **Git Repository URL**: `https://github.com/morbidsteve/keystone`
+   - **App Name**: `keystone`
+   - **Team Name**: your team name
+4. Click **Deploy**
+
+The platform will:
+- Detect the Docker Compose project (5 services)
+- Auto-provision PostgreSQL (PostGIS) and Redis
+- Build backend and frontend images via Kaniko
+- Deploy all services with Istio mTLS and network policies
+- Create ingress at `https://keystone.apps.sre.example.com`
+
+## What's Different on SRE
+
+| Feature | Standalone (Docker Compose) | SRE Platform |
+|---------|---------------------------|--------------|
+| TLS | Self-signed certs in nginx | Istio gateway handles TLS |
+| Service mesh | None | Istio mTLS (zero-trust) |
+| Database | docker-compose PostgreSQL | Platform-managed PostgreSQL |
+| Image registry | Local | Harbor (scanned + signed) |
+| Network security | Docker bridge networks | Kubernetes NetworkPolicies |
+| Build | docker compose build | Kaniko in-cluster builds |
+| Monitoring | Optional Prometheus profile | Prometheus + Grafana included |
+| Access | localhost:8443 | https://keystone.apps.sre.example.com |
+
+## SRE Build Targets
+
+The Dockerfiles include an `sre` build stage that the platform auto-detects:
+
+- **Frontend**: `nginx-sre.conf` serves on HTTP port 8080 (no SSL — Istio handles TLS)
+- **Backend**: Pre-configured DATABASE_URL with `?ssl=disable` (Istio mTLS encrypts the connection)
+
+These stages are selected automatically by the SRE platform. No manual configuration needed.
+
+## Environment Variables
+
+The SRE platform auto-configures these for the backend:
+
+| Variable | SRE Value |
+|----------|-----------|
+| DATABASE_URL | `postgresql+asyncpg://keystone:keystone_dev@db:5432/keystone?ssl=disable` |
+| REDIS_URL | `redis://redis:6379/0` |
+| ENV_MODE | `production` |
+
+For production deployments, override credentials via OpenBao/External Secrets.
+
+## Local Development
+
+Nothing changes for local development. `docker compose up` still works exactly as before
+with SSL on port 8443.


### PR DESCRIPTION
## Summary

Adds full support for deploying KEYSTONE on the SRE Platform (Secure Runtime Environment),
a government-compliant Kubernetes platform with Istio service mesh.

### Changes

- **fix(migrations)**: Migration 001 now checks if the `echelon` PostgreSQL enum type exists
  before trying to ALTER it. Fixes crash on fresh databases where alembic runs from scratch.
- **feat(frontend)**: Added `nginx-sre.conf` and Dockerfile `sre` build stage for deployments
  where Istio handles TLS termination (no SSL in nginx).
- **feat(backend)**: Added Dockerfile `sre` build stage with pre-configured DATABASE_URL
  (ssl=disable since Istio mTLS encrypts connections).
- **feat(compose)**: Added `docker-compose.sre.yml` override for SRE target builds.
- **docs**: Added `docs/sre-deployment.md` with deployment guide.

### How It Works

The SRE platform auto-detects the `sre` Dockerfile stage via `FROM ... AS sre` and uses it
when building. No manual configuration needed — just point the platform at the Git URL.

### Compatibility

- `docker compose up` still works exactly as before (SSL on port 8443)
- SRE deployment is fully automatic via the Deploy from Git dashboard feature

## Test Plan

- [ ] `docker compose up` works unchanged (standalone mode)
- [ ] `docker compose -f docker-compose.yml -f docker-compose.sre.yml up` works
- [ ] Fresh database: `alembic upgrade head` succeeds without errors
- [ ] SRE platform: Deploy from Git detects compose project, builds with sre target, app accessible